### PR TITLE
[WIP] Skip creating the clusterrole/clusterrolebinding if we are not enabling openshif OAuth

### DIFF
--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -91,6 +91,11 @@ export class OperatorTasks {
       },
       {
         title: `Create ClusterRole ${this.operatorClusterRole}`,
+        skip: () => {
+          if (!flags['os-oauth']) {
+            return `No need for ClusterRole ${this.operatorClusterRole}`
+          }
+        },
         task: async (_ctx: any, task: any) => {
           const exist = await kube.clusterRoleExist(this.operatorClusterRole)
           if (exist) {
@@ -120,6 +125,11 @@ export class OperatorTasks {
       },
       {
         title: `Create ClusterRoleBinding ${this.operatorClusterRoleBinding}`,
+        skip: () => {
+          if (!flags['os-oauth']) {
+            return `No need for ClusterRole ${this.operatorClusterRole}`
+          }
+        },
         task: async (_ctx: any, task: any) => {
           const exist = await kube.clusterRoleBindingExist(this.operatorRoleBinding)
           if (exist) {


### PR DESCRIPTION


Signed-off-by: Tom George <tg82490@gmail.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Skip creating the `che-operator` clusterrole if `--os-auth` is not enabled.

### What issues does this PR fix or reference?

Part of https://github.com/eclipse/che/issues/14662 that I changed as part of my testing.