### PR TITLE
Make templates being resolved either locally or from embedded location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: osx
 language: node_js
 node_js:
-- node
+- lts/*
 cache: yarn
 before_install:
 - npm install -g pkg

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ OPTIONS
 
   -s, --tls                            Enable TLS encryption and multi-user mode
 
-  -t, --templates=templates            [default: /Users/mloriedo/github/chectl/templates] Path to the templates folder
+  -t, --templates=templates            [default: templates] Path to the templates folder
 ```
 
 _See code: [src/commands/server/start.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/start.ts)_

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -11,6 +11,7 @@
 
 import { Command, flags } from '@oclif/command'
 import { string } from '@oclif/parser/lib/flags'
+import * as fs from 'fs-extra'
 import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
 import * as path from 'path'
@@ -40,7 +41,7 @@ export default class Start extends Command {
     templates: string({
       char: 't',
       description: 'Path to the templates folder',
-      default: path.join(__dirname, '../../../../chectl/templates'),
+      default:  Start.getTemplatesDir(),
       env: 'CHE_TEMPLATES_FOLDER'
     }),
     cheboottimeout: string({
@@ -80,6 +81,19 @@ export default class Start extends Command {
       description: 'Type of Kubernetes platform. Valid values are \"minikube\", \"minishift\", \"docker4mac\", \"ocp\", \"oso\".',
       default: 'minikube'
     })
+
+  }
+
+  static getTemplatesDir(): string {
+    // return local templates folder if present
+    const TEMPLATES = 'templates'
+    const templatesDir = path.resolve(TEMPLATES)
+    const exists = fs.pathExistsSync(templatesDir)
+    if (exists) {
+      return TEMPLATES
+    }
+    // else use the location from modules
+    return path.join(__dirname, '../../../../chectl/templates')
   }
 
   async run() {


### PR DESCRIPTION
Fix README being changed every time

so if in current directory, there is a templates folder, use it
fallback to embedded location

Change-Id: I841f3f88b39e712f0c17a217624fa255369d80e4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>