### PR TITLE
feat(inject): Allow to inject a kubeconfig with the specified context

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ OPTIONS
 
   -w, --workspace=workspace                Target workspace. Can be omitted if only one Workspace is running
 
+  --kube-context=kube-context              (required) [default: minikube] Kubeconfig context to inject
+
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 ```
 

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -9,6 +9,7 @@
  **********************************************************************/
 
 import { ApiextensionsV1beta1Api, ApisApi, AppsV1Api, CoreV1Api, CustomObjectsApi, ExtensionsV1beta1Api, KubeConfig, RbacAuthorizationV1Api, V1beta1CustomResourceDefinition, V1beta1IngressList, V1ClusterRole, V1ClusterRoleBinding, V1ConfigMap, V1ConfigMapEnvSource, V1Container, V1DeleteOptions, V1Deployment, V1DeploymentList, V1DeploymentSpec, V1EnvFromSource, V1LabelSelector, V1ObjectMeta, V1PersistentVolumeClaimList, V1Pod, V1PodSpec, V1PodTemplateSpec, V1Role, V1RoleBinding, V1RoleRef, V1Secret, V1ServiceAccount, V1ServiceList, V1Subject } from '@kubernetes/client-node'
+import { Context } from '@kubernetes/client-node/dist/config_types'
 import axios from 'axios'
 import { cli } from 'cli-ux'
 import { readFileSync } from 'fs'
@@ -1021,6 +1022,10 @@ export class KubeHelper {
 
   async currentContext(): Promise<string> {
     return this.kc.getCurrentContext()
+  }
+
+  getContext(name: string): Context | null {
+    return this.kc.getContextObject(name)
   }
 
   /**

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -9,6 +9,7 @@
  **********************************************************************/
 
 import { KubeConfig } from '@kubernetes/client-node'
+import { Context } from '@kubernetes/client-node/dist/config_types'
 import { Command, flags } from '@oclif/command'
 import { string } from '@oclif/parser/lib/flags'
 import * as execa from 'execa'
@@ -36,6 +37,11 @@ export default class Inject extends Command {
       char: 'c',
       description: 'Target container. If not specified, configuration files will be injected in all containers of a Che Workspace pod',
       required: false
+    }),
+    'kube-context': string({
+      description: 'Kubeconfig context to inject',
+      default: 'minikube',
+      required: true
     }),
     chenamespace: cheNamespace,
     'listr-renderer': listrRenderer
@@ -76,7 +82,7 @@ export default class Inject extends Command {
             return 'Currently, only injecting a kubeconfig is supported. Please, specify flag -k'
           }
         },
-        task: () => this.injectKubeconfigTasks(flags, flags.chenamespace!, flags.workspace!, flags.container)
+        task: () => this.injectKubeconfigTasks(flags)
       },
     ], { renderer: flags['listr-renderer'] as any, collapse: false } as Listr.ListrOptions)
 
@@ -92,10 +98,18 @@ export default class Inject extends Command {
     })
   }
 
-  async injectKubeconfigTasks(flags: any, chenamespace: string, workspace: string, container?: string): Promise<Listr> {
+  async injectKubeconfigTasks(flags: any): Promise<Listr> {
+    const kubeContext = flags['kube-context']
+    const kc = new KubeConfig()
+    kc.loadFromDefault()
+    const contextToInject = kc.getContexts().find(c => c.name === kubeContext)
+    if (!contextToInject) {
+      this.error(`Context ${kubeContext} is not found in the source kubeconfig`)
+    }
+
     const che = new CheHelper(flags)
     const tasks = new Listr({ exitOnError: false, concurrent: true })
-    const containers = container ? [container] : await che.getWorkspacePodContainers(chenamespace!, workspace!)
+    const containers = flags.container ? [flags.container] : await che.getWorkspacePodContainers(flags.chenamespace!, flags.workspace!)
     for (const cont of containers) {
       // che-machine-exec container is very limited for a security reason.
       // We cannot copy file into it.
@@ -106,8 +120,8 @@ export default class Inject extends Command {
         title: `injecting kubeconfig into container ${cont}`,
         task: async (ctx: any, task: any) => {
           try {
-            if (await this.canInject(chenamespace, ctx.pod, cont)) {
-              await this.injectKubeconfig(chenamespace!, ctx.pod, cont)
+            if (await this.canInject(flags.chenamespace, ctx.pod, cont)) {
+              await this.injectKubeconfig(flags.chenamespace!, ctx.pod, cont, contextToInject!)
               task.title = `${task.title}...done.`
             } else {
               task.skip('the container doesn\'t support file injection')
@@ -130,10 +144,10 @@ export default class Inject extends Command {
   }
 
   /**
-   * Copies the local kubeconfig (only minikube context) into the specified container.
+   * Copies the local kubeconfig into the specified container.
    * If returns, it means injection was completed successfully. If throws an error, injection failed
    */
-  async injectKubeconfig(cheNamespace: string, workspacePod: string, container: string): Promise<void> {
+  async injectKubeconfig(cheNamespace: string, workspacePod: string, container: string, contextToInject: Context): Promise<void> {
     const { stdout } = await execa(`kubectl exec ${workspacePod} -n ${cheNamespace} -c ${container} env | grep ^HOME=`, { timeout: 10000, shell: true })
     const containerHomeDir = stdout.split('=')[1]
 
@@ -144,19 +158,14 @@ export default class Inject extends Command {
 
     const kc = new KubeConfig()
     kc.loadFromDefault()
-    const contextName = 'minikube'
-    const contextToInject = kc.getContexts().find(c => c.name === contextName)
-    if (!contextToInject) {
-      throw new Error(`Context ${contextName} is not found in the source kubeconfig`)
-    }
     const kubeconfig = path.join(os.tmpdir(), 'che-kubeconfig')
     const cluster = kc.getCluster(contextToInject.cluster)
     if (!cluster) {
-      throw new Error(`Context ${contextName} has no cluster object`)
+      throw new Error(`Context ${contextToInject.name} has no cluster object`)
     }
     const user = kc.getUser(contextToInject.user)
     if (!user) {
-      throw new Error(`Context ${contextName} has no user object`)
+      throw new Error(`Context ${contextToInject.name} has no user object`)
     }
     await execa('kubectl', ['config', '--kubeconfig', kubeconfig, 'set-cluster', cluster.name, `--server=${cluster.server}`, `--certificate-authority=${cluster.caFile}`, '--embed-certs=true'], { timeout: 10000 })
     await execa('kubectl', ['config', '--kubeconfig', kubeconfig, 'set-credentials', user.name, `--client-certificate=${user.certFile}`, `--client-key=${user.keyFile}`, '--embed-certs=true'], { timeout: 10000 })


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Adds the parameter `--context` to the `workspace:inject` command. It's used to specify the context to be injected. If no `--context` parameter is provided, the current context will be injected.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14877 (partly)
