### PR TITLE
fix(stable): Use semver for 'stable' versions

### DIFF
--- a/_layouts/stable-channel.html
+++ b/_layouts/stable-channel.html
@@ -15,7 +15,9 @@ Filter all releases in descending order and matching 'next' channel
   {%- endif -%}
 {%- endfor -%}
 
-{%- assign lastRelease = stableRls[0] -%}
+{%- assign semVerReleases = stableRls | sort: 'name' | reverse -%}
+
+{%- assign lastRelease = semVerReleases[0] -%}
 {%- assign fileNameFilter = page.platform | append: '.tar.gz' -%}
 
 {%- for asset in lastRelease.assets -%}

--- a/_layouts/stable-download-link.html
+++ b/_layouts/stable-download-link.html
@@ -15,7 +15,8 @@ Filter all releases in descending order and matching 'next' channel
   {%- endif -%}
 {%- endfor -%}
 
-{%- assign lastRelease = stableRls[0] -%}
+{%- assign semVerReleases = stableRls | sort: 'name' | reverse -%}
+{%- assign lastRelease = semVerReleases[0] -%}
 {%- assign fileNameFilter = page.platform | append: '.tar.gz' -%}
 
 {%- for asset in lastRelease.assets -%}


### PR DESCRIPTION
### What does this PR do?
Use semVer order on chectl stable links
ordering by date is not good as for example `7.3.2` may be released after `7.4.0`


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15321


Change-Id: I0587de4c2c0c2499399d37230ff0197cdfd449f5
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

