### PR TITLE
[WIP] che-14963 CodeReady specific version of chectl

### DIFF
--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -108,7 +108,7 @@ export class CheHelper {
   }
 
   async cheOpenShiftURL(namespace = ''): Promise<string> {
-    const route_names = ['che', 'che-host']
+    const route_names = ['codeready', 'che-host']
     for (const route_name of route_names) {
       if (await this.oc.routeExist(route_name, namespace)) {
         const protocol = await this.oc.getRouteProtocol(route_name, namespace)

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -28,20 +28,20 @@ export class CheTasks {
   cheNamespace: string
 
   cheAccessToken: string
-  cheSelector = 'app=che,component=che'
+  cheSelector = 'app=codeready,component=codeready'
   cheDeploymentName: string
 
   keycloakDeploymentName = 'keycloak'
-  keycloakSelector = 'app=che,component=keycloak'
+  keycloakSelector = 'app=codeready,component=keycloak'
 
   postgresDeploymentName = 'postgres'
-  postgresSelector = 'app=che,component=postgres'
+  postgresSelector = 'app=codeready,component=postgres'
 
   devfileRegistryDeploymentName = 'devfile-registry'
-  devfileRegistrySelector = 'app=che,component=devfile-registry'
+  devfileRegistrySelector = 'app=codeready,component=devfile-registry'
 
   pluginRegistryDeploymentName = 'plugin-registry'
-  pluginRegistrySelector = 'app=che,component=plugin-registry'
+  pluginRegistrySelector = 'app=codeready,component=plugin-registry'
 
   constructor(flags: any) {
     this.kube = new KubeHelper(flags)


### PR DESCRIPTION

### What does this PR do?
Creating `codeready` specific version of `chect` for CRW 2.0
PR is meant to be merged in the dedicated `crw` branch. What does this PR do:

- [x] Changing labels from `che` to `codeready`
- [ ] Removing support of helm & minishift addon
- [ ] Updating help for `workspace` and `server` commands

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14963
