### PR TITLE
Support starting workspaces from remote devfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.4/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.6/src/commands/help.ts)_
 
 ## `chectl server:delete`
 
@@ -268,7 +268,7 @@ USAGE
   $ chectl workspace:start
 
 OPTIONS
-  -f, --devfile=devfile                  path to a valid devfile
+  -f, --devfile=devfile                  path or URL to a valid devfile
   -h, --help                             show CLI help
   -n, --chenamespace=chenamespace        [default: che] kubernetes namespace where Che server is deployed
   -w, --workspaceconfig=workspaceconfig  path to a valid workspace configuration json file

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -222,7 +222,7 @@ export class CheHelper {
     let devfile
     let response
     try {
-      devfile = fs.readFileSync(devfilePath, 'utf8')
+      devfile = await this.parseDevfile(devfilePath)
       response = await axios.post(endpoint, devfile, {headers: {'Content-Type': 'text/yaml'}})
     } catch (error) {
       if (!devfile) { throw new Error(`E_NOT_FOUND_DEVFILE - ${devfilePath} - ${error.message}`) }
@@ -237,7 +237,15 @@ export class CheHelper {
     } else {
       throw new Error('E_BAD_RESP_CHE_SERVER')
     }
+  }
 
+  async parseDevfile(devfilePath = ''): Promise<string> {
+    if (devfilePath.startsWith('http')) {
+      const response = await axios.get(devfilePath)
+      return response.data
+    } else {
+      return fs.readFileSync(devfilePath, 'utf8')
+    }
   }
 
   async createWorkspaceFromWorkspaceConfig(namespace: string | undefined, workspaceConfigPath = ''): Promise<string> {

--- a/src/commands/devfile/generate.ts
+++ b/src/commands/devfile/generate.ts
@@ -168,7 +168,7 @@ export default class Generate extends Command {
       const component: DevfileComponent = {
         type: TheEndpointName.Kubernetes,
         alias: `${flags.selector}`,
-        referenceContent: `${yaml.safeDump(k8sList)}`
+        referenceContent: `${yaml.safeDump(k8sList, { skipInvalid: true })}`
       }
       if (devfile.components) {
         devfile.components.push(component)

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -28,7 +28,7 @@ export default class Start extends Command {
     }),
     devfile: string({
       char: 'f',
-      description: 'path to a valid devfile',
+      description: 'path or URL to a valid devfile',
       env: 'DEVFILE_PATH',
       required: false,
     }),

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -49,7 +49,7 @@ export default class Start extends Command {
     const Listr = require('listr')
     const notifier = require('node-notifier')
     const che = new CheHelper()
-    if (!flags.devfile || !flags.workspaceconfig) {
+    if (!flags.devfile && !flags.workspaceconfig) {
       this.error('workspace:start command is expecting a devfile or workspace configuration parameter.')
     }
     const tasks = new Listr([


### PR DESCRIPTION
Support `chectl workspace:start --devfile=http://...` and fix `devfile:generate` yaml dump