### PR TITLE
fix(operator): Add compatibility with the last operator changes

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -769,6 +769,11 @@ export class KubeHelper {
       if (devfileRegistryUrl) {
         yamlCr.spec.server.devfileRegistryUrl = devfileRegistryUrl
       }
+      const tagExp = /:[^:]*$/
+      const newTag = ':' + yamlCr.spec.server.cheImageTag
+      yamlCr.spec.auth.identityProviderImage = yamlCr.spec.auth.identityProviderImage.replace(tagExp, newTag)
+      yamlCr.spec.server.pluginRegistryImage = yamlCr.spec.server.pluginRegistryImage.replace(tagExp, newTag)
+      yamlCr.spec.server.devfileRegistryImage = yamlCr.spec.server.devfileRegistryImage.replace(tagExp, newTag)
     }
     const customObjectsApi = this.kc.makeApiClient(Custom_objectsApi)
     try {

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -745,25 +745,30 @@ export class KubeHelper {
     }
   }
 
-  async createCheClusterFromFile(filePath: string, flags: any) {
+  async createCheClusterFromFile(filePath: string, flags: any, useDefaultCR: boolean) {
     const yamlFile = readFileSync(filePath)
     let yamlCr = yaml.safeLoad(yamlFile.toString())
-    const cheImage = flags.cheimage
     const cheNamespace = flags.chenamespace
-    const imageAndTag = cheImage.split(':', 2)
-    yamlCr.spec.server.cheImage = imageAndTag[0]
-    yamlCr.spec.server.cheImageTag = imageAndTag.length === 2 ? imageAndTag[1] : 'latest'
-    yamlCr.spec.auth.openShiftoAuth = flags['os-oauth']
-    yamlCr.spec.server.tlsSupport = flags.tls
-    yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
-    yamlCr.spec.k8s.ingressDomain = flags.domain
-    let pluginRegistryUrl = flags['plugin-registry-url']
-    if (pluginRegistryUrl) {
-      yamlCr.spec.server.pluginRegistryUrl = pluginRegistryUrl
-    }
-    let devfileRegistryUrl = flags['devfile-registry-url']
-    if (devfileRegistryUrl) {
-      yamlCr.spec.server.devfileRegistryUrl = devfileRegistryUrl
+    if (useDefaultCR) {
+      // If we don't use an explicitely provided CheCluster CR,
+      // then let's modify the default example CR with values
+      // derived from the other parameters
+      const cheImage = flags.cheimage
+      const imageAndTag = cheImage.split(':', 2)
+      yamlCr.spec.server.cheImage = imageAndTag[0]
+      yamlCr.spec.server.cheImageTag = imageAndTag.length === 2 ? imageAndTag[1] : 'latest'
+      yamlCr.spec.auth.openShiftoAuth = flags['os-oauth']
+      yamlCr.spec.server.tlsSupport = flags.tls
+      yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
+      yamlCr.spec.k8s.ingressDomain = flags.domain
+      let pluginRegistryUrl = flags['plugin-registry-url']
+      if (pluginRegistryUrl) {
+        yamlCr.spec.server.pluginRegistryUrl = pluginRegistryUrl
+      }
+      let devfileRegistryUrl = flags['devfile-registry-url']
+      if (devfileRegistryUrl) {
+        yamlCr.spec.server.devfileRegistryUrl = devfileRegistryUrl
+      }
     }
     const customObjectsApi = this.kc.makeApiClient(Custom_objectsApi)
     try {

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -757,8 +757,14 @@ export class KubeHelper {
     yamlCr.spec.server.tlsSupport = flags.tls
     yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
     yamlCr.spec.k8s.ingressDomain = flags.domain
-    yamlCr.spec.server.pluginRegistryUrl = flags['plugin-registry-url']
-    yamlCr.spec.server.devfileRegistryUrl = flags['devfile-registry-url']
+    let pluginRegistryUrl = flags['plugin-registry-url']
+    if (pluginRegistryUrl) {
+      yamlCr.spec.server.pluginRegistryUrl = pluginRegistryUrl
+    }
+    let devfileRegistryUrl = flags['devfile-registry-url']
+    if (devfileRegistryUrl) {
+      yamlCr.spec.server.devfileRegistryUrl = devfileRegistryUrl
+    }
     const customObjectsApi = this.kc.makeApiClient(Custom_objectsApi)
     try {
       return await customObjectsApi.createNamespacedCustomObject('org.eclipse.che', 'v1', cheNamespace, 'checlusters', yamlCr)

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -770,7 +770,7 @@ export class KubeHelper {
         yamlCr.spec.server.devfileRegistryUrl = devfileRegistryUrl
       }
       const tagExp = /:[^:]*$/
-      const newTag = ':' + yamlCr.spec.server.cheImageTag
+      const newTag = `:${yamlCr.spec.server.cheImageTag}`
       yamlCr.spec.auth.identityProviderImage = yamlCr.spec.auth.identityProviderImage.replace(tagExp, newTag)
       yamlCr.spec.server.pluginRegistryImage = yamlCr.spec.server.pluginRegistryImage.replace(tagExp, newTag)
       yamlCr.spec.server.devfileRegistryImage = yamlCr.spec.server.devfileRegistryImage.replace(tagExp, newTag)

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -114,7 +114,7 @@ export default class Start extends Command {
     }),
     'che-operator-image': string({
       description: 'Container image of the operator. This parameter is used only when the installer is the operator',
-      default: 'quay.io/eclipse-che/che-operator:nightly'
+      default: 'quay.io/eclipse/che-operator:nightly'
     }),
     'che-operator-cr-yaml': string({
       description: 'Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer is the operator.',

--- a/src/installers/operator.ts
+++ b/src/installers/operator.ts
@@ -155,8 +155,7 @@ export class OperatorHelper {
           if (exist) {
             task.title = `${task.title}...It already exist.`
           } else {
-            const yamlFilePath = flags['che-operator-cr-yaml'] === '' ? this.resourcesPath + 'operator.yaml' : flags['che-operator-cr-yaml']
-            await kube.createDeploymentFromFile(yamlFilePath, flags.chenamespace, flags['che-operator-image'])
+            await kube.createDeploymentFromFile(this.resourcesPath + 'operator.yaml', flags.chenamespace, flags['che-operator-image'])
             task.title = `${task.title}...done.`
           }
         }
@@ -168,7 +167,7 @@ export class OperatorHelper {
           if (exist) {
             task.title = `${task.title}...It already exist.`
           } else {
-            const yamlFilePath = this.resourcesPath + 'crds/org_v1_che_cr.yaml'
+            const yamlFilePath = flags['che-operator-cr-yaml'] === '' ? this.resourcesPath + 'crds/org_v1_che_cr.yaml' : flags['che-operator-cr-yaml']
             await kube.createCheClusterFromFile(yamlFilePath, flags)
             task.title = `${task.title}...done.`
           }

--- a/src/installers/operator.ts
+++ b/src/installers/operator.ts
@@ -168,7 +168,7 @@ export class OperatorHelper {
             task.title = `${task.title}...It already exist.`
           } else {
             const yamlFilePath = flags['che-operator-cr-yaml'] === '' ? this.resourcesPath + 'crds/org_v1_che_cr.yaml' : flags['che-operator-cr-yaml']
-            await kube.createCheClusterFromFile(yamlFilePath, flags)
+            await kube.createCheClusterFromFile(yamlFilePath, flags, flags['che-operator-cr-yaml'] === '')
             task.title = `${task.title}...done.`
           }
         }


### PR DESCRIPTION
This PR adds compatibility  with the last Che operator changes done in PR https://github.com/eclipse/che-operator/pull/51

This adds support for deploying registries along with the Che server from the operator.