### PR TITLE
Adapt chectl to fixes for TLS for helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ OPTIONS
   -p, --platform=platform                      [default: minikube] Type of Kubernetes platform. Valid values are
                                                "minikube", "minishift", "k8s", "openshift", "microk8s".
 
-  -s, --tls                                    Enable TLS encryption and multi-user mode
+  -s, --tls                                    Enable TLS encryption. Note that `che-tls` with TLS certificate must be
+                                               created in the configured namespace.
+
+  --self-signed-cert                           Authorize usage of self signed certificates for encryption.
 
   -t, --templates=templates                    [default: templates] Path to the templates folder
 
@@ -219,8 +222,6 @@ OPTIONS
   --os-oauth                                   Enable use of OpenShift credentials to log into Che
 
   --plugin-registry-url=plugin-registry-url    The URL of the external plugin registry.
-
-  --self-signed-cert                           Authorize usage of self signed certificates for encryption
 ```
 
 _See code: [src/commands/server/start.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/start.ts)_

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -86,7 +86,7 @@ export default class Start extends Command {
     }),
     tls: flags.boolean({
       char: 's',
-      description: 'Enable TLS encryption and multi-user mode',
+      description: 'Enable TLS encryption. Note that `che-tls` with TLS certificate must be created in the configured namespace.',
       default: false
     }),
     'self-signed-cert': flags.boolean({

--- a/src/installers/helm.ts
+++ b/src/installers/helm.ts
@@ -37,7 +37,7 @@ export class HelmHelper {
           const kh = new KubeHelper()
           const exists = await kh.secretExist('che-tls', `${flags.chenamespace}`)
           if (!exists) {
-            throw new Error(`TLS option is enabled but che-tls secret does not exist in '${flags.chenamespace}' namespace. Example on how to create the secret with TLS: kubectl create secret tls che-tls --namespace=che --key=privkey.pem --cert=fullchain.pem`)
+            throw new Error(`TLS option is enabled but che-tls secret does not exist in '${flags.chenamespace}' namespace. Example on how to create the secret with TLS: kubectl create secret tls che-tls --namespace='${flags.chenamespace}' --key=privkey.pem --cert=fullchain.pem`)
           }
           task.title = `${task.title}...che-tls secret found.`
         }


### PR DESCRIPTION
### What does this PR do?
**TODO** revise `--chenamespace=chenamespace` parameter

1. Fixes documentation since `--tls` does not enable multiuser anymore.
2. The only server strategy that works is `multi-host` and it requires wildcards certificates. It's why helm chart does not include cluster issuer and certificates anymore. User must provide `che-tls` secret with certificate content.
It's why checking that cert-manager is set is removed, as well as propagating `tls.email` parameter.

It's tested on GCP with the following configurations:
```
./bin/run server:start -a=helm -p=k8s -b=che.gcps.my-ide.cloud --tls --multiuser
```
```
./bin/run server:start -a=helm -p=k8s -b=che.gcps.my-ide.cloud --tls
```
```
./bin/run server:start -a=helm -p=k8s -b=che.gcps.my-ide.cloud --multiuser
```

### What issues does this PR fix or reference?
It's needed after https://github.com/eclipse/che/pull/13946
