### PR TITLE
fix(operator): Don't deploy a registry if its url is specified as an argument

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -764,10 +764,12 @@ export class KubeHelper {
       let pluginRegistryUrl = flags['plugin-registry-url']
       if (pluginRegistryUrl) {
         yamlCr.spec.server.pluginRegistryUrl = pluginRegistryUrl
+        yamlCr.spec.server.externalPluginRegistry = true
       }
       let devfileRegistryUrl = flags['devfile-registry-url']
       if (devfileRegistryUrl) {
         yamlCr.spec.server.devfileRegistryUrl = devfileRegistryUrl
+        yamlCr.spec.server.externalDevfileRegistry = true
       }
       const tagExp = /:[^:]*$/
       const newTag = `:${yamlCr.spec.server.cheImageTag}`


### PR DESCRIPTION
### What does this PR do?

Don't deploy a registry if its url is specified as an argument when installing with the operator.

This PR is to have, with the `operator` installer, the same behavior as the `helm` installer: https://github.com/che-incubator/chectl/blob/master/src/installers/helm.ts#L210

### What issues does this PR fix or reference?

This is related to https://github.com/eclipse/che/issues/13557
