### PR TITLE
CRW-483: The 'server:start' command of the 'oc' client fails on the OCP 3.11' cluster with state 'Running' / 'Pending' expected

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -533,7 +533,7 @@ export class KubeHelper {
       podExist = await this.podsExistBySelector(selector, namespace)
       if (podExist) {
         currentPhase = await this.getPodPhase(selector, namespace)
-        if (currentPhase === 'Pending') {
+        if (currentPhase === 'Pending' || currentPhase === 'Running') {
           return
         } else {
           throw new Error(`ERR_UNEXPECTED_PHASE: ${currentPhase} (Pending expected) `)


### PR DESCRIPTION
### What does this PR do?
CRW-483: The 'server:start' command of the 'oc' client fails on the OCP 3.11' cluster with state 'Running' / 'Pending' expected

### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CRW-483
