### PR TITLE
chore(travis): add gh-pages provider to make sure github pages are up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,59 @@
 os: osx
 language: node_js
-node_js:
-- lts/*
+node_js: '10'
 cache: yarn
 before_deploy:
-- brew update
-- brew install p7zip
-- git config --local user.name "Mario Loriedo"
-- git config --local user.email "mario.loriedo@gmail.com"
-- export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')}
-- export CHECTL_VERSION="UNKNOWN"
-- export GITHUB_RELEASE_NAME=$TRAVIS_TAG
 - |
-  if [ "$TRAVIS_BRANCH" = master ]; then
-    echo "Branch is master branch..."
-    CURRENT_DAY=$(date +'%Y%m%d')
-    SHORT_SHA1=$(git rev-parse --short HEAD)
-    export CHECTL_VERSION=0.0.$CURRENT_DAY-next
-    export GITHUB_RELEASE_NAME=0.0.$CURRENT_DAY-next.$SHORT_SHA1
-  fi;
-- |
-  if [ "$TRAVIS_BRANCH" = release ]; then
-    echo "Branch is release branch..."
-    export CHECTL_VERSION=$(cat VERSION)
-    export TRAVIS_TAG=${TRAVIS_TAG:-$CHECTL_VERSION}
-    export GITHUB_RELEASE_NAME=$CHECTL_VERSION
-  fi;
-- sed -i sed "s#version\":\ \"\(.*\)\",#version\":\ \"$CHECTL_VERSION\",#g" package.json
-- git tag $TRAVIS_TAG
-- npx oclif-dev pack
+  if ! [ "$BEFORE_DEPLOY_DONE" ]; then
+    export BEFORE_DEPLOY_DONE=1
+    brew update
+    brew install p7zip
+    git config --local user.name "Mario Loriedo"
+    git config --local user.email "mario.loriedo@gmail.com"
+    export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')}
+    export CHECTL_VERSION="UNKNOWN"
+    export GITHUB_RELEASE_NAME=$TRAVIS_TAG
+    if [ "$TRAVIS_BRANCH" = master ]; then
+      echo "Branch is master branch..."
+      CURRENT_DAY=$(date +'%Y%m%d')
+      SHORT_SHA1=$(git rev-parse --short HEAD)
+      export CHECTL_VERSION=0.0.$CURRENT_DAY-next
+      export GITHUB_RELEASE_NAME=0.0.$CURRENT_DAY-next.$SHORT_SHA1
+    fi;
+    if [ "$TRAVIS_BRANCH" = release ]; then
+      echo "Branch is release branch..."
+      export CHECTL_VERSION=$(cat VERSION)
+      export TRAVIS_TAG=${TRAVIS_TAG:-$CHECTL_VERSION}
+      export GITHUB_RELEASE_NAME=$CHECTL_VERSION
+    fi;
+    sed -i sed "s#version\":\ \"\(.*\)\",#version\":\ \"$CHECTL_VERSION\",#g" package.json
+    git tag $TRAVIS_TAG
+    npx oclif-dev pack
+    mkdir gh-pages
+    echo $(date +%s) > gh-pages/update
+    env
+  fi
 deploy:
-  provider: releases
-  api_key:
-    secure: eTiUIxetw+W54y7TIb3qttWPn0WFjotRamkzuILhzkWJOS21XpHJQNd/xi+fiS0q0bYaVBlnGR/z1xrJNPwjvygG6OMu7eIiDS7oHEXeH9i3WexmYlXesvuxVDVPieKMqfsctCNPP5dZim4aesRQ69kl64NE7ODLpu1DFdPwupjZOFl9VdjP0JdvdAWBrvRE/xe/bfJPfZb0DaLjXN6Cuf4Fh/r27U9avMFFFYMSkNInw2zqSos5yjDIgsTVd2ZEPrp7x0DWfQBmPrY7y7grRevLsZQI+J0e0yDpookb4VyGtI6dj53B3aO+PZ9nu852HWxrYHoYauzvdQOzsHqf/Q48a8yWHoBpcsA3iv4co264iETHBzfZDpuctatfX3xfKub3bD89cgt000vNhb/ynBvEtTsQkyccE5ZRJq9q53zemvdjNuVZeqrNyqWdgUYhOnNzAk69Nsv2dlPoY9kfCV63TC8r3Emq7PsTRF72D9KheLuMhObNRyg7SUD1BDqsESslOYx8KU9ifcWKyTd5GTrMSggNHSH7uctKzd3avSbWpetBkfxkEujOhLTnPnQEnq/yUqIWl3cK0uL6kKukkEz2/ycRvb8b760GnOxC0OJBxKENt/FDGW3+ydSWmhiH9plEhV68EJVGExrj+HMy73NLE3QlsngwPqFCogHBlvc=
-  file_glob: true
-  name: $GITHUB_RELEASE_NAME
-  file:
-  - "./dist/channels/**/chectl-*.gz"
-  skip_cleanup: true
-  on:
-    repo: che-incubator/chectl
-    tags: false
-    all_branches: true
-    condition: $TRAVIS_BRANCH =~ ^(master|release)$
+  - provider: releases
+    api-key:
+      secure: eTiUIxetw+W54y7TIb3qttWPn0WFjotRamkzuILhzkWJOS21XpHJQNd/xi+fiS0q0bYaVBlnGR/z1xrJNPwjvygG6OMu7eIiDS7oHEXeH9i3WexmYlXesvuxVDVPieKMqfsctCNPP5dZim4aesRQ69kl64NE7ODLpu1DFdPwupjZOFl9VdjP0JdvdAWBrvRE/xe/bfJPfZb0DaLjXN6Cuf4Fh/r27U9avMFFFYMSkNInw2zqSos5yjDIgsTVd2ZEPrp7x0DWfQBmPrY7y7grRevLsZQI+J0e0yDpookb4VyGtI6dj53B3aO+PZ9nu852HWxrYHoYauzvdQOzsHqf/Q48a8yWHoBpcsA3iv4co264iETHBzfZDpuctatfX3xfKub3bD89cgt000vNhb/ynBvEtTsQkyccE5ZRJq9q53zemvdjNuVZeqrNyqWdgUYhOnNzAk69Nsv2dlPoY9kfCV63TC8r3Emq7PsTRF72D9KheLuMhObNRyg7SUD1BDqsESslOYx8KU9ifcWKyTd5GTrMSggNHSH7uctKzd3avSbWpetBkfxkEujOhLTnPnQEnq/yUqIWl3cK0uL6kKukkEz2/ycRvb8b760GnOxC0OJBxKENt/FDGW3+ydSWmhiH9plEhV68EJVGExrj+HMy73NLE3QlsngwPqFCogHBlvc=
+    file_glob: true
+    name: $GITHUB_RELEASE_NAME
+    file:
+      - "./dist/channels/**/chectl-*.gz"
+    skip_cleanup: true
+    on:
+      repo: che-incubator/chectl
+      tags: false
+      all_branches: true
+      condition: $TRAVIS_BRANCH =~ ^(master|release)$
+  - provider: pages
+    github-token:
+      secure: eTiUIxetw+W54y7TIb3qttWPn0WFjotRamkzuILhzkWJOS21XpHJQNd/xi+fiS0q0bYaVBlnGR/z1xrJNPwjvygG6OMu7eIiDS7oHEXeH9i3WexmYlXesvuxVDVPieKMqfsctCNPP5dZim4aesRQ69kl64NE7ODLpu1DFdPwupjZOFl9VdjP0JdvdAWBrvRE/xe/bfJPfZb0DaLjXN6Cuf4Fh/r27U9avMFFFYMSkNInw2zqSos5yjDIgsTVd2ZEPrp7x0DWfQBmPrY7y7grRevLsZQI+J0e0yDpookb4VyGtI6dj53B3aO+PZ9nu852HWxrYHoYauzvdQOzsHqf/Q48a8yWHoBpcsA3iv4co264iETHBzfZDpuctatfX3xfKub3bD89cgt000vNhb/ynBvEtTsQkyccE5ZRJq9q53zemvdjNuVZeqrNyqWdgUYhOnNzAk69Nsv2dlPoY9kfCV63TC8r3Emq7PsTRF72D9KheLuMhObNRyg7SUD1BDqsESslOYx8KU9ifcWKyTd5GTrMSggNHSH7uctKzd3avSbWpetBkfxkEujOhLTnPnQEnq/yUqIWl3cK0uL6kKukkEz2/ycRvb8b760GnOxC0OJBxKENt/FDGW3+ydSWmhiH9plEhV68EJVGExrj+HMy73NLE3QlsngwPqFCogHBlvc=
+    skip_cleanup: true
+    keep_history: true
+    local-dir: gh-pages
+    on:
+      repo: che-incubator/chectl
+      all_branches: true
+      condition: $TRAVIS_BRANCH =~ ^(master|release)$


### PR DESCRIPTION
### What does this PR do?
Make gh-pages being refreshed automatically after each release

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14322

Change-Id: Ie017f64d5a13a54bec0e8bdc736605afc2c1a556
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
