### PR TITLE
fix(operator): fix creating cluster role since now it's needed without os-oauth

### DIFF
--- a/src/installers/operator.ts
+++ b/src/installers/operator.ts
@@ -87,7 +87,6 @@ export class OperatorHelper {
       },
       {
         title: `Create ClusterRole ${this.operatorClusterRole}`,
-        enabled: () => flags['os-oauth'],
         task: async (_ctx: any, task: any) => {
           const exist = await kube.clusterRoleExist(this.operatorClusterRole)
           if (exist) {
@@ -117,7 +116,6 @@ export class OperatorHelper {
       },
       {
         title: `Create ClusterRoleBinding ${this.operatorClusterRoleBinding}`,
-        enabled: () => flags['os-oauth'],
         task: async (_ctx: any, task: any) => {
           const exist = await kube.clusterRoleBindingExist(this.operatorRoleBinding)
           if (exist) {


### PR DESCRIPTION
### What does this PR do?
This PR fixes creating cluster role since now it's needed without os-oauth

### What issues does this PR fix or reference?
It's needed to be able to create console links on OpenShift 4.2
https://github.com/eclipse/che-operator/pull/71
