### PR TITLE
Include the short sha1 in the version of chectl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_deploy:
 - git config --local user.name "Mario Loriedo"
 - git config --local user.email "mario.loriedo@gmail.com"
 - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')}
+- export SHORT_SHA1=$(git rev-parse --short HEAD)
 - git tag $TRAVIS_TAG
+- sed -i sed "s#version\":\ \"\(.*\)\",#version\":\ \"\1-${SHORT_SHA1}\",#g" package.json
 - yarn pack
 - pkg . -t node10-linux-x64,node10-macos-x64,node10-win-x64 --out-path ./bin/
 deploy:


### PR DESCRIPTION
allow to know which version we have

https://github.com/che-incubator/chectl/issues/69

Change-Id: I03f9b5fb7ee46fe100c8ddd9bb674af2dec127ad
Signed-off-by: Florent Benoit <fbenoit@redhat.com>