### PR TITLE
Add initial support for openshift, k8s and docker-desktop platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ EXAMPLES
   $ chectl autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.1.0/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.1.1/src/commands/autocomplete/index.ts)_
 
 ## `chectl devfile:generate`
 
@@ -124,7 +124,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.6/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.0/src/commands/help.ts)_
 
 ## `chectl server:delete`
 
@@ -167,7 +167,7 @@ OPTIONS
   -o, --cheboottimeout=cheboottimeout      (required) [default: 40000] Che server bootstrap timeout (in milliseconds)
 
   -p, --platform=platform                  [default: minikube] Type of Kubernetes platform. Valid values are "minikube",
-                                           "minishift".
+                                           "minishift", "k8s", "openshift".
 
   -s, --tls                                Enable TLS encryption and multi-user mode
 

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -69,6 +69,18 @@ export class KubeHelper {
     throw new Error('ERR_LIST_SERVICES')
   }
 
+  async waitForService(selector: string, namespace = '', intervalMs = 500, timeoutMs = 30000) {
+    const iterations = timeoutMs / intervalMs
+    for (let index = 0; index < iterations; index++) {
+      let currentServices = await this.getServicesBySelector(selector, namespace)
+      if (currentServices && currentServices.items.length > 0) {
+        return
+      }
+      await cli.wait(intervalMs)
+    }
+    throw new Error(`ERR_TIMEOUT: Timeout set to waiting for service ${timeoutMs}`)
+  }
+
   async serviceAccountExist(name = '', namespace = ''): Promise<boolean | ''> {
     const k8sApi = this.kc.makeApiClient(Core_v1Api)
     try {
@@ -535,6 +547,10 @@ export class KubeHelper {
     } catch (e) {
       throw new Error(e.body.message)
     }
+  }
+
+  async currentContext(): Promise<string> {
+    return this.kc.getCurrentContext()
   }
 
   async checkKubeApi() {

--- a/src/installers/operator.ts
+++ b/src/installers/operator.ts
@@ -38,10 +38,10 @@ export class OperatorHelper {
           const exist = await che.cheNamespaceExist(flags.chenamespace)
           if (exist) {
             task.title = `${task.title}...It already exist.`
-          } else if (flags.platform === 'minikube') {
+          } else if (flags.platform === 'minikube' || flags.platform === 'k8s') {
             await execa.shell(`kubectl create namespace ${flags.chenamespace}`)
             task.title = `${task.title}...done.`
-          } else if (flags.platform === 'minishift') {
+          } else if (flags.platform === 'minishift' || flags.platform === 'openshift') {
             await execa.shell(`oc new-project ${flags.chenamespace}`)
             task.title = `${task.title}...done.`
           }
@@ -53,10 +53,10 @@ export class OperatorHelper {
           const exist = await kube.serviceAccountExist(this.operatorServiceAccount, flags.chenamespace)
           if (exist) {
             task.title = `${task.title}...It already exist.`
-          } else if (flags.platform === 'minikube') {
+          } else if (flags.platform === 'minikube' || flags.platform === 'k8s') {
             await execa.shell(`kubectl create serviceaccount ${this.operatorServiceAccount} -n=${flags.chenamespace}`)
             task.title = `${task.title}...done.`
-          } else if (flags.platform === 'minishift') {
+          } else if (flags.platform === 'minishift' || flags.platform === 'openshift') {
             await execa.shell(`oc create serviceaccount ${this.operatorServiceAccount} -n=${flags.chenamespace}`)
             task.title = `${task.title}...done.`
           }

--- a/src/platforms/docker-desktop.ts
+++ b/src/platforms/docker-desktop.ts
@@ -1,0 +1,125 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+
+import { Command } from '@oclif/command'
+import * as commandExists from 'command-exists'
+import * as execa from 'execa'
+import * as Listr from 'listr'
+import * as os from 'os'
+
+import { KubeHelper } from '../api/kube'
+
+export class DockerDesktopHelper {
+  private readonly kh: KubeHelper
+
+  constructor() {
+    this.kh = new KubeHelper()
+  }
+
+  startTasks(flags: any, command: Command): Listr {
+    return new Listr([
+      {
+        title: 'Verify if kubectl is installed',
+        task: () => {
+          if (!commandExists.sync('kubectl')) {
+            command.error('E_REQUISITE_NOT_FOUND')
+          }
+        }
+      },
+      {
+        title: 'Verify if kubectl context is Docker Desktop',
+        task: async (_ctx: any, task: any) => {
+          const context = await this.kh.currentContext()
+          if (context !== 'docker-for-desktop') {
+            command.error(`E_PLATFORM_NOT_READY: current kube context is not Docker Desktop context. Found ${context}`)
+          } else {
+            task.title = `${task.title}: Found ${context}.`
+          }
+        }
+      },
+      {
+        title: 'Verify remote kubernetes status',
+        task: async (_ctx: any, task: any) => {
+          try {
+            await this.kh.checkKubeApi()
+            task.title = `${task.title}...done.`
+          } catch (error) {
+            command.error('E_PLATFORM_NOT_READY: ' + error)
+          }
+        }
+      },
+      {
+        title: 'Verify if nginx ingress is installed',
+        task: async (ctx: any) => {
+          ctx.isNginxIngressInstalled = await this.isNginxIngressEnabled()
+        }
+      },
+      {
+        title: 'Installing nginx ingress',
+        skip: (ctx: any) => {
+          if (ctx.isNginxIngressInstalled) {
+            return 'Ngninx ingress is already setup.'
+          }
+        },
+        task: () => this.enableNginxIngress()
+      },
+
+      // Should automatically compute route if missing
+      {
+        title: 'Verify domain is set',
+        task: async (_ctx: any, task: any) => {
+          if (flags.domain === undefined || flags.domain === '') {
+            const ips = this.grabIps()
+            if (ips.length === 0) {
+              command.error('E_MISSING_DOMAIN: Unable to find IPV4 ip on this computer. Needs to provide --domain flag')
+            } else if (ips.length >= 1) {
+              flags.domain = `${ips[0]}.nip.io`
+            }
+            task.title = `${task.title}... auto-assigning domain to ${flags.domain}.`
+          }
+          task.title = `${task.title}...set to ${flags.domain}.`
+        }
+      },
+    ], { renderer: flags['listr-renderer'] as any })
+  }
+
+  // $ kubectl get services --namespace ingress-nginx
+  async isNginxIngressEnabled(): Promise<boolean> {
+    const services = await this.kh.getServicesBySelector('', 'ingress-nginx')
+    return services.items.length > 0
+  }
+
+  async enableNginxIngress(execTimeout = 30000): Promise<void> {
+    const sha1 = '78d6ce6e6e7d77309bc1e8a563e4ee5308db5566'
+
+    // mandatory part
+    const mandatoryCommand = `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${sha1}/deploy/static/mandatory.yaml`
+    await execa.shell(mandatoryCommand, { timeout: execTimeout })
+
+    // mandatory part
+    const genericCommand = `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${sha1}/deploy/static/provider/cloud-generic.yaml`
+    await execa.shell(genericCommand, { timeout: execTimeout })
+  }
+
+  grabIps(): string[] {
+    let networkInterfaces = os.networkInterfaces()
+    const allIps: string[] = []
+    Object.keys(networkInterfaces).forEach(interfaceName => {
+      networkInterfaces[interfaceName].forEach(iface => {
+        if (iface.family === 'IPv4' && iface.internal !== true) {
+          allIps.push(iface.address)
+        }
+      })
+    })
+    return allIps
+  }
+
+}

--- a/src/platforms/k8s.ts
+++ b/src/platforms/k8s.ts
@@ -1,0 +1,54 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+
+import { Command } from '@oclif/command'
+import * as commandExists from 'command-exists'
+import * as Listr from 'listr'
+
+import { KubeHelper } from '../api/kube'
+
+export class K8sHelper {
+  startTasks(flags: any, command: Command): Listr {
+    return new Listr([
+      {
+        title: 'Verify if kubectl is installed',
+        task: () => {
+          if (!commandExists.sync('kubectl')) {
+            command.error('E_REQUISITE_NOT_FOUND')
+          }
+        }
+      },
+      {
+        title: 'Verify remote kubernetes status',
+        task: async (_ctx: any, task: any) => {
+          const kh = new KubeHelper()
+          try {
+            await kh.checkKubeApi()
+            task.title = `${task.title}...done.`
+          } catch (error) {
+            command.error('E_PLATFORM_NOT_READY: ' + error)
+          }
+        }
+      },
+      // Should automatically compute route if missing
+      {
+        title: 'Verify domain is set',
+        task: (_ctx: any, task: any) => {
+          if (flags.domain === undefined || flags.domain === '') {
+            command.error('E_MISSING_ARGUMENT: the domain parameter needs to be defined.')
+          }
+          task.title = `${task.title}...set to ${flags.domain}.`
+        }
+      },
+    ], { renderer: flags['listr-renderer'] as any })
+  }
+
+}

--- a/src/platforms/openshift.ts
+++ b/src/platforms/openshift.ts
@@ -1,0 +1,57 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+
+import { Command } from '@oclif/command'
+import * as commandExists from 'command-exists'
+import * as execa from 'execa'
+import * as Listr from 'listr'
+
+export class OpenshiftHelper {
+  startTasks(flags: any, command: Command): Listr {
+    return new Listr([
+      {
+        title: 'Verify if oc is installed',
+        task: (_ctx: any, task: any) => {
+          if (!commandExists.sync('oc')) {
+            command.error('E_REQUISITE_NOT_FOUND')
+          } else {
+            task.title = `${task.title}...done.`
+          }
+        }
+      },
+      { title: 'Verify if openshift is running',
+        task: async (_ctx: any, task: any) => {
+          const openshiftIsRunning = await this.isOpenshiftRunning()
+          if (!openshiftIsRunning) {
+            command.error(`E_PLATFORM_NOT_READY: oc status command failed. If there is no project, please create it before by running "oc new-project ${flags.chenamespace}"`)
+          } else {
+            task.title = `${task.title}...done.`
+          }
+        }
+      },
+      // Should automatically compute route if missing
+      { title: 'Verify domain is set',
+        task: (_ctx: any, task: any) => {
+          if (flags.domain === undefined || flags.domain === '') {
+            command.error('E_MISSING_ARGUMENT: the domain parameter needs to be defined.')
+          }
+          task.title = `${task.title}...set to ${flags.domain}.`
+        }
+      },
+    ], {renderer: flags['listr-renderer'] as any})
+  }
+
+  async isOpenshiftRunning(): Promise<boolean> {
+    const { code } = await execa('oc', ['status'], { timeout: 60000, reject: false })
+    return code === 0
+  }
+
+}

--- a/test/platforms/openshift.test.ts
+++ b/test/platforms/openshift.test.ts
@@ -1,0 +1,54 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+import * as execa from 'execa'
+import { expect, fancy } from 'fancy-test'
+
+import {OpenshiftHelper} from '../../src/platforms/openshift'
+
+jest.mock('execa')
+
+let openshift = new OpenshiftHelper()
+
+describe('start', () => {
+  fancy
+    .it('confirms that openshift is running when it does run', async () => {
+      const status = `In project che on server https://master.rhpds311.openshift.opentlc.com:443
+      
+      http://che-che.apps.rhpds311.openshift.opentlc.com (svc/che-host)
+        deployment/che deploys eclipse/che-server:latest
+          deployment #1 running for 18 hours - 1 pod
+      
+      http://keycloak-che.apps.rhpds311.openshift.opentlc.com (svc/keycloak)
+        deployment/keycloak deploys registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.2-8
+          deployment #1 running for 18 hours - 1 pod
+      
+      svc/postgres - 172.30.187.205:5432
+        deployment/postgres deploys registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-25
+          deployment #1 running for 18 hours - 1 pod
+      
+      
+      3 infos identified, use 'oc status --suggest' to see details.`;
+
+      (execa as any).mockResolvedValue({ code: 0, stdout: status })
+      const res = await openshift.isOpenshiftRunning()
+      expect(res).to.equal(true)
+    })
+
+  fancy
+    .it('confirms that openshift is not running when both minishift and OpenShift are stopped', async () => {
+      const status = `Error from server (Forbidden): projects.project.openshift.io "che" is forbidden: User "system:anonymous" cannot get projects.project.openshift.io in the namespace "che": no RBAC policy matched
+      `;
+
+      (execa as any).mockResolvedValue({ code: 1, stdout: status })
+      const res = await openshift.isOpenshiftRunning()
+      expect(res).to.equal(false)
+    })
+})


### PR DESCRIPTION
`--platform=openshift` , `--platform=k8s` or `--platform=docker-desktop`
It fixes https://github.com/che-incubator/chectl/issues/14 and fixes https://github.com/che-incubator/chectl/issues/80

note: you need to be logged in on the underlying platform before running chectl

I've tested by using Openshift v3.11 on RHPDS and on K8S/digitalocean and Docker Desktop for mac

example with command
```$ chectl server:start --platform=docker-desktop```
![image](https://user-images.githubusercontent.com/436777/59613311-ff502680-911e-11e9-99b1-ec22930c67e5.png)

note: using operator is still failing on workspaces due to https://github.com/che-incubator/chectl/issues/92


Change-Id: Ic541c5d7932c6782c67bc0103a0d941fd34288d6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>