### PR TITLE
WIP Revert "userland-proxy=false is not required anymore"

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ _See code: [src/commands/server/delete.ts](https://github.com/che-incubator/chec
 
 ## `chectl server:start`
 
-start Eclipse Che Server
+start Eclipse Che Server.
+
+Currently `chectl` requires [minikube](https://github.com/kubernetes/minikube#installation) and [minishift](https://github.com/minishift/minishift) launched with _--docker-opt userland-proxy=false_ option.
 
 ```
 USAGE

--- a/src/platforms/minikube.ts
+++ b/src/platforms/minikube.ts
@@ -45,6 +45,22 @@ export class MinikubeHelper {
         },
         task: () => this.startMinikube()
       },
+      { title: 'Verify userland-proxy is disabled',
+        task: async (_ctx: any, task: any) => {
+          const userlandDisabled = await this.isUserLandDisabled()
+          if (!userlandDisabled) {
+            command.error(`E_PLATFORM_NOT_COMPLIANT_USERLAND: userland-proxy=false parameter is required on docker daemon but it was not found.
+            This setting is given when originally starting minikube. (you can then later check by performing command : minikube ssh -- ps auxwwww | grep dockerd
+            It needs to contain --userland-proxy=false
+            Command that needs to be added on top of your start command:
+            $ minikube start <all your existing-options> --docker-opt userland-proxy=false
+            Note: you may have to recreate the minikube installation.
+            `)
+          } else {
+            task.title = `${task.title}...done.`
+          }
+        }
+      },
       // { title: 'Verify minikube memory configuration', skip: () => 'Not implemented yet', task: () => {}},
       // { title: 'Verify kubernetes version', skip: () => 'Not implemented yet', task: () => {}},
       { title: 'Verify if minikube ingress addon is enabled',
@@ -77,7 +93,7 @@ export class MinikubeHelper {
   }
 
   async startMinikube() {
-    await execa('minikube', ['start', '--memory=4096', '--cpus=4', '--disk-size=50g'], { timeout: 180000 })
+    await execa('minikube', ['start', '--memory=4096', '--cpus=4', '--disk-size=50g', '--docker-opt', 'userland-proxy=false'], { timeout: 180000 })
   }
 
   async isIngressAddonEnabled(): Promise<boolean> {
@@ -94,4 +110,12 @@ export class MinikubeHelper {
     return stdout
   }
 
+  /**
+   * Check if userland-proxy=false is set in docker daemon options
+   * if not, return an error
+   */
+  async isUserLandDisabled(): Promise<boolean> {
+    const {stdout} = await execa('minikube', ['ssh', '--', 'ps', 'auxwww', '|', 'grep dockerd'], { timeout: 10000 })
+    return stdout.includes('--userland-proxy=false')
+  }
 }

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -15,7 +15,7 @@ jest.setTimeout(600000)
 /*
 ## Before
 PROFILE=chectl-e2e-tests
-minikube start --memory=8192 -p ${PROFILE}
+minikube start --memory=8192 --docker-opt userland-proxy=false -p ${PROFILE}
 minikube profile ${PROFILE}
 
 yarn test --coverage=false --testRegex=/test/e2e/minikube.test.ts

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -16,7 +16,7 @@ jest.setTimeout(600000)
 ## Before
 PROFILE=chectl-e2e-tests && \
 minishift profile set ${PROFILE} && \
-minishift start --memory=8GB --cpus=4 --disk-size=50g --vm-driver=xhyve  --network-nameserver 8.8.8.8 --profile ${PROFILE}
+minishift start --memory=8GB --cpus=4 --disk-size=50g --vm-driver=xhyve  --network-nameserver 8.8.8.8  --docker-opt userland-proxy=false --profile ${PROFILE}
 
 yarn test --coverage=false --testRegex=/test/e2e/minishift.test.ts
 


### PR DESCRIPTION
### What does this PR do?
This reverts commit b862e0ededde7efa90f4c1d7f599ffbb1fa4aa96.

It follows the following email posted to `che-dev` https://www.eclipse.org/lists/che-dev/msg03375.html

Which minishift/minikube problems this PR fixes:
1. [NodeJS + Mongo Devfile](https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/nodejs-mongo/devfile.yaml#L54) is working again. It can be fixed in an alternative way, and use `localhost` for application->DB communication.
2. If a user defines in their Devfile multiple Deployments and Service for setting up communication - it will work again. Like an example https://github.com/redhat-developer/devfile/blob/master/samples/web-nodejs-with-db-sample/devfile.yaml
3. [Discoverable endpoints](https://github.com/eclipse/che/blob/caae00e21b2fd316560a406f2e1d8ad98edf1dad/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/Constants.java#L67
) work again. User may declare them in dockerimage component. As an example, the [NodeJS+Mongo Devfile](https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/nodejs-mongo/devfile.yaml#L54) referenced above.

:warning: It's has WIP in the title because it was created to get feedback and concerns about requiring `userland-proxy=false` again

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14009
