### PR TITLE
fix: do not fetch service account if it's unneeded

### DIFF
--- a/test/api/kube.test.ts
+++ b/test/api/kube.test.ts
@@ -100,13 +100,23 @@ describe('Kube API helper', () => {
     })
   fancy
     .nock(kubeClusterURL, api => api
+      .get('/healthz')
+      .reply(200, 'ok'))
+    .it('verifies that kuber API is ok via public healthz endpoint', async () => {
+      await kube.checkKubeApi()
+    })
+  fancy
+    .nock(kubeClusterURL, api => api
+      .get('/healthz')
+      .matchHeader('Authorization', val => !val)
+      .reply(401, 'token is missing')
       .get('/api/v1/namespaces/default/serviceaccounts')
       .replyWithFile(200, __dirname + '/replies/get-serviceaccounts.json', { 'Content-Type': 'application/json' })
       .get('/api/v1/namespaces/default/secrets')
       .replyWithFile(200, __dirname + '/replies/get-secrets.json', { 'Content-Type': 'application/json' })
       .get('/healthz')
       .reply(200, 'ok'))
-    .it('verifies that kuber API is ok', async () => {
+    .it('verifies that kuber API is ok via secure healthz endpoint', async () => {
       await kube.checkKubeApi()
     })
   fancy


### PR DESCRIPTION
### What does this PR do?
This PR is made as a result of the following discussion https://github.com/che-incubator/chectl/pull/257#discussion_r322772354

Do not fetch the service account if it's unneeded. See attachments:
before:
![Screenshot_20191004_152445](https://user-images.githubusercontent.com/5887312/66207462-84098500-e6bb-11e9-986c-71fb1e8f8926.png)

After:
`minishift-addon`
![Screenshot_20191004_152359](https://user-images.githubusercontent.com/5887312/66207478-8ec41a00-e6bb-11e9-9e3b-a7c5d2608489.png)
`operator`
![Screenshot_20191004_152412](https://user-images.githubusercontent.com/5887312/66207482-9388ce00-e6bb-11e9-896b-8c08fa0c0ec5.png)

It also improves error message when the current context is not set:
before
![Screenshot_20191004_153539](https://user-images.githubusercontent.com/5887312/66207914-a5b73c00-e6bc-11e9-9136-d79bdacf6f3b.png)
now
![Screenshot_20191004_153524](https://user-images.githubusercontent.com/5887312/66207918-a9e35980-e6bc-11e9-9f95-ad4c821775f0.png)


I did not check it on an installation where `healthz` endpoint requires token since I do not know when to find it or how to set up, like even secure OSIO installation have `healthz` as public https://console.starter-us-east-2.openshift.com/healthz

It's like an unplanned quick fix, and some things can be done not in the best way. So, I'm open to proposals related to refactoring or messages.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/14534

It partially fixes(there are still may be places that should be addressed) https://github.com/eclipse/che/issues/14665

### How to test it?
Here are built chectl(based on the master 25.10.2019) that can be used for testing:
https://dropmefiles.com/lVXSh <- Click more to select only package specific to your OS