### PR TITLE
Use alias in devfile.yaml and remove component names.

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,11 +6,10 @@ projects:
       type: git
       location: 'https://github.com/che-incubator/chectl.git'
 components:
-  - name: theia-ide
+  - alias: theia-ide
     type: cheEditor
     id: org.eclipse.che.editor.theia:1.0.0
-  - name: exec-plugin
-    type: chePlugin
+  - type: chePlugin
     id: che-machine-exec-plugin:0.0.1
 commands:
   - name: build


### PR DESCRIPTION
Che 7.0.0-beta-4.0 is going to drop support for component names and replaces it with an alias. We need to update the devfile.yaml to take that into account.
