### PR TITLE
fix(k8s): token missing in endpoint when calling /healthz

### DIFF
--- a/test/api/kube.test.ts
+++ b/test/api/kube.test.ts
@@ -101,6 +101,10 @@ describe('Kube API helper', () => {
     })
   fancy
     .nock(kubeClusterURL, api => api
+      .get(`/api/v1/namespaces/default/serviceaccounts`)
+      .replyWithFile(200, __dirname + '/replies/get-serviceaccounts.json', { 'Content-Type': 'application/json' })
+      .get(`/api/v1/namespaces/default/secrets`)
+      .replyWithFile(200, __dirname + '/replies/get-secrets.json', { 'Content-Type': 'application/json' })
       .get('/healthz')
       .reply(200, 'ok'))
     .it('verifies that kuber API is ok', async () => {

--- a/test/api/replies/get-secrets.json
+++ b/test/api/replies/get-secrets.json
@@ -1,0 +1,64 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "data": {
+                "secret-access-key": "foobar"
+            },
+            "kind": "Secret",
+            "metadata": {
+                "creationTimestamp": "2019-07-08T09:49:32Z",
+                "name": "acme-route53",
+                "namespace": "default",
+                "resourceVersion": "7357",
+                "selfLink": "/api/v1/namespaces/default/secrets/acme-route53",
+                "uid": "123-123-123-123-123"
+            },
+            "type": "Opaque"
+        },
+        {
+            "apiVersion": "v1",
+            "data": {
+                "ACME_EMAIL": "Zm9vQGV4YW1wbGUuY29t"
+            },
+            "kind": "Secret",
+            "metadata": {
+                "creationTimestamp": "2019-07-10T08:42:54Z",
+                "name": "che-tls",
+                "namespace": "default",
+                "resourceVersion": "363521",
+                "selfLink": "/api/v1/namespaces/default/secrets/che-tls",
+                "uid": "123-123-123-123-123"
+            },
+            "type": "Opaque"
+        },
+        {
+            "apiVersion": "v1",
+            "data": {
+                "ca.crt": "dGhpcyBpcyBzZWNyZXQgOi0p",
+                "namespace": "ZGVmYXVsdA==",
+                "token": "bXkgc2VjcmV0IHRva2Vu"
+            },
+            "kind": "Secret",
+            "metadata": {
+                "annotations": {
+                    "kubernetes.io/service-account.name": "default",
+                    "kubernetes.io/service-account.uid": "123-123-123-123-123"
+                },
+                "creationTimestamp": "2019-07-08T08:40:21Z",
+                "name": "default-token-krzwc",
+                "namespace": "default",
+                "resourceVersion": "247",
+                "selfLink": "/api/v1/namespaces/default/secrets/default-token-krzwc",
+                "uid": "123-123-123-123-123"
+            },
+            "type": "kubernetes.io/service-account-token"
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}

--- a/test/api/replies/get-serviceaccounts.json
+++ b/test/api/replies/get-serviceaccounts.json
@@ -1,0 +1,27 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {
+                "creationTimestamp": "2019-07-08T08:40:21Z",
+                "name": "default",
+                "namespace": "default",
+                "resourceVersion": "251",
+                "selfLink": "/api/v1/namespaces/default/serviceaccounts/default",
+                "uid": "fff"
+            },
+            "secrets": [
+                {
+                    "name": "default-token-krzwc"
+                }
+            ]
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}


### PR DESCRIPTION
It fixes https://github.com/eclipse/che/issues/13800

Grab secret from serviceAccount and use it when calling the endpoint

I've tested on a remote k8s and docker-desktop


Change-Id: I5daf5df41d8cebc51ef501c629eca65bc63ae729
Signed-off-by: Florent Benoit <fbenoit@redhat.com>