### PR TITLE
fix(yarn.lock): Old templates were used as yarn.lock is locking sha-1 master

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
   "scripts": {
     "postinstall-helm": "rimraf templates/kubernetes && cpx 'node_modules/eclipse-che/deploy/kubernetes/**' 'templates/kubernetes'",
     "postinstall-operator": "rimraf templates/che-operator && cpx 'node_modules/eclipse-che-operator/deploy/**' 'templates/che-operator'",
-    "postinstall": "npm run -s postinstall-helm & npm run -s postinstall-operator",
+    "postinstall-repositories": "yarn upgrade eclipse-che eclipse-che-operator",
+    "postinstall": "npm run -s postinstall-repositories && npm run -s postinstall-helm && npm run -s postinstall-operator",
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
     "tslint-fix": "tslint --fix -p test -t stylish",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1717,11 +1717,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#d545e8b18035d568a240fe8b86e1fb194fe2c588"
+  resolved "git://github.com/eclipse/che-operator#6f463e0e1cb88cad396c6f4c61271e92729933dc"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#283a21ca4d6f905be73334f6b3a415d2bf14abc9"
+  resolved "git://github.com/eclipse/che#9cddc3efdc8ae9d1f4de0c0c42dfd14e5fd365df"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Self-update `eclipse/che` and `eclipse/che-operator` dependencies when running yarn install command.
So yarn.lock is using latest master versions every time it's used.

Change-Id: I430aa868b07cbc954de699154ad070b3cca42756
Signed-off-by: Florent Benoit <fbenoit@redhat.com>