### PR TITLE
fix(helm): Use client version all the time as server response may be unavailable on v2

### DIFF
--- a/src/tasks/installers/helm.ts
+++ b/src/tasks/installers/helm.ts
@@ -243,7 +243,11 @@ export class HelmTasks {
   }
 
   async getVersion(execTimeout = 10000): Promise<string> {
-    const { stdout, exitCode } = await execa('helm', ['version', '--short'], { timeout: execTimeout, reject: false })
+    let { stdout, exitCode } = await execa('helm', ['version', '-c', '--short'], { timeout: execTimeout, reject: false })
+    const CLIENT_PREFIX = 'Client: '
+    if (stdout.startsWith(CLIENT_PREFIX)) {
+      stdout = stdout.substring(CLIENT_PREFIX.length)
+    }
     if (exitCode === 0) { return stdout }
     throw new Error('Unable to get version')
   }

--- a/test/tasks/installers/helm.test.ts
+++ b/test/tasks/installers/helm.test.ts
@@ -25,4 +25,12 @@ describe('Helm helper', () => {
       const version = await helmTasks.getVersion();
       expect(version).to.equal('v3.0.0+ge29ce2a')
     })
+
+    fancy
+    .it('check get v2 version', async () => {
+      const helmVersionOutput = 'Client: v2.13.0-rc.2+gb0d4c9e';
+      (execa as any).mockResolvedValue({ exitCode: 0, stdout: helmVersionOutput })
+      const version = await helmTasks.getVersion();
+      expect(version).to.equal('v2.13.0-rc.2+gb0d4c9e')
+    })    
 })


### PR DESCRIPTION
# What does this PR do?
In V2 there are two versions, client and server and server version can lead to errors

```
Client: v2.13.0-rc.2+gb0d4c9e
Error: Get http://localhost:8080/api/v1/namespaces/kube-system/pods?labelSelector=app%3Dhelm%2Cname%3Dtiller: dial tcp [::1]:8080: connect: connection refused
```
so we stick to client only version
```
$ helm version -c --short
Client: v2.13.0-rc.2+gb0d4c9e

$ helm version -c --short
v3.0.0+ge29ce2a
```

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15340

Change-Id: I0ca8ca68019aac5508079dc88f78aeff5cbdc142
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

