### PR TITLE
Fix missing crc flag check

### DIFF
--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -52,7 +52,7 @@ export class OperatorTasks {
           } else if (flags.platform === 'minikube' || flags.platform === 'k8s' || flags.platform === 'microk8s') {
             await execa(`kubectl create namespace ${flags.chenamespace}`, { shell: true })
             task.title = `${task.title}...done.`
-          } else if (flags.platform === 'minishift' || flags.platform === 'openshift') {
+          } else if (flags.platform === 'minishift' || flags.platform === 'openshift' || flags.platform === 'crc') {
             await execa(`oc new-project ${flags.chenamespace}`, { shell: true })
             task.title = `${task.title}...done.`
           }


### PR DESCRIPTION
Adds crc platform flag check as an option to
namespace creation.

Fixes https://github.com/eclipse/che/issues/14516