### PR TITLE
fix(helm): Automatically grab tls email from che-tls and checks for cert-manager

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -973,6 +973,24 @@ export class KubeHelper {
     }
   }
 
+  async getSecret(name = '', namespace = 'default'): Promise<string | undefined> {
+    const k8sCoreApi = this.kc.makeApiClient(Core_v1Api)
+
+    // now get the matching secrets
+    try {
+      const res = await k8sCoreApi.readNamespacedSecret(name, namespace)
+      if (res && res.body && res.body.metadata && res.body.metadata.name && res.body.data && res.body.data.ACME_EMAIL) {
+        if (res.body.metadata.name === name) {
+          return Buffer.from(res.body.data.ACME_EMAIL, 'base64').toString()
+        }
+      } else {
+        return
+      }
+    } catch {
+      return
+    }
+  }
+
   async persistentVolumeClaimExist(name = '', namespace = ''): Promise<boolean | ''> {
     const k8sCoreApi = this.kc.makeApiClient(Core_v1Api)
     try {

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 // tslint:disable:object-curly-spacing
 
-import { Apiextensions_v1beta1Api, ApisApi, Apps_v1Api, Core_v1Api, Custom_objectsApi, Extensions_v1beta1Api, KubeConfig, RbacAuthorization_v1Api, V1beta1CustomResourceDefinition, V1beta1IngressList, V1ClusterRole, V1ClusterRoleBinding, V1ConfigMap, V1ConfigMapEnvSource, V1Container, V1DeleteOptions, V1Deployment, V1DeploymentList, V1DeploymentSpec, V1EnvFromSource, V1LabelSelector, V1ObjectMeta, V1PersistentVolumeClaimList, V1Pod, V1PodSpec, V1PodTemplateSpec, V1Role, V1RoleBinding, V1RoleRef, V1ServiceAccount, V1ServiceList, V1Subject} from '@kubernetes/client-node'
+import { Apiextensions_v1beta1Api, ApisApi, Apps_v1Api, Core_v1Api, Custom_objectsApi, Extensions_v1beta1Api, KubeConfig, RbacAuthorization_v1Api, V1beta1CustomResourceDefinition, V1beta1IngressList, V1ClusterRole, V1ClusterRoleBinding, V1ConfigMap, V1ConfigMapEnvSource, V1Container, V1DeleteOptions, V1Deployment, V1DeploymentList, V1DeploymentSpec, V1EnvFromSource, V1LabelSelector, V1ObjectMeta, V1PersistentVolumeClaimList, V1Pod, V1PodSpec, V1PodTemplateSpec, V1Role, V1RoleBinding, V1RoleRef, V1ServiceAccount, V1ServiceList, V1Subject } from '@kubernetes/client-node'
 import axios from 'axios'
 import { cli } from 'cli-ux'
 import { readFileSync } from 'fs'
@@ -955,6 +955,22 @@ export class KubeHelper {
       else throw new Error(e)
     }
     throw new Error('ERR_LIST_INGRESSES')
+  }
+
+  async apiVersionExist(expectedVersion: string): Promise<boolean> {
+    const k8sCoreApi = this.kc.makeApiClient(ApisApi)
+
+    // if matching APi Version
+    try {
+      const res = await k8sCoreApi.getAPIVersions()
+      if (res && res.body && res.body.groups) {
+        return res.body.groups.some(version => version.name === expectedVersion)
+      } else {
+        return false
+      }
+    } catch {
+      return false
+    }
   }
 
   async secretExist(name = '', namespace = 'default'): Promise<boolean> {

--- a/src/installers/helm.ts
+++ b/src/installers/helm.ts
@@ -48,6 +48,26 @@ export class HelmHelper {
         }
       },
       {
+        title: 'Check for cert-manager',
+        // Check only if TLS is enabled
+        enabled: () => {
+          return flags.tls
+        },
+        task: async (_ctx: any, task: any) => {
+          const kh = new KubeHelper()
+          const exists = await kh.apiVersionExist('certmanager.k8s.io')
+          if (!exists) {
+            throw new Error(`TLS option is enabled but cert-manager API has not been found. Cert Manager is probably not installed. Example on how to install it:
+            $ kubectl create namespace cert-manager
+            $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+            $ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.8.1/cert-manager.yaml --validate=false
+
+            Please install cert-manager.`)
+          }
+          task.title = `${task.title}...done`
+        }
+      },
+      {
         title: 'Create Tiller Role Binding',
         task: async (_ctx: any, task: any) => {
           const roleBindingExist = await this.tillerRoleBindingExist()


### PR DESCRIPTION
For now tls let's encrypt certificates are failing as the default email is with example.com
But as we require che-tls secret with email inside, re-use this one (if `--tls` option is given)

And when cert-manager is not installed and that `--tls` option is enabled there are helm errors hard to understand for newcomers, so detect it automatically if cert-manager has been installed or not and provides guidance.

It completes fixes of https://github.com/eclipse/che/issues/13801