### PR TITLE
allow to override CHE_IMAGE parameter with the custom flags --cheImage for che operator

### DIFF
--- a/src/installers/operator.ts
+++ b/src/installers/operator.ts
@@ -94,7 +94,9 @@ export class OperatorHelper {
         task: async (_ctx: any, task: any) => {
           const patch = { data: {
             CHE_INFRA_KUBERNETES_INGRESS_DOMAIN : flags.domain,
-            CHE_OPENSHIFT_API_URL: '' }
+            CHE_OPENSHIFT_API_URL: '',
+            CHE_IMAGE: flags.cheimage
+          }
           }
           await kube.patchConfigMap(this.operatorConfigMap, patch, flags.chenamespace)
           task.title = `${task.title}...done.`


### PR DESCRIPTION
fix #161 

trying with RC2 resulted in having RC2 image for che-server

```
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  47s   default-scheduler  Successfully assigned che/che-7c9677d4d6-fmjdj to minikube
  Normal  Pulling    46s   kubelet, minikube  Pulling image "eclipse/che-server:7.0.0-RC-2.0"
  Normal  Pulled     29s   kubelet, minikube  Successfully pulled image "eclipse/che-server:7.0.0-RC-2.0"


```

Change-Id: I522ebfa7e37f8063a4f0a8824cef6ad77b7dfdf0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>