### PR TITLE
option to override workspace name when creating a workspace from a devfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ OPTIONS
   -n, --chenamespace=chenamespace        [default: che] kubernetes namespace where Che server is deployed
   -w, --workspaceconfig=workspaceconfig  path to a valid workspace configuration json file
   --listr-renderer=listr-renderer        [default: default] Listr renderer. Can be 'default', 'silent' or 'verbose'
+
+  --name=name                            workspace name: overrides the workspace name to use instead of the one defined
+                                         in the devfile. Works only for devfile
 ```
 
 _See code: [src/commands/workspace/start.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/workspace/start.ts)_

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -17,6 +17,8 @@ import * as fs from 'fs'
 
 import { KubeHelper } from '../api/kube'
 import { OpenShiftHelper } from '../api/openshift'
+import { Devfile } from './devfile'
+import * as yaml from 'js-yaml'
 
 export class CheHelper {
   defaultCheResponseTimeoutMs = 3000
@@ -213,7 +215,7 @@ export class CheHelper {
     }
   }
 
-  async createWorkspaceFromDevfile(namespace: string | undefined, devfilePath = ''): Promise<string> {
+  async createWorkspaceFromDevfile(namespace: string | undefined, devfilePath = '', workspaceName: string | undefined): Promise<string> {
     if (!await this.cheNamespaceExist(namespace)) {
       throw new Error('E_BAD_NS')
     }
@@ -223,6 +225,11 @@ export class CheHelper {
     let response
     try {
       devfile = await this.parseDevfile(devfilePath)
+      if (workspaceName) {
+        let json: Devfile = yaml.load(devfile)
+        json.metadata.name = workspaceName
+        devfile = yaml.dump(json);
+      }
       response = await axios.post(endpoint, devfile, {headers: {'Content-Type': 'text/yaml'}})
     } catch (error) {
       if (!devfile) { throw new Error(`E_NOT_FOUND_DEVFILE - ${devfilePath} - ${error.message}`) }

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -14,11 +14,12 @@ import { Core_v1Api, KubeConfig } from '@kubernetes/client-node'
 import axios from 'axios'
 import { cli } from 'cli-ux'
 import * as fs from 'fs'
+import * as yaml from 'js-yaml'
 
 import { KubeHelper } from '../api/kube'
 import { OpenShiftHelper } from '../api/openshift'
+
 import { Devfile } from './devfile'
-import * as yaml from 'js-yaml'
 
 export class CheHelper {
   defaultCheResponseTimeoutMs = 3000
@@ -228,7 +229,7 @@ export class CheHelper {
       if (workspaceName) {
         let json: Devfile = yaml.load(devfile)
         json.metadata.name = workspaceName
-        devfile = yaml.dump(json);
+        devfile = yaml.dump(json)
       }
       response = await axios.post(endpoint, devfile, {headers: {'Content-Type': 'text/yaml'}})
     } catch (error) {

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -38,6 +38,10 @@ export default class Start extends Command {
       env: 'WORKSPACE_CONFIG_JSON_PATH',
       required: false,
     }),
+    name: string({
+      description: 'workspace name: overrides the workspace name to use instead of the one defined in the devfile. Works only for devfile',
+      required: false,
+    }),
     'listr-renderer': string({
       description: 'Listr renderer. Can be \'default\', \'silent\' or \'verbose\'',
       default: 'default'
@@ -72,7 +76,7 @@ export default class Start extends Command {
         title: `Create workspace from Devfile ${flags.devfile}`,
         enabled: () => flags.devfile !== undefined,
         task: async (ctx: any) => {
-          ctx.workspaceIdeURL = await che.createWorkspaceFromDevfile(flags.chenamespace, flags.devfile)
+          ctx.workspaceIdeURL = await che.createWorkspaceFromDevfile(flags.chenamespace, flags.devfile, flags.name)
         }
       },
       {

--- a/test/api/che.test.ts
+++ b/test/api/che.test.ts
@@ -103,7 +103,7 @@ describe('Che helper', () => {
         .post('/api/devfile')
         .replyWithFile(201, __dirname + '/replies/create-workspace-from-valid-devfile.json', { 'Content-Type': 'application/json' }))
       .it('succeds creating a workspace from a valid devfile', async () => {
-        const res = await ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.valid')
+        const res = await ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.valid', undefined)
         expect(res).to.equal('https://che-che.192.168.64.39.nip.io/dashboard/#/ide/che/chectl')
       })
     fancy
@@ -114,13 +114,13 @@ describe('Che helper', () => {
         .replyWithFile(400, __dirname + '/replies/create-workspace-from-invalid-devfile.json', {
           'Content-Type': 'application/json'
         }))
-      .do(() => ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.invalid'))
+      .do(() => ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.invalid', undefined))
       .catch(/E_BAD_DEVFILE_FORMAT/)
       .it('fails creating a workspace from an invalid devfile')
     fancy
       .stub(ch, 'cheNamespaceExist', () => true)
       .stub(ch, 'cheURL', () => cheURL)
-      .do(() => ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.inexistent'))
+      .do(() => ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.inexistent', undefined))
       .catch(/E_NOT_FOUND_DEVFILE/)
       .it('fails creating a workspace from a non-existing devfile')
     fancy
@@ -133,7 +133,7 @@ describe('Che helper', () => {
         .post('/api/devfile')
         .replyWithFile(201, __dirname + '/replies/create-workspace-from-valid-devfile.json', { 'Content-Type': 'application/json' }))
       .it('succeeds creating a workspace from a remote devfile', async () => {
-        const res = await ch.createWorkspaceFromDevfile(namespace, devfileServerURL + '/devfile.yaml')
+        const res = await ch.createWorkspaceFromDevfile(namespace, devfileServerURL + '/devfile.yaml', undefined)
         expect(res).to.equal('https://che-che.192.168.64.39.nip.io/dashboard/#/ide/che/chectl')
       })
     fancy
@@ -142,7 +142,7 @@ describe('Che helper', () => {
       .nock(devfileServerURL, api => api
         .get('/devfile.yaml')
         .reply(404, '404 - Not Found'))
-      .do(() => ch.createWorkspaceFromDevfile(namespace, devfileServerURL + '/devfile.yaml'))
+      .do(() => ch.createWorkspaceFromDevfile(namespace, devfileServerURL + '/devfile.yaml', undefined))
       .catch(/E_NOT_FOUND_DEVFILE/)
       .it('fails creating a workspace from a non-existing remote devfile')
   })


### PR DESCRIPTION
Each time a developer creates a workpace from the same devfile, if the workspace name already exist, che would suffix it with an underscore char + incremental number.
This PR provides the ability to customize this name in the case user would like to name its workspace differently. For instance name could containsindication about the task/issue or anything else.

Previously, without the option:
```
chectl workspace:start --devfile=devfile.yaml
  ✔ Retrieving Che Server URL...http://che-che.192.168.39.216.nip.io
  ✔ Verify if Che server is running
  ✔ Create workspace from Devfile devfile.yaml

Workspace IDE URL:
http://che-che.192.168.39.216.nip.io/dashboard/#/ide/che/chectl_3
```

Now with the option `--name=`
```
chectl workspace:start --devfile=devfile.yaml --name=chectl-fix-component-name
  ✔ Retrieving Che Server URL...http://che-che.192.168.39.216.nip.io
  ✔ Verify if Che server is running
  ✔ Create workspace from Devfile devfile.yaml

Workspace IDE URL:
http://che-che.192.168.39.216.nip.io/dashboard/#/ide/che/chectl-fix-component-name
```