### PR TITLE
feat(helm): Add support for helm v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/dist"
     ],
-    "testRegex": "/test/(api|platforms|installers)/.*.test.ts",
+    "testRegex": "/test/(api|tasks)/.*.test.ts",
     "testEnvironment": "node",
     "moduleFileExtensions": [
       "ts",

--- a/test/tasks/installers/helm.test.ts
+++ b/test/tasks/installers/helm.test.ts
@@ -1,0 +1,28 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+// tslint:disable:object-curly-spacing
+import { expect, fancy } from 'fancy-test'
+import * as execa from 'execa'
+
+import { HelmTasks } from '../../../src/tasks/installers/helm'
+
+jest.mock('execa')
+
+let helmTasks = new HelmTasks()
+describe('Helm helper', () => {
+
+  fancy
+    .it('check get v3 version', async () => {
+      const helmVersionOutput = 'v3.0.0+ge29ce2a';
+      (execa as any).mockResolvedValue({ exitCode: 0, stdout: helmVersionOutput })
+      const version = await helmTasks.getVersion();
+      expect(version).to.equal('v3.0.0+ge29ce2a')
+    })
+})

--- a/test/tasks/installers/minishift-addon.test.ts
+++ b/test/tasks/installers/minishift-addon.test.ts
@@ -9,6 +9,7 @@
  **********************************************************************/
 // tslint:disable:object-curly-spacing
 import { expect, fancy } from 'fancy-test'
+import * as execa from 'execa'
 
 import { MinishiftAddonTasks } from '../../../src/tasks/installers/minishift-addon'
 

--- a/test/tasks/platforms/crc.test.ts
+++ b/test/tasks/platforms/crc.test.ts
@@ -10,7 +10,7 @@
 import * as execa from 'execa'
 import { expect, fancy } from 'fancy-test'
 
-import {CRCHelper} from '../../src/platforms/crc'
+import { CRCHelper } from '../../../src/tasks/platforms/crc'
 
 jest.mock('execa')
 


### PR DESCRIPTION
### What does this PR do?
feat(helm): Add support for helm v3

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15235

I tested with docker-desktop

```
$ chectl server:start --platform=docker-desktop --installer=helm
  ✔ Verify Kubernetes API...OK
  ✔ 👀  Looking for an already existing Che instance
    ✔ Verify if Che is deployed into namespace "che"...it is not
  ✔ ✈️  Docker Desktop preflight checklist
    ✔ Verify if kubectl is installed
    ✔ Verify if kubectl context is Docker Desktop: Found docker-desktop.
    ✔ Verify remote kubernetes status...done.
    ✔ Verify if nginx ingress is installed
    ↓ Installing nginx ingress [skipped]
      → Ngninx ingress is already setup.
    ✔ Verify domain is set... auto-assigning domain to 192.168.1.11.nip.io....set to 192.168.1.11.nip.io.
  ✔ 🏃‍  Running Helm to install Che
    ✔ Verify if helm is installed
    ✔ Check Helm Version: Found v3.0.0+ge29ce2a
    ✔ Create Namespace (che)...done.
    ✔ Check Cluster Role Binding...does not exists.
    ✔ Preparing Che Helm Chart...done.
    ✔ Updating Helm Chart dependencies...done.
    ✔ Deploying Che Helm Chart...done.
  ✔ ✅  Post installation checklist
    ✔ Devfile registry pod bootstrap
      ✔ scheduling...done.
      ✔ downloading images...done.
      ✔ starting...done.
    ✔ Plugin registry pod bootstrap
      ✔ scheduling...done.
      ✔ downloading images...done.
      ✔ starting...done.
    ✔ Che pod bootstrap
      ✔ scheduling...done.
      ✔ downloading images...done.
      ✔ starting...done.
    ✔ Retrieving Che Server URL...http://che-che.192.168.1.11.nip.io
    ✔ Che status check
Command server:start has completed successfully.
```

note: there is another commit that enable back some unit tests