### PR TITLE
fix(inject): Rely on che.original_name label when looking for a workspace pod

### DIFF
--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -39,7 +39,7 @@ export class CheHelper {
 
     const res = await k8sApi.listNamespacedPod(namespace)
     const pods = res.body.items
-    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.workspace_id'])
+    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.original_name'] === 'che-workspace-pod')
     if (wsPods.length === 0) {
       throw new Error('No workspace pod is found')
     }
@@ -64,7 +64,7 @@ export class CheHelper {
 
     const res = await k8sApi.listNamespacedPod(namespace)
     const pods = res.body.items
-    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.workspace_id'])
+    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.original_name'] === 'che-workspace-pod')
     if (wsPods.length === 0) {
       throw new Error('No workspace pod is found')
     }

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -39,7 +39,7 @@ export class CheHelper {
 
     const res = await k8sApi.listNamespacedPod(namespace)
     const pods = res.body.items
-    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.original_name'] === 'che-workspace-pod')
+    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.workspace_id'] && pod.metadata!.labels!['che.original_name'] !== 'che-jwtproxy')
     if (wsPods.length === 0) {
       throw new Error('No workspace pod is found')
     }
@@ -64,7 +64,7 @@ export class CheHelper {
 
     const res = await k8sApi.listNamespacedPod(namespace)
     const pods = res.body.items
-    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.original_name'] === 'che-workspace-pod')
+    const wsPods = pods.filter(pod => pod.metadata!.labels!['che.workspace_id'] && pod.metadata!.labels!['che.original_name'] !== 'che-jwtproxy')
     if (wsPods.length === 0) {
       throw new Error('No workspace pod is found')
     }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Fixes looking for a workspace pod while `workspace:inject`.

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/14746
