### PR TITLE
remove devfile and plugin registries defaults

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -53,13 +53,11 @@ export default class Start extends Command {
       env: 'CHE_TEMPLATES_FOLDER'
     }),
     'devfile-registry-url': string({
-      description: 'The URL of the Devfile registry.',
-      default: 'https://che-devfile-registry.openshift.io/',
+      description: 'The URL of the external Devfile registry.',
       env: 'CHE_WORKSPACE_DEVFILE__REGISTRY__URL'
     }),
     'plugin-registry-url': string({
-      description: 'The URL of the plugin registry.',
-      default: 'https://che-plugin-registry.openshift.io/v3',
+      description: 'The URL of the external plugin registry.',
       env: 'CHE_WORKSPACE_PLUGIN__REGISTRY__URL'
     }),
     cheboottimeout: string({

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -286,6 +286,20 @@ export default class Start extends Command {
       })
     }
 
+    if (!flags['devfile-registry-url']) {
+      cheBootstrapSubTasks.add({
+        title: 'Devfile registry pod bootstrap',
+        task: () => this.podStartTasks(this.getDevfileRegistrySelector(), flags.chenamespace)
+      })
+    }
+
+    if (!flags['plugin-registry-url']) {
+      cheBootstrapSubTasks.add({
+        title: 'Plugin registry pod bootstrap',
+        task: () => this.podStartTasks(this.getPluginRegistrySelector(), flags.chenamespace)
+      })
+    }
+
     cheBootstrapSubTasks.add({
       title: 'Che pod bootstrap',
       task: () => this.podStartTasks(this.getCheServerSelector(), flags.chenamespace)
@@ -327,6 +341,14 @@ export default class Start extends Command {
 
   getKeycloakSelector(): string {
     return 'app=che,component=keycloak'
+  }
+
+  getDevfileRegistrySelector(): string {
+    return 'app=che,component=devfile-registry'
+  }
+
+  getPluginRegistrySelector(): string {
+    return 'app=che,component=plugin-registry'
   }
 
   getCheServerSelector(): string {


### PR DESCRIPTION
Registries will be deployed locally by default (https://github.com/eclipse/che/issues/13557), so we don't want to have default registries URL sent to helm.

- [x] Wait for related PR: https://github.com/eclipse/che/pull/13890


This will now work just with helm chart. It must be synced with work on operator side.