### PR TITLE
fix(templates): parent directories of chectl may not be named chectl

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -125,7 +125,7 @@ export default class Start extends Command {
       return TEMPLATES
     }
     // else use the location from modules
-    return path.join(__dirname, '../../../../chectl/templates')
+    return path.join(__dirname, '../../../templates')
   }
 
   static setPlaformDefaults(flags: any) {


### PR DESCRIPTION
### What does this PR do?

Do not navigate too far in upper directories

### What issues does this PR fix or reference?

Fix https://github.com/eclipse/che/issues/14484

Change-Id: Ic66a482eb2e697452b2f495404ea31ef016e4daa
Signed-off-by: Florent Benoit <fbenoit@redhat.com>




