### PR TITLE
Added minishift-addon: minishift default single-user installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ USAGE
   $ chectl server:start
 
 OPTIONS
-  -a, --installer=installer            [default: helm] Installer type. Valid values are "helm" and "operator"
+  -a, --installer=installer            Installer type. Valid values are "helm", "operator" and "minishift-addon"
 
   -b, --domain=domain                  Domain of the Kubernetes/OpenShift cluster (e.g.
                                        starter-us-east-2.openshiftapps.com or <local-ip>.nip.io)

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/dist"
     ],
-    "testRegex": "/test/(api|platforms)/.*.test.ts",
+    "testRegex": "/test/(api|platforms|installers)/.*.test.ts",
     "testEnvironment": "node",
     "moduleFileExtensions": [
       "ts",

--- a/src/installers/minishift-addon.ts
+++ b/src/installers/minishift-addon.ts
@@ -1,0 +1,72 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+
+import * as execa from 'execa'
+import * as Listr from 'listr'
+
+export class MinishiftAddonHelper {
+  static getImageRepository(image: string): string {
+    if (image.includes(':')) {
+      return image.split(':')[0]
+    } else {
+      return image
+    }
+  }
+
+  static getImageTag(image: string) {
+    if (image.includes(':')) {
+      return image.split(':')[1]
+    } else {
+      return 'latest'
+    }
+  }
+
+  startTasks(flags: any): Listr {
+    return new Listr([
+      {
+        title: 'Apply Che addon',
+        task: async (_ctx: any, task: any) => {
+          await this.applyAddon(flags)
+          task.title = `${task.title}...done.`
+        }
+      }
+    ])
+  }
+
+  async applyAddon(flags: any, execTimeout= 120000) {
+    let args = ['addon', 'apply']
+    const imageRepo = MinishiftAddonHelper.getImageRepository(flags.cheimage)
+    const imageTag = MinishiftAddonHelper.getImageTag(flags.cheimage)
+    args = args.concat(['--addon-env', `NAMESPACE=${flags.chenamespace}`])
+    args = args.concat(['--addon-env', `CHE_IMAGE_REPO=${imageRepo}`])
+    args = args.concat(['--addon-env', `CHE_IMAGE_TAG=${imageTag}`])
+    args = args.concat(['che'])
+    const { cmd,
+            code,
+            stderr,
+            stdout,
+            timedOut } = await execa('minishift',
+                                     args,
+                                     { timeout: execTimeout, reject: false })
+    if (timedOut) {
+      throw new Error(`Command "${cmd}" timed out after ${execTimeout}ms
+stderr: ${stderr}
+stdout: ${stdout}
+error: E_TIMEOUT`)
+    }
+    if (code !== 0) {
+      throw new Error(`Command "${cmd}" failed with return code ${code}
+stderr: ${stderr}
+stdout: ${stdout}
+error: E_COMMAND_FAILED`)
+    }
+  }
+}

--- a/test/installers/minishift-addon.test.ts
+++ b/test/installers/minishift-addon.test.ts
@@ -1,0 +1,44 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+import { expect, fancy } from 'fancy-test'
+
+import {MinishiftAddonHelper} from '../../src/installers/minishift-addon'
+
+describe('Minishift addon helper', () => {
+  fancy
+    .it('extracts the tag part from an image name', async () => {
+      const image = 'eclipse/che:latest'
+      const tag = MinishiftAddonHelper.getImageTag(image)
+      expect(tag).to.equal('latest')
+    })
+
+  fancy
+    .it('extracts the repo part from an image name', async () => {
+      const image = 'eclipse/che:latest'
+      const repository = MinishiftAddonHelper.getImageRepository(image)
+      expect(repository).to.equal('eclipse/che')
+    })
+
+  fancy
+    .it('returns the repo part even if an image has no tag', async () => {
+      const image = 'eclipse/che'
+      const repository = MinishiftAddonHelper.getImageRepository(image)
+      expect(repository).to.equal('eclipse/che')
+    })
+
+  fancy
+    .it('returns latest as tag if an image has no tag', async () => {
+      const image = 'eclipse/che'
+      const tag = MinishiftAddonHelper.getImageTag(image)
+      expect(tag).to.equal('latest')
+    })
+
+})


### PR DESCRIPTION
Added a new installer: [minishift-addon](https://github.com/minishift/minishift/tree/master/addons/che). 

This installer is the default minishift installer for Che single-user (for multi-user it's still the operator). 
Minikube defaults are helm for Che single-user, the operator for multi-user.