### PR TITLE
Inject configuration files in all containers if it's not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,17 @@ USAGE
   $ chectl workspace:inject
 
 OPTIONS
-  -c, --container=container        [default: dev] Target container
+  -c, --container=container        Target container. If not specified, configuration files will be injected in all
+                                   containers of a Che Workspace pod
+
   -h, --help                       show CLI help
+
   -k, --kubeconfig                 Inject the local Kubernetes configuration
+
   -n, --chenamespace=chenamespace  [default: che] Kubernetes namespace where Che workspace is running
-  -w, --workspace=workspace        Target workspace
+
+  -w, --workspace=workspace        Target workspace. Can be omitted if only one Workspace is running
+
   --listr-renderer=listr-renderer  [default: default] Listr renderer. Can be 'default', 'silent' or 'verbose'
 ```
 

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -31,7 +31,7 @@ export default class Inject extends Command {
     }),
     workspace: string({
       char: 'w',
-      description: 'Target workspace'
+      description: 'Target workspace. Can be omitted if only one Workspace is running'
     }),
     container: string({
       char: 'c',

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -10,6 +10,7 @@
 // tslint:disable:object-curly-spacing
 
 import * as execa from 'execa'
+import * as Listr from 'listr'
 import * as os from 'os'
 import * as path from 'path'
 
@@ -34,8 +35,8 @@ export default class Inject extends Command {
     }),
     container: string({
       char: 'c',
-      description: 'Target container',
-      default: 'dev'
+      description: 'Target container. If not specified, configuration files will be injected in all containers of a Che Workspace pod',
+      required: false
     }),
     chenamespace: string({
       char: 'n',
@@ -51,7 +52,6 @@ export default class Inject extends Command {
 
   async run() {
     const { flags } = this.parse(Inject)
-    const Listr = require('listr')
     const notifier = require('node-notifier')
     const che = new CheHelper()
     const tasks = new Listr([
@@ -59,7 +59,7 @@ export default class Inject extends Command {
         title: `Verify if namespace ${flags.chenamespace} exists`,
         task: async () => {
           if (!await che.cheNamespaceExist(flags.chenamespace)) {
-            this.error(`E_BAD_NS - Namespace does not exist.\nThe Kubernetes Namespace "${flags.chenamespace}" doesn't exist. The Kubernetes configuration cannot be injected.\nFix with: verify the namespace where Che workspace is running (kubectl get --all-namespaces deployment | grep workspace)`, {code: 'EBADNS'})
+            this.error(`E_BAD_NS - Namespace does not exist.\nThe Kubernetes Namespace "${flags.chenamespace}" doesn't exist. The configuration cannot be injected.\nFix with: verify the namespace where Che workspace is running (kubectl get --all-namespaces deployment | grep workspace)`, {code: 'EBADNS'})
           }
         }
       },
@@ -71,24 +71,22 @@ export default class Inject extends Command {
       },
       {
         title: `Verify if container ${flags.container} exists`,
+        enabled: () => flags.container !== undefined,
         task: async (ctx: any) => {
           if (!await this.containerExists(flags.chenamespace!, ctx.pod, flags.container!)) {
-            this.error(`The container "${flags.container}" doesn't exist. The Kubernetes configuration cannot be injected.`)
+            this.error(`The specified container "${flags.container}" doesn't exist. The configuration cannot be injected.`)
           }
         }
       },
       {
-        title: 'Injecting Kubernetes configuration',
+        title: 'Injecting configurations',
         skip: () => {
           if (!flags.kubeconfig) {
-            return 'Currently, injecting only the local kubeconfig is supported. Please, specify flag -k'
+            return 'Currently, only injecting a kubeconfig is supported. Please, specify flag -k'
           }
         },
-        task: (ctx: any, task: any) => this.injectKubeconfig(flags.chenamespace!, ctx.pod, flags.container!).then(result => {
-          if (!result) {
-            task.skip('kubeconfig already exists in the target container')
-          }
-        }).catch(e => this.error(e.message)) },
+        task: () => this.injectKubeconfigTasks(flags.chenamespace!, flags.workspace!, flags.container)
+      },
     ], {renderer: flags['listr-renderer'] as any})
 
     try {
@@ -103,16 +101,36 @@ export default class Inject extends Command {
     })
   }
 
+  async injectKubeconfigTasks(chenamespace: string, workspace: string, container?: string): Promise<Listr> {
+    const che = new CheHelper()
+    const tasks = new Listr({exitOnError: false, collapse: false, concurrent: true})
+    const containers = container ? [container] : await che.getWorkspacePodContainers(chenamespace!, workspace!)
+    for (const cont of containers) {
+      tasks.add({
+        title: `injecting kubeconfig into container ${cont}`,
+        task: async (ctx: any, task: any) => {
+          try {
+            await this.injectKubeconfig(chenamespace!, ctx.pod, cont)
+            task.title = `${task.title}...done.`
+          } catch (error) {
+            this.error(error)
+          }
+        }
+      })
+    }
+    return tasks
+  }
+
   /**
-   * Copies the local kubeconfig (only minikube context) in a Che Workspace.
-   * Returns true if file is injected successfully and false otherwise.
+   * Copies the local kubeconfig (only minikube context) into the specified container.
+   * If returns, it means injection was completed successfully. If throws an error, injection failed
    */
-  async injectKubeconfig(cheNamespace: string, workspacePod: string, container: string): Promise<boolean> {
+  async injectKubeconfig(cheNamespace: string, workspacePod: string, container: string): Promise<void> {
     const { stdout } = await execa.shell(`kubectl exec ${workspacePod} -n ${cheNamespace} -c ${container} env | grep ^HOME=`, { timeout: 10000 })
     const containerHomeDir = stdout.split('=')[1]
 
     if (await this.fileExists(cheNamespace, workspacePod, container, `${containerHomeDir}/.kube/config`)) {
-      return false
+      throw new Error('kubeconfig already exists in the target container')
     }
     await execa.shell(`kubectl exec ${workspacePod} -n ${cheNamespace} -c ${container} -- mkdir ${containerHomeDir}/.kube -p`, { timeout: 10000 })
 
@@ -121,7 +139,7 @@ export default class Inject extends Command {
     const contextName = 'minikube'
     const contextToInject = kc.getContexts().find(c => c.name === contextName)
     if (!contextToInject) {
-      throw new Error(`Context ${contextName} is not found in the local kubeconfig`)
+      throw new Error(`Context ${contextName} is not found in the source kubeconfig`)
     }
     const kubeconfig = path.join(os.tmpdir(), 'che-kubeconfig')
     const cluster = kc.getCluster(contextToInject.cluster)
@@ -131,7 +149,7 @@ export default class Inject extends Command {
     await execa('kubectl', ['config', '--kubeconfig', kubeconfig, 'set-context', contextToInject.name, `--cluster=${contextToInject.cluster}`, `--user=${contextToInject.user}`, `--namespace=${cheNamespace}`], { timeout: 10000 })
     await execa('kubectl', ['config', '--kubeconfig', kubeconfig, 'use-context', contextToInject.name], { timeout: 10000 })
     await execa('kubectl', ['cp', kubeconfig, `${cheNamespace}/${workspacePod}:${containerHomeDir}/.kube/config`, '-c', container], { timeout: 10000 })
-    return true
+    return
   }
 
   async fileExists(namespace: string, pod: string, container: string, file: string): Promise<boolean> {

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -106,6 +106,11 @@ export default class Inject extends Command {
     const tasks = new Listr({exitOnError: false, concurrent: true})
     const containers = container ? [container] : await che.getWorkspacePodContainers(chenamespace!, workspace!)
     for (const cont of containers) {
+      // che-machine-exec container is very limited for a security reason.
+      // We cannot copy file into it.
+      if (cont === 'che-machine-exec') {
+        continue
+      }
       tasks.add({
         title: `injecting kubeconfig into container ${cont}`,
         task: async (ctx: any, task: any) => {


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

closes #59 

Executing `chectl workspace:inject` command without a container specified (`-c` option) injects a configuration file in all containers of a Workspace pod.
Tasks are running in parallel indicating the status of each.

See the example of output when injecting kubeconfig in the Workspace with 4 containers.

![inject](https://user-images.githubusercontent.com/1636395/56302222-00c29a00-6142-11e9-9bd8-aeb9f910952b.gif)


