### PR TITLE
Fix TLS templates typos

### DIFF
--- a/templates/kubernetes/helm/che/templates/cert-issuer.yaml
+++ b/templates/kubernetes/helm/che/templates/cert-issuer.yaml
@@ -19,10 +19,10 @@ spec:
 {{- if .Values.global.tls.useStaging }}
     server: https://acme-staging.api.letsencrypt.org/directory
 {{- else }}
-    server: https://acme-v01.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
 {{- end }}
     # Email address used for ACME registration
-    email: user@example.com
+    email: {{ .Values.global.tls.email }}
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt

--- a/templates/kubernetes/helm/che/templates/certificate.yaml
+++ b/templates/kubernetes/helm/che/templates/certificate.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-{{- if .Values.global.tlsEnabled }}
+{{- if .Values.global.tls.enabled }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -16,6 +16,7 @@ spec:
   secretName: {{ .Values.global.tls.secretName }}
   issuerRef:
     name: letsencrypt
+    kind: ClusterIssuer
   commonName: {{ .Values.global.cheDomain }}
   dnsNames:
       - {{ .Values.global.cheDomain }}

--- a/templates/kubernetes/helm/che/values.yaml
+++ b/templates/kubernetes/helm/che/values.yaml
@@ -42,6 +42,7 @@ global:
     useCertManager: true
     useStaging: true
     secretName: che-tls
+    email: user@example.com
   gitHubClientID: ""
   gitHubClientSecret: ""
   pvcClaim: "1Gi"


### PR DESCRIPTION
Fix few typos for making `global.tls.enabled` work.