### PR TITLE
fix: Fixup previous PR #394 (missing `await` instruction)

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -778,7 +778,7 @@ export class KubeHelper {
       if (e.response && e.response.body && e.response.body.message && e.response.body.message.toString().endsWith('field is immutable')) {
         try {
           await k8sAppsApi.deleteNamespacedDeployment(yamlDeployment.metadata.name, namespace)
-          return k8sAppsApi.createNamespacedDeployment(namespace, yamlDeployment)
+          return await k8sAppsApi.createNamespacedDeployment(namespace, yamlDeployment)
         } catch (e) {
           throw this.wrapK8sClientError(e)
         }


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

This PR fixes a bug that was introduced in the previous PR #394 
It should use the `await` instruction before returning from the function, in order to return **only after** the deployment has been created. 

### What issues does this PR fix or reference?

