### PR TITLE
chectl devfile:generate. Fixed dockerimage alias that contains invalid characters

### DIFF
--- a/src/commands/devfile/generate.ts
+++ b/src/commands/devfile/generate.ts
@@ -124,7 +124,7 @@ export default class Generate extends Command {
 
     if (flags.dockerimage !== undefined) {
       const component: DevfileComponent = {
-        alias: `${flags.dockerimage.replace(/[\.\/]/g, '-').substring(0, 20)}`,
+        alias: `${flags.dockerimage.replace(/[\.\/:]/g, '-').substring(0, 20)}`,
         type: TheEndpointName.Dockerimage,
         image: `${flags.dockerimage}`,
         memoryLimit: '512M',


### PR DESCRIPTION
Thanks to daniel that worked on that PR during https://hack-commit-pu.sh/ :)

When using chectl devfile:generate with the dockerimage option and when it docker image contains a character like `:`, the workspace is failing to start because alias name container `:` which is not allowed in Che.

How to reproduce:
Run the command and start the workspace from the generated file:

```

$ chectl devfile:generate --dockerimage=maven:3.6.0-jdk-11 > test.devfile.yaml

 $ chectl workspace:start -f test.devfile.yaml
  ✔ Retrieving Che Server URL...http://che-che.192.168.39.25.nip.io
  ✔ Verify if Che server is running
  ✔ Create workspace from Devfile test.devfile.yaml

Workspace IDE URL:
http://che-che.192.168.39.25.nip.io/dashboard/#/ide/che/chectl-generated
```

![Selection_300](https://user-images.githubusercontent.com/650571/59552449-65a24100-8f87-11e9-9c85-db3c95253bea.png)
