### PR TITLE
chore(travis): Fix assemblies build (.tgz)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_deploy:
 - git tag $TRAVIS_TAG
 - sed -i sed "s#version\":\ \"\(.*\)\",#version\":\ \"\1-${SHORT_SHA1}\",#g" package.json
 - yarn pack
-- pkg . -t node10-linux-x64,node10-macos-x64,node10-win-x64 --options max_old_space_size=1024 --out-path ./bin/
+- mkdir ${TRAVIS_BUILD_DIR}/packages
+- pkg . -t node10-linux-x64,node10-macos-x64,node10-win-x64 --options max_old_space_size=1024 --out-path ${TRAVIS_BUILD_DIR}/packages/
 - npx oclif-dev pack
 deploy:
   provider: releases
@@ -24,9 +25,7 @@ deploy:
   file_glob: true
   file:
   - "dist/chectl-v*/chectl-*.gz"
-  - "./bin/chectl-linux"
-  - "./bin/chectl-macos"
-  - "./bin/chectl-win.exe"
+  - "${TRAVIS_BUILD_DIR}/packages/chectl-*"
   skip_cleanup: true
   on:
     repo: che-incubator/chectl

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
     "tslint-fix": "tslint --fix -p test -t stylish",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "rm -rf lib && rm -rf tsconfig.tsbuildinfo && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest",
     "test-watch": "jest --watchAll",
     "version": "oclif-dev readme && git add README.md"


### PR DESCRIPTION
### What does this PR do?
Assemblies were missing the lib folder. It's because with the newer typescript if the outDir is removed we also need to remove tsconfig.tsbuildinfo else the incremental build thinks that everything is up-to-date and then it doesn't generate the files again
Also remove from tgz the chectl-* files that are the pkg executable files

### What issues does this PR fix or reference?
It fixes https://github.com/eclipse/che/issues/13872


Change-Id: Id7a79c37bde9018b3a1f49d50e5d600cdf758a9e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
