### PR TITLE
fix(minishift-addon): fix pod selector for minishift addon installer

### DIFF
--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -28,24 +28,6 @@ export class CheHelper {
     this.kube = new KubeHelper(flags)
   }
 
-  async cheServerPodExist(namespace: string): Promise<boolean> {
-    const kc = new KubeConfig()
-    kc.loadFromDefault()
-
-    const k8sApi = kc.makeApiClient(Core_v1Api)
-    let found = false
-
-    await k8sApi.listNamespacedPod(namespace, undefined, undefined, undefined, undefined, 'app=che')
-      .then(res => {
-        if (res.body.items.length > 0) {
-          found = true
-        } else {
-          found = false
-        }
-      }).catch(err => { throw err })
-    return found
-  }
-
   /**
    * Finds a pod where Che workspace is running.
    * Rejects if no workspace is found for the given workspace ID

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -28,7 +28,7 @@ export class CheTasks {
   cheNamespace: string
 
   cheAccessToken: string
-  cheSelector: string
+  cheSelector = 'app=che,component=che'
   cheDeploymentName: string
 
   keycloakDeploymentName = 'keycloak'
@@ -47,12 +47,6 @@ export class CheTasks {
     this.kube = new KubeHelper(flags)
     this.kubeTasks = new KubeTasks(flags)
     this.che = new CheHelper(flags)
-
-    if (flags.installer === 'minishift-addon') {
-      this.cheSelector = 'app=che'
-    } else {
-      this.cheSelector = 'app=che,component=che'
-    }
 
     this.cheAccessToken = flags['access-token']
 


### PR DESCRIPTION
### What does this PR do?
Fixes pod selector for minishift addon installer

### What issues does this PR fix or reference?
It became needed after merging https://github.com/minishift/minishift/pull/3333/files#diff-e2fbb6157fa0ac05d672c51b89aa421aR46 since minishift addon provides plugin and devfile registries with the same `app=che` label
