### PR TITLE
Check running state before waiting for a pod

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -232,8 +232,19 @@ export default class Start extends Command {
       {
         title: 'scheduling',
         task: async (_ctx: any, task: any) => {
-          await kube.waitForPodPending(selector, namespace)
-          task.title = `${task.title}...done.`
+          let phase
+          const title = task.title
+          try {
+            phase = await kube.getPodPhase(selector, namespace)
+          } catch (_err) {
+            // not able to grab current phase
+            this.debug(_err)
+          }
+          // wait only if not yet running
+          if (phase !== 'Running') {
+            await kube.waitForPodPending(selector, namespace)
+          }
+          task.title = `${title}...done.`
         }
       },
       {


### PR DESCRIPTION
Fixes #48 and #103
If pod is already in running state, do not wait for scheduling

Change-Id: Ibd3f8ced681140691fdcc3cc6e7b9068d7d2ec6b
Signed-off-by: Florent Benoit <fbenoit@redhat.com>