### PR TITLE
fix(docker-desktop): Handle another docker desktop context

### DIFF
--- a/src/tasks/platforms/docker-desktop.ts
+++ b/src/tasks/platforms/docker-desktop.ts
@@ -40,7 +40,7 @@ export class DockerDesktopTasks {
         title: 'Verify if kubectl context is Docker Desktop',
         task: async (_ctx: any, task: any) => {
           const context = await this.kh.currentContext()
-          if (context !== 'docker-for-desktop') {
+          if (context !== 'docker-for-desktop' && context !== 'docker-desktop') {
             command.error(`E_PLATFORM_NOT_READY: current kube context is not Docker Desktop context. Found ${context}`)
           } else {
             task.title = `${task.title}: Found ${context}.`


### PR DESCRIPTION
### What does this PR do?
Docker desktop has changed its kubernetes context

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/14718

Change-Id: I2d069050d692ac9b3398d88cc4e89c5ba5b3b28e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
