### PR TITLE
fix: Increase microk8s.status timeout from 1s to 10s

### DIFF
--- a/src/tasks/platforms/microk8s.ts
+++ b/src/tasks/platforms/microk8s.ts
@@ -97,7 +97,7 @@ export class MicroK8sTasks {
   }
 
   async isMicroK8sRunning(): Promise<boolean> {
-    const { exitCode } = await execa('microk8s.status', { timeout: 1000, reject: false })
+    const { exitCode } = await execa('microk8s.status', { timeout: 10000, reject: false })
     if (exitCode === 0) { return true } else { return false }
   }
 


### PR DESCRIPTION
`microk8s.status` can sometimes take longer than 1 second to execute, causing chectl to erroneously determine that it is not running.

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
This PR increases the timeout on the async call to microk8s.status from 1s to 10s.

### What issues does this PR fix or reference?
I did not create an issue, as the change is very small and simple. This PR does, however, fix an issue I had on my machine with microk8s.status taking more than 1s to run.
