### PR TITLE
Handle deleted state of che helm chart by rollbacking or purging the charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ OPTIONS
   -o, --cheboottimeout=cheboottimeout      (required) [default: 40000] Che server bootstrap timeout (in milliseconds)
 
   -p, --platform=platform                  [default: minikube] Type of Kubernetes platform. Valid values are "minikube",
-                                           "minishift", "k8s", "openshift".
+                                           "minishift", "k8s", "openshift", "microk8s".
 
   -s, --tls                                Enable TLS encryption and multi-user mode
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,11 +2177,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
-
 fsevents@^1.0.0, fsevents@^1.2.7:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"


### PR DESCRIPTION
Fix #18


`$ helm history` will display now
```shell
29      	Wed Jul  3 11:00:29 2019	SUPERSEDED	che-0.1.0	Rollback to 28   
30      	Wed Jul  3 11:00:30 2019	DEPLOYED  	che-0.1.0	Upgrade complete 
```

Change-Id: I30a7e4462d5c10219c216ee528e73f2853aeaba5
Signed-off-by: Florent Benoit <fbenoit@redhat.com>