### PR TITLE
Default generated (by devfile:generate) dockerimage should not override the container image entrypoint

### DIFF
--- a/src/commands/devfile/generate.ts
+++ b/src/commands/devfile/generate.ts
@@ -129,8 +129,7 @@ export default class Generate extends Command {
         image: `${flags.dockerimage}`,
         memoryLimit: '512M',
         mountSources: true,
-        command: ['tail'],
-        args: ['-f', '/dev/null']
+        args: ['sleep', 'infinity']
       }
       if (devfile.components) {
         devfile.components.push(component)


### PR DESCRIPTION
See https://github.com/eclipse/che/issues/13817#issuecomment-511747894

A lot of the images would have a entrypoint define that has to be executed. For instance some may have permission settings for arbitrary user in the entrypoint. To avoid breaking few containers that would run on a Che workspace, this is just generating the dockerimage with the right CMD to avoid kubernetes to run the app but keeping the original entrypoint call.