### PR TITLE
Fix renderers.

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -182,7 +182,7 @@ export default class Start extends Command {
 
   async run() {
     const { flags } = this.parse(Start)
-    const listrOptions: Listr.ListrOptions = { rendered: (flags['listr-renderer'] as any), collapse: false, showSubtasks: true } as Listr.ListrOptions
+    const listrOptions: Listr.ListrOptions = { renderer: (flags['listr-renderer'] as any), collapse: false, showSubtasks: true } as Listr.ListrOptions
 
     const cheTasks = new CheTasks(flags)
     const platformTasks = new PlatformTasks()

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -90,7 +90,7 @@ export default class Update extends Command {
 
   async run() {
     const { flags } = this.parse(Update)
-    const listrOptions: Listr.ListrOptions = { rendered: (flags['listr-renderer'] as any), collapse: false } as Listr.ListrOptions
+    const listrOptions: Listr.ListrOptions = { renderer: (flags['listr-renderer'] as any), collapse: false } as Listr.ListrOptions
 
     const cheTasks = new CheTasks(flags)
     const platformTasks = new PlatformTasks()


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Fixes renderer selection. Probably a typo from the time of creation of this repo.

So far only way to use/don't use the default renderer was to use/don't use interactive shell (tty).

### What issues does this PR fix or reference?
Issue wasn't created for this AFAIK.

### Demo:

```
$ bin/run server:start --listr-renderer=verbose
[20:10:03] Verify Kubernetes API [started]
[20:10:03] Verify Kubernetes API...OK [title changed]
[20:10:03] Verify Kubernetes API...OK (it's OpenShift) [title changed]
[20:10:03] Verify Kubernetes API...OK (it's OpenShift) [completed]
[20:10:03] 👀  Looking for an already existing Che instance [started]
[20:10:03] Verify if Che is deployed into namespace "che" [started]
[20:10:03] Verify if Che is deployed into namespace "che"...it is not [title changed]
[20:10:03] Verify if Che is deployed into namespace "che"...it is not [completed]
[20:10:03] 👀  Looking for an already existing Che instance [completed]
[20:10:03] ✈️  Platform preflight checklist [started]
[20:10:03] ✈️  Platform preflight checklist [failed]
[20:10:03] → Platform is required ¯\_(ツ)_/¯
 ›   Error: Platform is required ¯\_(ツ)_/¯
```
```
$ bin/run server:start --listr-renderer=default
  ✔ Verify Kubernetes API...OK (it's OpenShift)
  ✔ 👀  Looking for an already existing Che instance
    ✔ Verify if Che is deployed into namespace "che"...it is not
  ✖ ✈️  Platform preflight checklist
    → Platform is required ¯\_(ツ)_/¯
 ›   Error: Platform is required ¯\_(ツ)_/¯
```
```
$ bin/run server:start --listr-renderer=silent
 ›   Error: Platform is required ¯\_(ツ)_/¯
```