### PR TITLE
Updating codeowners for Che 7 endgame code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global Owners
+* @l0rd @rhopp @benoitf @vparfonov @azatsarynnyy
+


### PR DESCRIPTION
Adding @l0rd @rhopp and @benoitf as global code reviewers as required by eclipse/che#13637