### PR TITLE
Added an ability to update deployed Che with operator installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os: osx
 language: node_js
 node_js: '10'
-cache: yarn
 before_deploy:
 - |
   if ! [ "$BEFORE_DEPLOY_DONE" ]; then

--- a/README.md
+++ b/README.md
@@ -274,12 +274,29 @@ USAGE
   $ chectl server:update
 
 OPTIONS
-  -h, --help                       show CLI help
-  -n, --chenamespace=chenamespace  [default: che] Kubernetes namespace where Che resources will be deployed
-  --listr-renderer=listr-renderer  [default: default] Listr renderer. Can be 'default', 'silent' or 'verbose'
+  -a, --installer=helm|operator|minishift-addon        Installer type
+
+  -h, --help                                           show CLI help
+
+  -n, --chenamespace=chenamespace                      [default: che] Kubernetes namespace where Che server is supposed by be deployed
+
+  -p, --platform=minikube|minishift|
+                 k8s|openshift|
+                 microk8s|docker-desktop|  
+                 crc                                    Type of Kubernetes platform. 
+                                                        Valid values are "minikube", "minishift", "k8s (for kubernetes)", 
+                                                        "openshift", "crc (for CodeReady Containers)", "microk8s".
+
+  -t, --templates=templates                             [default: templates] Path to the templates folder
+
+  --deployment-name=deployment-name                     [default: che] Che deployment name
+
+  --listr-renderer=default|silent|verbose               [default: default] Listr renderer
+
+  --skip-version-check                                  Should be specified if user confirmation after version check should be skipped
 ```
 
-_See code: [src/commands/server/update.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/update.ts)_
+_See code: [src/commands/server/update.ts](https://github.com/che-incubator/chectl/blob/master/src/commands/server/update.ts)_
 
 ## `chectl update [CHANNEL]`
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -37,7 +37,7 @@ apply_sed() {
 run() {
   # use master branch
   git checkout master
-  
+
   # reset local changes
   while true; do
     read -r -p "It will reset any local changes to the current branch ?" yn
@@ -47,28 +47,30 @@ run() {
       * ) echo "Please answer yes or no.";;
     esac
   done
-  
+
   git fetch
   if git show-ref -q --heads "release"; then
     git branch -D release
   fi
-  
+
   VERSION=$1
-  
+
   # Create VERSION file
   echo "$VERSION" > VERSION
-  
+
   # replace nightly versions by release version
   apply_sed "s#eclipse/che-server:nightly#eclipse/che-server:${VERSION}#g" src/commands/server/start.ts
   apply_sed "s#quay.io/eclipse/che-operator:nightly#quay.io/eclipse/che-operator:${VERSION}#g" src/commands/server/start.ts
-  
+
+  apply_sed "s#quay.io/eclipse/che-operator:nightly#quay.io/eclipse/che-operator:${VERSION}#g" src/commands/server/update.ts
+
   # now replace package.json dependencies
   apply_sed "s;github.com/eclipse/che#\(.*\)\",;github.com/eclipse/che#${VERSION}\",;g" package.json
   apply_sed "s;github.com/eclipse/che-operator#\(.*\)\",;github.com/eclipse/che-operator#${VERSION}\",;g" package.json
-  
+
   # move into the release branch
   git checkout -b release
-  
+
   # add VERSION file to commit
   git add VERSION src package.json yarn.lock
 }

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -9,36 +9,145 @@
  **********************************************************************/
 
 import { Command, flags } from '@oclif/command'
+import { boolean, string } from '@oclif/parser/lib/flags'
+import { cli } from 'cli-ux'
+import * as fs from 'fs-extra'
+import * as Listr from 'listr'
+import * as notifier from 'node-notifier'
+import * as path from 'path'
 
-import { cheNamespace, listrRenderer } from '../../common-flags'
+import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
+import { CheTasks } from '../../tasks/che'
+import { InstallerTasks } from '../../tasks/installers/installer'
+import { K8sTasks } from '../../tasks/platforms/k8s'
+import { PlatformTasks } from '../../tasks/platforms/platform'
 
 export default class Update extends Command {
   static description = 'update Eclipse Che Server'
 
   static flags = {
-    help: flags.help({ char: 'h' }),
+    installer: string({
+      char: 'a',
+      description: 'Installer type',
+      options: ['helm', 'operator', 'minishift-addon'],
+      default: ''
+    }),
+    platform: string({
+      char: 'p',
+      description: 'Type of Kubernetes platform. Valid values are \"minikube\", \"minishift\", \"k8s (for kubernetes)\", \"openshift\", \"crc (for CodeReady Containers)\", \"microk8s\".',
+      options: ['minikube', 'minishift', 'k8s', 'openshift', 'microk8s', 'docker-desktop', 'crc'],
+    }),
     chenamespace: cheNamespace,
-    'listr-renderer': listrRenderer
+    templates: string({
+      char: 't',
+      description: 'Path to the templates folder',
+      default: Update.getTemplatesDir(),
+      env: 'CHE_TEMPLATES_FOLDER'
+    }),
+    'che-operator-image': string({
+      description: 'Container image of the operator. This parameter is used only when the installer is the operator',
+      default: 'quay.io/eclipse/che-operator:nightly'
+    }),
+    'skip-version-check': boolean({
+      description: 'Skip user confirmation on version check',
+      default: false
+    }),
+    'deployment-name': cheDeployment,
+    'listr-renderer': listrRenderer,
+    help: flags.help({ char: 'h' }),
+  }
+
+  static getTemplatesDir(): string {
+    // return local templates folder if present
+    const TEMPLATES = 'templates'
+    const templatesDir = path.resolve(TEMPLATES)
+    const exists = fs.pathExistsSync(templatesDir)
+    if (exists) {
+      return TEMPLATES
+    }
+    // else use the location from modules
+    return path.join(__dirname, '../../../templates')
+  }
+
+  checkIfInstallerSupportUpdating(flags: any) {
+    // matrix checks
+    if (!flags.installer) {
+      this.error('🛑 --installer parameter must be specified.')
+    }
+
+    if (flags.installer === 'operator') {
+      // operator already supports updating
+      return
+    }
+
+    if (flags.installer === 'minishift-addon' || flags.installer === 'helm') {
+      this.error(`🛑 The specified installer ${flags.installer} does not support updating yet.`)
+    }
+
+    this.error(`🛑 Unknown installer ${flags.installer} is specified.`)
   }
 
   async run() {
     const { flags } = this.parse(Update)
-    const Listr = require('listr')
-    const notifier = require('node-notifier')
-    const tasks = new Listr([
-      { title: 'Verify if we can access Kubernetes API', skip: this.warn('Not implemented yet') },
-      { title: 'Verify if Che is running', skip: this.warn('Not implemented yet') },
-      { title: 'Rolling out Che Server', skip: this.warn('Not implemented yet') },
-      { title: 'Waiting for the new Che Server pod to be created', skip: this.warn('Not implemented yet') },
-      { title: 'Waiting for the new Che Server to start', skip: this.warn('Not implemented yet') },
-      { title: 'Retrieving Che Server URL', skip: this.warn('Not implemented yet') },
-    ], { renderer: flags['listr-renderer'] as any })
+    const listrOptions: Listr.ListrOptions = { rendered: (flags['listr-renderer'] as any), collapse: false } as Listr.ListrOptions
 
-    await tasks.run()
+    const cheTasks = new CheTasks(flags)
+    const platformTasks = new PlatformTasks()
+    const installerTasks = new InstallerTasks()
+    const k8sTasks = new K8sTasks()
+
+    // Platform Checks
+    let platformCheckTasks = new Listr(platformTasks.preflightCheckTasks(flags, this), listrOptions)
+
+    this.checkIfInstallerSupportUpdating(flags)
+
+    // Checks if Che is already deployed
+    let preInstallTasks = new Listr(undefined, listrOptions)
+    preInstallTasks.add(k8sTasks.testApiTasks(flags, this))
+    preInstallTasks.add({
+      title: '👀  Looking for an already existing Che instance',
+      task: () => new Listr(cheTasks.checkIfCheIsInstalledTasks(flags, this))
+    })
+
+    let preUpdateTasks = new Listr(installerTasks.preUpdateTasks(flags, this), listrOptions)
+
+    let updateTasks = new Listr(undefined, listrOptions)
+    updateTasks.add({
+      title: '↺  Updating...',
+      task: () => new Listr(installerTasks.updateTasks(flags, this))
+    })
+
+    try {
+      const ctx: any = {}
+      await preInstallTasks.run(ctx)
+
+      if (!ctx.isCheDeployed) {
+        this.error('Eclipse Che deployment is not found. Use `chectl server:start` to initiate new deployment.')
+      } else {
+        await platformCheckTasks.run(ctx)
+
+        await preUpdateTasks.run(ctx)
+
+        if (!flags['skip-version-check']) {
+          await cli.anykey(`      Found deployed Che with operator [${ctx.deployedCheOperatorImage}]:${ctx.deployedCheOperatorTag}.
+      You are going to update it to [${ctx.newCheOperatorImage}]:${ctx.newCheOperatorTag}.
+      Note that che operator will update components images (che server, plugin registry) only if their values
+      are not overridden in eclipse-che Customer Resource. So, you may need to remove them manually.
+      Press q to quit or any key to continue`)
+        }
+
+        await updateTasks.run(ctx)
+      }
+      this.log('Command server:update has completed successfully.')
+    } catch (err) {
+      this.error(err)
+    }
 
     notifier.notify({
       title: 'chectl',
-      message: 'Command server:update has completed.'
+      message: 'Command server:start has completed successfully.'
     })
+
+    this.exit(0)
   }
 }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -156,7 +156,7 @@ export class CheTasks {
           }
 
           if (!ctx.isCheDeployed) {
-            task.title = await `${task.title}...it is not`
+            task.title = `${task.title}...it is not`
           } else {
             return new Listr([
               {
@@ -198,7 +198,7 @@ export class CheTasks {
             const status = await this.che.getCheServerStatus(cheURL)
             ctx.isAuthEnabled = await this.che.isAuthenticationEnabled(cheURL)
             const auth = ctx.isAuthEnabled ? '(auth enabled)' : '(auth disabled)'
-            task.title = await `${task.title}...${status} ${auth}`
+            task.title = `${task.title}...${status} ${auth}`
           } catch (error) {
             command.error(`E_CHECK_CHE_STATUS_FAIL - Failed to check Che status (URL: ${cheURL}). ${error.message}`)
           }

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -16,6 +16,52 @@ import { MinishiftAddonTasks } from './minishift-addon'
 import { OperatorTasks } from './operator'
 
 export class InstallerTasks {
+  updateTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
+    const operatorTasks = new OperatorTasks()
+
+    let title: string
+    let task: any
+
+    // let task: Listr.ListrTask
+    if (flags.installer === 'operator') {
+      title = '🏃‍  Running the Che Operator Update'
+      task = () => {
+        return operatorTasks.updateTasks(flags, command)
+      }
+    } else {
+      title = '🏃‍  Installer preflight check'
+      task = () => { command.error(`Installer ${flags.installer} does not support update ¯\\_(ツ)_/¯`) }
+    }
+
+    return [{
+      title,
+      task
+    }]
+  }
+
+  preUpdateTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
+    const operatorTasks = new OperatorTasks()
+
+    let title: string
+    let task: any
+
+    // let task: Listr.ListrTask
+    if (flags.installer === 'operator') {
+      title = '🏃‍  Running the Che Operator Update'
+      task = () => {
+        return operatorTasks.preUpdateTasks(flags, command)
+      }
+    } else {
+      title = '🏃‍  Installer preflight check'
+      task = () => { command.error(`Installer ${flags.installer} does not support update ¯\\_(ツ)_/¯`) }
+    }
+
+    return [{
+      title,
+      task
+    }]
+  }
+
   installTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
     const helmTasks = new HelmTasks()
     const operatorTasks = new OperatorTasks()

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -7,10 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
+import { V1Deployment } from '@kubernetes/client-node'
 import { Command } from '@oclif/command'
 import { cli } from 'cli-ux'
 import * as execa from 'execa'
+import { readFileSync } from 'fs'
 import { copy, mkdirp, remove } from 'fs-extra'
+import * as yaml from 'js-yaml'
 import * as Listr from 'listr'
 import * as path from 'path'
 
@@ -23,7 +26,7 @@ export class OperatorTasks {
   operatorClusterRole = 'che-operator'
   operatorRoleBinding = 'che-operator'
   operatorClusterRoleBinding = 'che-operator'
-  operatorCrd = 'checlusters.org.eclipse.che'
+  cheClusterCrd = 'checlusters.org.eclipse.che'
   operatorName = 'che-operator'
   operatorCheCluster = 'eclipse-che'
   resourcesPath = ''
@@ -128,9 +131,9 @@ export class OperatorTasks {
         }
       },
       {
-        title: `Create CRD ${this.operatorCrd}`,
+        title: `Create CRD ${this.cheClusterCrd}`,
         task: async (_ctx: any, task: any) => {
-          const exist = await kube.crdExist(this.operatorCrd)
+          const exist = await kube.crdExist(this.cheClusterCrd)
           if (exist) {
             task.title = `${task.title}...It already exists.`
           } else {
@@ -179,6 +182,168 @@ export class OperatorTasks {
             await kube.createCheClusterFromFile(yamlFilePath, flags, flags['che-operator-cr-yaml'] === '')
             task.title = `${task.title}...done.`
           }
+        }
+      }
+    ], { renderer: flags['listr-renderer'] as any })
+  }
+
+  preUpdateTasks(flags: any, command: Command): Listr {
+    const kube = new KubeHelper(flags)
+    return new Listr([
+      {
+        title: 'Checking versions compatibility before updating',
+        task: async (ctx: any, _task: any) => {
+          const operatorDeployment = await kube.getDeployment('che-operator', flags.chenamespace)
+          if (!operatorDeployment) {
+            command.error(`che-operator deployment is not found in namespace ${flags.chenamespace}.\nProbably Che was initially deployed with another installer`)
+            return
+          }
+          const deployedCheOperator = this.retrieveContainerImage(operatorDeployment)
+          const deployedCheOperatorImageAndTag = deployedCheOperator.split(':', 2)
+          ctx.deployedCheOperatorImage = deployedCheOperatorImageAndTag[0]
+          ctx.deployedCheOperatorTag = deployedCheOperatorImageAndTag.length === 2 ? deployedCheOperatorImageAndTag[1] : 'latest'
+
+          const newCheOperatorImageAndTag = flags['che-operator-image'].split(':', 2)
+          ctx.newCheOperatorImage = newCheOperatorImageAndTag[0]
+          ctx.newCheOperatorTag = newCheOperatorImageAndTag.length === 2 ? newCheOperatorImageAndTag[1] : 'latest'
+        }
+      }])
+  }
+
+  updateTasks(flags: any, command: Command): Listr {
+    const kube = new KubeHelper(flags)
+    return new Listr([
+      {
+        title: 'Copying operator resources',
+        task: async (_ctx: any, task: any) => {
+          this.resourcesPath = await this.copyCheOperatorResources(flags.templates, command.config.cacheDir)
+          task.title = `${task.title}...done.`
+        }
+      },
+      {
+        title: `Updating ServiceAccount ${this.operatorServiceAccount} in namespace ${flags.chenamespace}`,
+        task: async (_ctx: any, task: any) => {
+          const exist = await kube.serviceAccountExist(this.operatorServiceAccount, flags.chenamespace)
+          const yamlFilePath = this.resourcesPath + 'service_account.yaml'
+          if (exist) {
+            await kube.replaceServiceAccountFromFile(yamlFilePath, flags.chenamespace)
+            task.title = `${task.title}...updated.`
+          } else {
+            await kube.createServiceAccountFromFile(yamlFilePath, flags.chenamespace)
+            task.title = `${task.title}...created new one.`
+          }
+        }
+      },
+      {
+        title: `Updating Role ${this.operatorRole} in namespace ${flags.chenamespace}`,
+        task: async (_ctx: any, task: any) => {
+          const exist = await kube.roleExist(this.operatorRole, flags.chenamespace)
+          const yamlFilePath = this.resourcesPath + 'role.yaml'
+          if (exist) {
+            const statusCode = await kube.replaceRoleFromFile(yamlFilePath, flags.chenamespace)
+            if (statusCode === 403) {
+              command.error('ERROR: It looks like you don\'t have enough privileges. You need to grant more privileges to current user or use a different user. If you are using minishift you can "oc login -u system:admin"')
+            }
+            task.title = `${task.title}...updated.`
+          } else {
+            const statusCode = await kube.createRoleFromFile(yamlFilePath, flags.chenamespace)
+            if (statusCode === 403) {
+              command.error('ERROR: It looks like you don\'t have enough privileges. You need to grant more privileges to current user or use a different user. If you are using minishift you can "oc login -u system:admin"')
+            }
+            task.title = `${task.title}...created new one.`
+          }
+        }
+      },
+      {
+        title: `Updating ClusterRole ${this.operatorClusterRole}`,
+        task: async (_ctx: any, task: any) => {
+          const exist = await kube.clusterRoleExist(this.operatorClusterRole)
+          const yamlFilePath = this.resourcesPath + 'cluster_role.yaml'
+          if (exist) {
+            const statusCode = await kube.replaceClusterRoleFromFile(yamlFilePath)
+            if (statusCode === 403) {
+              command.error('ERROR: It looks like you don\'t have enough privileges. You need to grant more privileges to current user or use a different user. If you are using minishift you can "oc login -u system:admin"')
+            }
+            task.title = `${task.title}...updated.`
+          } else {
+            const statusCode = await kube.createClusterRoleFromFile(yamlFilePath)
+            if (statusCode === 403) {
+              command.error('ERROR: It looks like you don\'t have enough privileges. You need to grant more privileges to current user or use a different user. If you are using minishift you can "oc login -u system:admin"')
+            }
+            task.title = `${task.title}...created a new one.`
+          }
+        }
+      },
+      {
+        title: `Updating RoleBinding ${this.operatorRoleBinding} in namespace ${flags.chenamespace}`,
+        task: async (_ctx: any, task: any) => {
+          const exist = await kube.roleBindingExist(this.operatorRoleBinding, flags.chenamespace)
+          const yamlFilePath = this.resourcesPath + 'role_binding.yaml'
+          if (exist) {
+            await kube.replaceRoleBindingFromFile(yamlFilePath, flags.chenamespace)
+            task.title = `${task.title}...updated.`
+          } else {
+            await kube.createRoleBindingFromFile(yamlFilePath, flags.chenamespace)
+            task.title = `${task.title}...created new one.`
+          }
+        }
+      },
+      {
+        title: `Updating ClusterRoleBinding ${this.operatorClusterRoleBinding}`,
+        task: async (_ctx: any, task: any) => {
+          const exist = await kube.clusterRoleBindingExist(this.operatorRoleBinding)
+          if (exist) {
+            await kube.replaceClusterRoleBinding(this.operatorClusterRoleBinding, this.operatorServiceAccount, flags.chenamespace, this.operatorClusterRole)
+            task.title = `${task.title}...updated.`
+          } else {
+            await kube.createClusterRoleBinding(this.operatorClusterRoleBinding, this.operatorServiceAccount, flags.chenamespace, this.operatorClusterRole)
+            task.title = `${task.title}...created new one.`
+          }
+        }
+      },
+      {
+        title: `Updating Che Cluster CRD ${this.cheClusterCrd}`,
+        task: async (_ctx: any, task: any) => {
+          const crd = await kube.getCrd(this.cheClusterCrd)
+          const yamlFilePath = this.resourcesPath + 'crds/org_v1_che_crd.yaml'
+          if (crd) {
+            if (!crd.metadata || !crd.metadata.resourceVersion) {
+              throw new Error(`Fetched CRD ${this.cheClusterCrd} without resource version`)
+            }
+
+            await kube.replaceCrdFromFile(yamlFilePath, crd.metadata.resourceVersion)
+            task.title = `${task.title}...updated.`
+          } else {
+            await kube.createCrdFromFile(yamlFilePath)
+            task.title = `${task.title}...created new one.`
+          }
+        }
+      },
+      {
+        title: 'Waiting 5 seconds for the new Kubernetes resources to get flushed',
+        task: async (_ctx: any, task: any) => {
+          await cli.wait(5000)
+          task.title = `${task.title}...done.`
+        }
+      },
+      {
+        title: `Updating deployment ${this.operatorName} in namespace ${flags.chenamespace}`,
+        task: async (_ctx: any, task: any) => {
+          const exist = await kube.deploymentExist(this.operatorName, flags.chenamespace)
+          if (exist) {
+            await kube.replaceDeploymentFromFile(this.resourcesPath + 'operator.yaml', flags.chenamespace, flags['che-operator-image'])
+            task.title = `${task.title}...updated.`
+          } else {
+            await kube.createDeploymentFromFile(this.resourcesPath + 'operator.yaml', flags.chenamespace, flags['che-operator-image'])
+            task.title = `${task.title}...created new one.`
+          }
+        }
+      },
+      {
+        title: 'Waiting newer operator to be run',
+        task: async (_ctx: any, _task: any) => {
+          await cli.wait(1000)
+          await kube.waitLatestReplica('che-operator', flags.chenamespace)
         }
       }
     ], { renderer: flags['listr-renderer'] as any })
@@ -281,5 +446,37 @@ export class OperatorTasks {
     await mkdirp(destDir)
     await copy(srcDir, destDir)
     return destDir
+  }
+
+  async evaluateTemplateOperatorImage(flags: any): Promise<string> {
+    if (flags['che-operator-image']) {
+      return flags['che-operator-image']
+    } else {
+      const filePath = flags.templates + '/che-operator/operator.yaml'
+      const yamlFile = readFileSync(filePath)
+      const yamlDeployment = yaml.safeLoad(yamlFile.toString()) as V1Deployment
+      return yamlDeployment.spec!.template.spec!.containers[0].image!
+    }
+  }
+
+  retrieveContainerImage(deployment: V1Deployment) {
+    const containers = deployment.spec!.template!.spec!.containers
+
+    const namespace = deployment.metadata!.namespace
+    const name = deployment.metadata!.name
+    if (containers.length === 0) {
+      throw new Error(`Can not evaluate image of ${namespace}/${name} deployment. Containers list are empty`)
+    }
+
+    if (containers.length > 1) {
+      throw new Error(`Can not evaluate image of ${namespace}/${name} deployment. It has multiple containers`)
+    }
+
+    const container = containers[0]
+    if (!container.image) {
+      throw new Error(`Container ${container.name} in deployment ${namespace}/${name} must have image specified`)
+    }
+
+    return container.image
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds an ability to update Che deployed with an operator by executing a command `server:update`.
It's not a final state where we want `server:update` be but it's a good start point where we can start using it.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14793

#### How to test?

##### 7.0.0 to nightly
1. Download chectl released version like [7.0.0](https://github.com/che-incubator/chectl/releases/tag/20190814170217), unpack it, remove `~/.local/share/chectl/client`, and make sure that chectl version returns correct version. And only then install Che with this chectl.
2. Remove `~/.local/share/chectl/client` and use chectl from this branch (.tar.gz for your OS can be found in the following [archive](https://dropmefiles.com/osUs7) for chectl:nightly for my branch) and do `/bin/run server:update --installer=operator --platform=minishift`
3. Modify CR and null all images that are there.
4. Make sure that Che is fully updated. 
<!--
watch -n 0.5 "kubectl get deployment -o go-template='{{range .items}}Deployment: {{.metadata.name}} | Image: {{range .spec.template.spec.containers}}{{.image}}{{end}};{{end}}' | tr ';' '\n'"
-->

The latest try https://youtu.be/7hh4V3V3GFU

##### 6.19.6 to 7.2.0
1. Deploy Che 6.19.6 with operator but without chectl (did not find the corresponding chectl version for it):
  1. Clone https://github.com/sleshchenko/che-operator
  2. Checkout to 6.19.6 (it's based on 7.0.0-rc-4.0 you can check the latest commits to understand what I changed to get 6.19.6 deployed https://github.com/sleshchenko/che-operator/commits/6.19.6)
  3. Current dir should be newly clonned repo
  4. Execute the following commands(if facts it's the same that chectl does to deploy che with CheOperator but without platform checks):
```bash
cd deploy

# addon admin-user must be installed! Or use another user with admin rights
oc login -u admin  
oc new-project che
oc apply -f service_account.yaml
oc apply -f role.yaml
oc apply -f cluster_role.yaml
oc apply -f cluster_role_binding.yaml
oc apply -f role_binding.yaml

oc apply -f ./crds/org_v1_che_crd.yaml

oc apply -f ./operator.yaml
oc apply -f ./crds/org_v1_che_cr.yaml
```
  5. Wait until Che is ready to use.
2. You may be interested in running Che 6, Che 7 Preview workspaces. So DO IT - run them.
3. Download chectl 7.2.0 binaries with this PR changes https://dropmefiles.com/ksOMB.
4. Unpack version for your OS
5. Execute `rm -r ~/.local/share/chectl` to avoid caching issues.
6. Execute `./bin/chectl server:update --platform=minishift --installer=operator`
7. Wait until new operator is ready.
7. Wait until new operator finishes his work and restart everything it needs.
8. Edit CR:
  - set empty values for all images, like che-server, keycloack, plugin-registry.
  - set `useExternalDevfileRegistry: false`
9. Wait until new Che is ready.
10. Test existing running workspaces.
11. Try to run new Che 7 workspaces.

My laptop is not powerful enough or my minishift has not enough memory. So minishift crashed during update, minishift stop/start does not help to make it working again https://youtu.be/IBzCrRpr-3Y

On OpenShift 4.2 on AWS test scenario is done successfully, see screencast https://youtu.be/7Jqfxi8NvyU (sorry for not sound there)

#### What can be improved as separate PRs
##### Versions comparing
Now we print the following message
```
Found deployed Che with operator [eclipse/che-operator]:7.0.0
      You are going to update it to [eclipse/che-operator]:7.2.0
Note that che operator will update components images (che server, plugin registry) only if their values
      are not overridden in eclipse-che Customer Resource. So, you may need to remove them manually.
      Press q to quit or any key to continue
```
And user has to decide by themselves if an update should be performed or not.

- [ ] implement some auto versions comparing, like to not allow 7.2.0 upgrading to 7.0.0 since it supposed by fail because of DB migrations.
- [ ] confirmation needs some additional attention from the user. We could consider adding colored text for confirmation like with https://github.com/klaussinani/signale or https://github.com/chalk/chalk. I did not implement it in this PR since it may postpone feature delivering because of CQs
- [ ] show a information about default images for new version of che-operator

##### Wait until the updating process is done
Currently after updating all additional .yaml resources like SA, Role, RoleBinding we:
  - update **kubectl.kubernetes.io/restartedAt** (it's the same logic as kubectl does for rollout restart)
  - wait 1 second to let k8s lauch new replicaset
  - wait until new deployment does not have any unavailable replica
  - we do not track Che Server, Keycloak pods at all.

- [ ] it would be better to expose particular pod status, like we do on `server:start` (scheduled, pulling, pulled)
- [ ] we should consider tracking that new Che Operator triggers rolling updates for components like (keycloak, che server, plugin registry) and wait until they are finished. Also, when we do `server:update` and there is not CR changes - like we updating nightly version to nightly, then chectl probably needs to trigger Che components deployments to do rollout.

##### Updating to nightly
Che Operator in master branch contains the latest released tag as default one. As a result if you update to nightly - you'll get che-operator nightly but all che components will have the latest released version https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L25.
It should be improved