### PR TITLE
feat: Collect logs during installation of Eclipse Che

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to remote",
+            "port": 9229,
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -205,9 +205,7 @@ OPTIONS
       [default: che] Che deployment name
 
   -d, --directory=directory
-      [default: ./Logs] Directory to store server logs
-
-  --access-token=access-token              Che OIDC Access Token
+      [default: ./Logs] Directory to store Eclipse Che logs
 ```
 
 ## `chectl server:start`
@@ -252,6 +250,9 @@ OPTIONS
 
   -t, --templates=templates
       [default: templates] Path to the templates folder
+
+  -d, --directory=directory
+      [default: ./Logs] Directory to store Eclipse Che logs
 
   --che-operator-cr-yaml=che-operator-cr-yaml
       Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer
@@ -478,9 +479,7 @@ OPTIONS
   -w, --workspace=workspace                Target workspace. Can be omitted if only one Workspace is running
 
   -d, --directory=directory
-      [default: ./logs] Directory to store server logs
-
-  --access-token=access-token              Che OIDC Access Token
+      [default: ./logs] Directory to store workspace logs
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -486,25 +486,6 @@ OPTIONS
 _See code: [src/commands/workspace/stop.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/workspace/stop.ts)_
 <!-- commandsstop -->
 
-## `chectl workspace:logs`
-
-Retrieve Workspace Logs
-
-```
-USAGE
-  $ chectl workspace:logs
-
-OPTIONS
-  -h, --help  show CLI help
-
-  -n, --chenamespace=chenamespace
-      [default: che] Kubernetes namespace where Che server is supposed to be deployed
-
-  -w, --workspace=workspace                Target workspace. Can be omitted if only one Workspace is running
-
-  -d, --directory=directory
-      [default: ./logs] Directory to store workspace logs
-```
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Assemblies of chectl are available at [https://github.com/che-incubator/chectl/r
 
 Manual install:
 
-1) Download a .tgz file based on your Operating System / Arch 
+1) Download a .tgz file based on your Operating System / Arch
 2) Unpack the assembly
 3) move `chectl` folder into a folder like `$HOME/chectl`
 4) add `$HOME/chectl/bin` to `$PATH``
@@ -85,6 +85,7 @@ USAGE
 * [`chectl devfile:generate`](#chectl-devfilegenerate)
 * [`chectl help [COMMAND]`](#chectl-help-command)
 * [`chectl server:delete`](#chectl-serverdelete)
+* [`chectl server:logs`](#chectl-serverlogs)
 * [`chectl server:start`](#chectl-serverstart)
 * [`chectl server:stop`](#chectl-serverstop)
 * [`chectl server:update`](#chectl-serverupdate)
@@ -93,6 +94,7 @@ USAGE
 * [`chectl workspace:list`](#chectl-workspacelist)
 * [`chectl workspace:start`](#chectl-workspacestart)
 * [`chectl workspace:stop`](#chectl-workspacestop)
+* [`chectl workspace:logs`](#chectl-workspacelogs)
 
 ## `chectl autocomplete [SHELL]`
 
@@ -185,6 +187,29 @@ OPTIONS
 
 _See code: [src/commands/server/delete.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/delete.ts)_
 
+## `chectl server:logs`
+
+Retrieve Eclipse Che Logs
+
+```
+USAGE
+  $ chectl server:logs
+
+OPTIONS
+  -h, --help  show CLI help
+
+  -n, --chenamespace=chenamespace
+      [default: che] Kubernetes namespace where Che server is supposed to be deployed
+
+  --deployment-name=deployment-name
+      [default: che] Che deployment name
+
+  -d, --directory=directory
+      [default: ./Logs] Directory to store server logs
+
+  --access-token=access-token              Che OIDC Access Token
+```
+
 ## `chectl server:start`
 
 start Eclipse Che Server
@@ -216,12 +241,12 @@ OPTIONS
       (required) [default: 40000] Che server bootstrap timeout (in milliseconds)
 
   -p, --platform=minikube|minishift|k8s|openshift|microk8s|docker-desktop|crc
-      Type of Kubernetes platform. Valid values are "minikube", "minishift", "k8s (for kubernetes)", "openshift", "crc 
+      Type of Kubernetes platform. Valid values are "minikube", "minishift", "k8s (for kubernetes)", "openshift", "crc
       (for CodeReady Containers)", "microk8s".
 
   -s, --tls
       Enable TLS encryption.
-                           Note that for kubernetes 'che-tls' with TLS certificate must be created in the configured 
+                           Note that for kubernetes 'che-tls' with TLS certificate must be created in the configured
       namespace.
                            For OpenShift, router will use default cluster certificates.
 
@@ -229,11 +254,11 @@ OPTIONS
       [default: templates] Path to the templates folder
 
   --che-operator-cr-yaml=che-operator-cr-yaml
-      Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer 
+      Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer
       is the operator.
 
   --che-operator-image=che-operator-image
-      [default: quay.io/eclipse/che-operator:nightly] Container image of the operator. This parameter is used only when 
+      [default: quay.io/eclipse/che-operator:nightly] Container image of the operator. This parameter is used only when
       the installer is the operator
 
   --deployment-name=deployment-name
@@ -258,7 +283,7 @@ OPTIONS
       The URL of the external plugin registry.
 
   --self-signed-cert
-      Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate 
+      Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate
       must be created in the configured namespace.
 ```
 
@@ -435,6 +460,28 @@ OPTIONS
 
 _See code: [src/commands/workspace/stop.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/workspace/stop.ts)_
 <!-- commandsstop -->
+
+## `chectl workspace:logs`
+
+Retrieve Workspace Logs
+
+```
+USAGE
+  $ chectl workspace:logs
+
+OPTIONS
+  -h, --help  show CLI help
+
+  -n, --chenamespace=chenamespace
+      [default: che] Kubernetes namespace where Che server is supposed to be deployed
+
+  -w, --workspace=workspace                Target workspace. Can be omitted if only one Workspace is running
+
+  -d, --directory=directory
+      [default: ./logs] Directory to store server logs
+
+  --access-token=access-token              Che OIDC Access Token
+```
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ USAGE
 * [`chectl update [CHANNEL]`](#chectl-update-channel)
 * [`chectl workspace:inject`](#chectl-workspaceinject)
 * [`chectl workspace:list`](#chectl-workspacelist)
+* [`chectl workspace:logs`](#chectl-workspacelogs)
 * [`chectl workspace:start`](#chectl-workspacestart)
 * [`chectl workspace:stop`](#chectl-workspacestop)
-* [`chectl workspace:logs`](#chectl-workspacelogs)
 
 ## `chectl autocomplete [SHELL]`
 
@@ -189,24 +189,25 @@ _See code: [src/commands/server/delete.ts](https://github.com/che-incubator/chec
 
 ## `chectl server:logs`
 
-Retrieve Eclipse Che Logs
+Retrieve Eclipse Che logs
 
 ```
 USAGE
   $ chectl server:logs
 
 OPTIONS
-  -h, --help  show CLI help
+  -d, --directory=directory                [default: ./logs] Directory to store logs into
+  -h, --help                               show CLI help
 
-  -n, --chenamespace=chenamespace
-      [default: che] Kubernetes namespace where Che server is supposed to be deployed
+  -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Che server is supposed to be
+                                           deployed
 
-  --deployment-name=deployment-name
-      [default: che] Che deployment name
+  --deployment-name=deployment-name        [default: che] Che deployment name
 
-  -d, --directory=directory
-      [default: ./logs] Directory to store Eclipse Che logs
+  --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 ```
+
+_See code: [src/commands/server/logs.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/logs.ts)_
 
 ## `chectl server:start`
 
@@ -222,6 +223,9 @@ OPTIONS
 
   -b, --domain=domain
       Domain of the Kubernetes cluster (e.g. example.k8s-cluster.com or <local-ip>.nip.io)
+
+  -d, --directory=directory
+      [default: ./logs] Directory to store logs into
 
   -h, --help
       show CLI help
@@ -239,27 +243,24 @@ OPTIONS
       (required) [default: 40000] Che server bootstrap timeout (in milliseconds)
 
   -p, --platform=minikube|minishift|k8s|openshift|microk8s|docker-desktop|crc
-      Type of Kubernetes platform. Valid values are "minikube", "minishift", "k8s (for kubernetes)", "openshift", "crc
+      Type of Kubernetes platform. Valid values are "minikube", "minishift", "k8s (for kubernetes)", "openshift", "crc 
       (for CodeReady Containers)", "microk8s".
 
   -s, --tls
       Enable TLS encryption.
-                           Note that for kubernetes 'che-tls' with TLS certificate must be created in the configured
+                           Note that for kubernetes 'che-tls' with TLS certificate must be created in the configured 
       namespace.
                            For OpenShift, router will use default cluster certificates.
 
   -t, --templates=templates
       [default: templates] Path to the templates folder
 
-  -d, --directory=directory
-      [default: ./logs] Directory to store Eclipse Che logs
-
   --che-operator-cr-yaml=che-operator-cr-yaml
-      Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer
+      Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer 
       is the operator.
 
   --che-operator-image=che-operator-image
-      [default: quay.io/eclipse/che-operator:nightly] Container image of the operator. This parameter is used only when
+      [default: quay.io/eclipse/che-operator:nightly] Container image of the operator. This parameter is used only when 
       the installer is the operator
 
   --deployment-name=deployment-name
@@ -284,7 +285,7 @@ OPTIONS
       The URL of the external plugin registry.
 
   --self-signed-cert
-      Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate
+      Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate 
       must be created in the configured namespace.
 ```
 
@@ -385,7 +386,7 @@ OPTIONS
 
   -w, --workspace=workspace                Target workspace. Can be omitted if only one Workspace is running
 
-  --kube-context=kube-context              (required) [default: minikube] Kubeconfig context to inject
+  --kube-context=kube-context              Kubeconfig context to inject
 
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 ```
@@ -413,6 +414,28 @@ OPTIONS
 
 _See code: [src/commands/workspace/list.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/workspace/list.ts)_
 
+## `chectl workspace:logs`
+
+Retrieve workspace logs
+
+```
+USAGE
+  $ chectl workspace:logs
+
+OPTIONS
+  -d, --directory=directory                [default: ./logs] Directory to store logs into
+  -h, --help                               show CLI help
+
+  -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Che server is supposed to be
+                                           deployed
+
+  -w, --workspace=workspace                Target workspace. Can be omitted if only one Workspace is running
+
+  --listr-renderer=default|silent|verbose  [default: default] Listr renderer
+```
+
+_See code: [src/commands/workspace/logs.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/workspace/logs.ts)_
+
 ## `chectl workspace:start`
 
 create and start a Che workspace
@@ -422,6 +445,7 @@ USAGE
   $ chectl workspace:start
 
 OPTIONS
+  -d, --directory=directory                [default: ./logs] Directory to store logs into
   -f, --devfile=devfile                    path or URL to a valid devfile
   -h, --help                               show CLI help
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ OPTIONS
       [default: che] Che deployment name
 
   -d, --directory=directory
-      [default: ./Logs] Directory to store Eclipse Che logs
+      [default: ./logs] Directory to store Eclipse Che logs
 ```
 
 ## `chectl server:start`
@@ -252,7 +252,7 @@ OPTIONS
       [default: templates] Path to the templates folder
 
   -d, --directory=directory
-      [default: ./Logs] Directory to store Eclipse Che logs
+      [default: ./logs] Directory to store Eclipse Che logs
 
   --che-operator-cr-yaml=che-operator-cr-yaml
       Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer

--- a/bin/debug
+++ b/bin/debug
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+export NODE_OPTIONS='--inspect-brk'
+./run "$@"

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -388,15 +388,4 @@ export class CheHelper {
       return new Error(`E_CHECTL_UNKNOWN_ERROR - Endpoint: ${endpoint} - Message: ${error.message}`)
     }
   }
-
-  private getK8sError(error: any): Error {
-    if (error.response && error.response.statusCode === 403) {
-      return new Error(`Message: ${error.response.body.message}`)
-    }
-    if (error.response && error.response.statusCode === 401) {
-      return new Error(`Message: ${error.response.body.message}`)
-    }
-
-    return new Error(`Unknown error. Message: ${error.response.body.message}`)
-  }
 }

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CoreV1Api, KubeConfig, V1Pod } from '@kubernetes/client-node'
+import { CoreV1Api, KubeConfig } from '@kubernetes/client-node'
 import axios from 'axios'
 import { cli } from 'cli-ux'
 import * as fs from 'fs-extra'
@@ -34,7 +34,7 @@ export class CheHelper {
    * Rejects if no workspace is found for the given workspace ID
    * or if workspace ID wasn't specified but more than one workspace is found.
    */
-  async getWorkspacePod(namespace: string, cheWorkspaceId?: string): Promise<V1Pod> {
+  async getWorkspacePod(namespace: string, cheWorkspaceId?: string): Promise<string> {
     this.kc.loadFromDefault()
     const k8sApi = this.kc.makeApiClient(CoreV1Api)
 
@@ -48,12 +48,12 @@ export class CheHelper {
     if (cheWorkspaceId) {
       const wsPod = wsPods.find(p => p.metadata!.labels!['che.workspace_id'] === cheWorkspaceId)
       if (wsPod) {
-        return wsPod
+        return wsPod.metadata!.name!
       }
       throw new Error('Pod is not found for the given workspace ID')
     } else {
       if (wsPods.length === 1) {
-        return wsPods[0]
+        return wsPods[0].metadata!.name!
       }
       throw new Error('More than one pod with running workspace is found. Please, specify Che Workspace ID.')
     }

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -382,7 +382,7 @@ export class CheHelper {
    * Reads log from a specific container of the pod and stores into a file.
    */
   private async readContainerLog(namespace: string, podName: string, containerName: string, directory: string, follow: boolean): Promise<void> {
-    const fileName = path.resolve(directory, podName, `${containerName}.log`)
+    const fileName = path.resolve(directory, namespace, podName, `${containerName}.log`)
     fs.ensureFileSync(fileName)
     return this.kube.readNamespacedPodLog(podName, namespace, containerName, fileName, follow)
   }

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -13,12 +13,11 @@ import { Context } from '@kubernetes/client-node/dist/config_types'
 import axios from 'axios'
 import { cli } from 'cli-ux'
 import * as fs from 'fs'
+import https = require('https')
 import * as yaml from 'js-yaml'
 import { Writable } from 'stream'
 
 import { DEFAULT_CHE_IMAGE } from '../constants'
-
-import https = require('https')
 
 export class KubeHelper {
   kc = new KubeConfig()
@@ -711,11 +710,11 @@ export class KubeHelper {
   }
 
   async createDeployment(name: string,
-    image: string,
-    serviceAccount: string,
-    pullPolicy: string,
-    configMapEnvSource: string,
-    namespace: string) {
+                         image: string,
+                         serviceAccount: string,
+                         pullPolicy: string,
+                         configMapEnvSource: string,
+                         namespace: string) {
     const k8sAppsApi = this.kc.makeApiClient(AppsV1Api)
     let deployment = new V1Deployment()
     deployment.metadata = new V1ObjectMeta()
@@ -832,12 +831,12 @@ export class KubeHelper {
   }
 
   async createPod(name: string,
-    image: string,
-    serviceAccount: string,
-    restartPolicy: string,
-    pullPolicy: string,
-    configMapEnvSource: string,
-    namespace: string) {
+                  image: string,
+                  serviceAccount: string,
+                  restartPolicy: string,
+                  pullPolicy: string,
+                  configMapEnvSource: string,
+                  namespace: string) {
     const k8sCoreApi = this.kc.makeApiClient(CoreV1Api)
     let pod = new V1Pod()
     pod.metadata = new V1ObjectMeta()

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1271,6 +1271,9 @@ export class KubeHelper {
     }
   }
 
+  /**
+   * Reads log by chunk and writes into a file.
+   */
   async readNamespacedPodLog(pod: string, namespace: string, container: string, filename: string, follow: boolean): Promise<void> {
     return new Promise((resolve, reject) => {
       const stream = new Writable()

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -19,7 +19,6 @@ import { Writable } from 'stream'
 import { DEFAULT_CHE_IMAGE } from '../constants'
 
 import https = require('https')
-import { rejects } from 'assert'
 
 export class KubeHelper {
   kc = new KubeConfig()

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { ApiextensionsV1beta1Api, ApisApi, AppsV1Api, CoreV1Api, CustomObjectsApi, ExtensionsV1beta1Api, KubeConfig, RbacAuthorizationV1Api, V1beta1CustomResourceDefinition, V1beta1IngressList, V1ClusterRole, V1ClusterRoleBinding, V1ConfigMap, V1ConfigMapEnvSource, V1Container, V1DeleteOptions, V1Deployment, V1DeploymentList, V1DeploymentSpec, V1EnvFromSource, V1LabelSelector, V1ObjectMeta, V1PersistentVolumeClaimList, V1Pod, V1PodSpec, V1PodTemplateSpec, V1Role, V1RoleBinding, V1RoleRef, V1Secret, V1ServiceAccount, V1ServiceList, V1Subject } from '@kubernetes/client-node'
+import { ApiextensionsV1beta1Api, ApisApi, AppsV1Api, CoreV1Api, CustomObjectsApi, ExtensionsV1beta1Api, KubeConfig, RbacAuthorizationV1Api, V1beta1CustomResourceDefinition, V1beta1IngressList, V1ClusterRole, V1ClusterRoleBinding, V1ConfigMap, V1ConfigMapEnvSource, V1Container, V1DeleteOptions, V1Deployment, V1DeploymentList, V1DeploymentSpec, V1EnvFromSource, V1LabelSelector, V1ObjectMeta, V1PersistentVolumeClaimList, V1Pod, V1PodSpec, V1PodTemplateSpec, V1Role, V1RoleBinding, V1RoleRef, V1Secret, V1ServiceAccount, V1ServiceList, V1Subject, V1PodList } from '@kubernetes/client-node'
 import { Context } from '@kubernetes/client-node/dist/config_types'
 import axios from 'axios'
 import { cli } from 'cli-ux'
@@ -586,7 +586,7 @@ export class KubeHelper {
     }
   }
 
-   // make sure that flag is specified for command that it's invoked
+  // make sure that flag is specified for command that it's invoked
   async waitLatestReplica(deploymentName: string, namespace = '', intervalMs = 500, timeoutMs = this.podWaitTimeout) {
     const iterations = timeoutMs / intervalMs
     for (let index = 0; index < iterations; index++) {
@@ -1249,6 +1249,30 @@ export class KubeHelper {
       throw this.wrapK8sClientError(e)
     }
     throw new Error('ERR_LIST_PVCS')
+  }
+
+  async getPodBySelector(namespace: string, selector: string): Promise<V1PodList | undefined> {
+    const k8sApi = this.kc.makeApiClient(CoreV1Api)
+    try {
+      const res = await k8sApi.listNamespacedPod(namespace, true, undefined, undefined, undefined, selector)
+      if (res && res.body) {
+        return res.body
+      }
+    } catch (e) {
+      throw this.wrapK8sClientError(e)
+    }
+  }
+
+  async readNamespacedPodLog(pod: string, namespace: string, container: string): Promise<string | undefined> {
+    const k8sApi = this.kc.makeApiClient(CoreV1Api)
+    try {
+      const res = await k8sApi.readNamespacedPodLog(pod, namespace, container, false, undefined, 'true')
+      if (res && res.body) {
+        return res.body
+      }
+    } catch (e) {
+      throw this.wrapK8sClientError(e)
+    }
   }
 
   /**

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1257,12 +1257,16 @@ export class KubeHelper {
     throw new Error('ERR_LIST_PVCS')
   }
 
-  async getPodBySelector(namespace: string, selector: string): Promise<V1PodList | undefined> {
+  async listNamespacedPod(namespace: string, selector?: string): Promise<V1PodList> {
     const k8sApi = this.kc.makeApiClient(CoreV1Api)
     try {
       const res = await k8sApi.listNamespacedPod(namespace, true, undefined, undefined, undefined, selector)
       if (res && res.body) {
         return res.body
+      } else {
+        return {
+          items: []
+        }
       }
     } catch (e) {
       throw this.wrapK8sClientError(e)

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -426,10 +426,10 @@ export class KubeHelper {
     }
   }
 
-  async readNamespacedPod(name: string, namespace: string): Promise<V1Pod | undefined> {
+  async readNamespacedPod(podName: string, namespace: string): Promise<V1Pod | undefined> {
     const k8sCoreApi = this.kc.makeApiClient(CoreV1Api)
     try {
-      const res = await k8sCoreApi.readNamespacedPod(name, namespace)
+      const res = await k8sCoreApi.readNamespacedPod(podName, namespace)
       if (res && res.body) {
         return res.body
       }

--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { Command, flags } from '@oclif/command'
+import { string } from '@oclif/parser/lib/flags'
+import * as Listr from 'listr'
+import * as notifier from 'node-notifier'
+import * as path from 'path'
+
+import { accessToken, cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
+import { CheTasks } from '../../tasks/che'
+
+export default class Logs extends Command {
+  static description = 'Retrieve Eclipse Che logs'
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    chenamespace: cheNamespace,
+    'access-token': accessToken,
+    'listr-renderer': listrRenderer,
+    'deployment-name': cheDeployment,
+    directory: string({
+      char: 'd',
+      description: 'Directory to store logs into',
+      default: './logs'
+    })
+  }
+
+  async run() {
+    const { flags } = this.parse(Logs)
+    const cheTasks = new CheTasks(flags)
+    const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
+    flags.directory = path.resolve(flags.directory, flags.chenamespace)
+
+    tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
+    tasks.add(cheTasks.serverLogsTasks(flags, this))
+
+    await tasks.run()
+
+    notifier.notify({
+      title: 'chectl',
+      message: 'Command server:logs has completed successfully.'
+    })
+  }
+}

--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -16,6 +16,7 @@ import * as path from 'path'
 
 import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
+import { K8sTasks } from '../../tasks/platforms/k8s'
 
 export default class Logs extends Command {
   static description = 'Retrieve Eclipse Che logs'
@@ -35,9 +36,11 @@ export default class Logs extends Command {
   async run() {
     const { flags } = this.parse(Logs)
     const cheTasks = new CheTasks(flags)
+    const k8sTasks = new K8sTasks()
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
     flags.directory = path.resolve(flags.directory, flags.chenamespace)
 
+    tasks.add(k8sTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
     tasks.add(cheTasks.serverLogsTasks(flags, false))
 

--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -14,7 +14,7 @@ import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
 import * as path from 'path'
 
-import { accessToken, cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
+import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
 
 export default class Logs extends Command {
@@ -23,7 +23,6 @@ export default class Logs extends Command {
   static flags = {
     help: flags.help({ char: 'h' }),
     chenamespace: cheNamespace,
-    'access-token': accessToken,
     'listr-renderer': listrRenderer,
     'deployment-name': cheDeployment,
     directory: string({
@@ -40,7 +39,7 @@ export default class Logs extends Command {
     flags.directory = path.resolve(flags.directory, flags.chenamespace)
 
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
-    tasks.add(cheTasks.serverLogsTasks(flags, this))
+    tasks.add(cheTasks.serverLogsTasks(flags, false))
 
     await tasks.run()
 
@@ -48,5 +47,7 @@ export default class Logs extends Command {
       title: 'chectl',
       message: 'Command server:logs has completed successfully.'
     })
+
+    this.exit(0)
   }
 }

--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -38,13 +38,19 @@ export default class Logs extends Command {
     const cheTasks = new CheTasks(flags)
     const k8sTasks = new K8sTasks()
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
-    flags.directory = path.resolve(flags.directory, flags.chenamespace)
 
     tasks.add(k8sTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
     tasks.add(cheTasks.serverLogsTasks(flags, false))
 
-    await tasks.run()
+    try {
+      await tasks.run()
+      this.log('Command server:logs has completed successfully.')
+    } catch (error) {
+      this.error(error)
+    } finally {
+      this.log(`Eclipse Che logs will be available in '${path.resolve(flags.directory)}'`)
+    }
 
     notifier.notify({
       title: 'chectl',

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -221,7 +221,7 @@ export default class Start extends Command {
 
     flags.directory = path.resolve(flags.directory, flags.chenamespace)
     const logsTasks = new Listr([{
-      title: 'Start logs following',
+      title: 'Start following logs',
       task: () => new Listr(cheTasks.serverLogsTasks(flags, true))
     }], listrOptions)
 

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -219,7 +219,6 @@ export default class Start extends Command {
       task: () => new Listr(cheTasks.waitDeployedChe(flags, this))
     }], listrOptions)
 
-    flags.directory = path.resolve(flags.directory, flags.chenamespace)
     const logsTasks = new Listr([{
       title: 'Start following logs',
       task: () => new Listr(cheTasks.serverLogsTasks(flags, true))
@@ -250,6 +249,8 @@ export default class Start extends Command {
       this.log('Command server:start has completed successfully.')
     } catch (err) {
       this.error(err)
+    } finally {
+      this.log(`Eclipse Che logs will be available in '${path.resolve(flags.directory)}'`)
     }
 
     notifier.notify({

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -61,7 +61,7 @@ export default class Inject extends Command {
         title: `Verify if container ${flags.container} exists`,
         enabled: () => flags.container !== undefined,
         task: async (ctx: any) => {
-          if (!await this.containerExists(flags.chenamespace!, ctx.pod.metadata.name, flags.container!)) {
+          if (!await this.containerExists(flags.chenamespace!, ctx.pod, flags.container!)) {
             this.error(`The specified container "${flags.container}" doesn't exist. The configuration cannot be injected.`)
           }
         }
@@ -117,7 +117,7 @@ export default class Inject extends Command {
         task: async (ctx: any, task: any) => {
           try {
             if (await this.canInject(flags.chenamespace, ctx.pod, cont)) {
-              await this.injectKubeconfig(flags.chenamespace!, ctx.pod.metadata.name, cont, contextToInject!)
+              await this.injectKubeconfig(flags.chenamespace!, ctx.pod, cont, contextToInject!)
               task.title = `${task.title}...done.`
             } else {
               task.skip('the container doesn\'t support file injection')

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -20,6 +20,7 @@ import * as path from 'path'
 import { CheHelper } from '../../api/che'
 import { KubeHelper } from '../../api/kube'
 import { cheNamespace, listrRenderer } from '../../common-flags'
+import { CheTasks } from '../../tasks/che'
 
 export default class Inject extends Command {
   static description = 'inject configurations and tokens in a Che Workspace'
@@ -50,27 +51,17 @@ export default class Inject extends Command {
   async run() {
     const { flags } = this.parse(Inject)
     const notifier = require('node-notifier')
-    const che = new CheHelper(flags)
-    const tasks = new Listr([
-      {
-        title: `Verify if namespace ${flags.chenamespace} exists`,
-        task: async () => {
-          if (!await che.cheNamespaceExist(flags.chenamespace)) {
-            this.error(`E_BAD_NS - Namespace does not exist.\nThe Kubernetes Namespace "${flags.chenamespace}" doesn't exist. The configuration cannot be injected.\nFix with: verify the namespace where Che workspace is running (kubectl get --all-namespaces deployment | grep workspace)`, { code: 'EBADNS' })
-          }
-        }
-      },
-      {
-        title: 'Verify if the workspaces is running',
-        task: async (ctx: any) => {
-          ctx.pod = await che.getWorkspacePod(flags.chenamespace!, flags.workspace).catch(e => this.error(e.message))
-        }
-      },
+    const cheTasks = new CheTasks(flags)
+
+    const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
+    tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
+    tasks.add(cheTasks.verifyWorkspaceRunTask(flags, this))
+    tasks.add([
       {
         title: `Verify if container ${flags.container} exists`,
         enabled: () => flags.container !== undefined,
         task: async (ctx: any) => {
-          if (!await this.containerExists(flags.chenamespace!, ctx.pod, flags.container!)) {
+          if (!await this.containerExists(flags.chenamespace!, ctx.pod.metadata.name, flags.container!)) {
             this.error(`The specified container "${flags.container}" doesn't exist. The configuration cannot be injected.`)
           }
         }
@@ -84,7 +75,7 @@ export default class Inject extends Command {
         },
         task: () => this.injectKubeconfigTasks(flags)
       },
-    ], { renderer: flags['listr-renderer'] as any, collapse: false } as Listr.ListrOptions)
+    ])
 
     try {
       await tasks.run()

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -117,7 +117,7 @@ export default class Inject extends Command {
         task: async (ctx: any, task: any) => {
           try {
             if (await this.canInject(flags.chenamespace, ctx.pod, cont)) {
-              await this.injectKubeconfig(flags.chenamespace!, ctx.pod, cont, contextToInject!)
+              await this.injectKubeconfig(flags.chenamespace!, ctx.pod.metadata.name, cont, contextToInject!)
               task.title = `${task.title}...done.`
             } else {
               task.skip('the container doesn\'t support file injection')

--- a/src/commands/workspace/logs.ts
+++ b/src/commands/workspace/logs.ts
@@ -14,7 +14,7 @@ import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
 import * as path from 'path'
 
-import { accessToken, cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
+import { cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
 
 export default class Logs extends Command {
@@ -23,7 +23,6 @@ export default class Logs extends Command {
   static flags = {
     help: flags.help({ char: 'h' }),
     chenamespace: cheNamespace,
-    'access-token': accessToken,
     'listr-renderer': listrRenderer,
     workspace: string({
       char: 'w',
@@ -44,7 +43,7 @@ export default class Logs extends Command {
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
     tasks.add(cheTasks.verifyWorkspaceRunTask(flags, this))
-    tasks.add(cheTasks.workspaceLogsTasks(flags, this))
+    tasks.add(cheTasks.workspaceLogsTasks(flags, false))
 
     await tasks.run()
 
@@ -52,5 +51,7 @@ export default class Logs extends Command {
       title: 'chectl',
       message: 'Command workspace:logs has completed successfully.'
     })
+
+    this.exit(0)
   }
 }

--- a/src/commands/workspace/logs.ts
+++ b/src/commands/workspace/logs.ts
@@ -1,0 +1,56 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { Command, flags } from '@oclif/command'
+import { string } from '@oclif/parser/lib/flags'
+import * as Listr from 'listr'
+import * as notifier from 'node-notifier'
+import * as path from 'path'
+
+import { accessToken, cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
+import { CheTasks } from '../../tasks/che'
+
+export default class Logs extends Command {
+  static description = 'Retrieve workspace logs'
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    chenamespace: cheNamespace,
+    'access-token': accessToken,
+    'listr-renderer': listrRenderer,
+    workspace: string({
+      char: 'w',
+      description: 'Target workspace. Can be omitted if only one Workspace is running'
+    }),
+    directory: string({
+      char: 'd',
+      description: 'Directory to store logs into',
+      default: './logs'
+    })
+  }
+
+  async run() {
+    const { flags } = this.parse(Logs)
+    const cheTasks = new CheTasks(flags)
+    flags.directory = path.resolve(flags.directory, flags.chenamespace)
+
+    const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
+    tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
+    tasks.add(cheTasks.verifyWorkspaceRunTask(flags, this))
+    tasks.add(cheTasks.workspaceLogsTasks(flags, this))
+
+    await tasks.run()
+
+    notifier.notify({
+      title: 'chectl',
+      message: 'Command workspace:logs has completed successfully.'
+    })
+  }
+}

--- a/src/commands/workspace/logs.ts
+++ b/src/commands/workspace/logs.ts
@@ -16,6 +16,7 @@ import * as path from 'path'
 
 import { cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
+import { K8sTasks } from '../../tasks/platforms/k8s'
 
 export default class Logs extends Command {
   static description = 'Retrieve workspace logs'
@@ -38,9 +39,11 @@ export default class Logs extends Command {
   async run() {
     const { flags } = this.parse(Logs)
     const cheTasks = new CheTasks(flags)
+    const k8sTasks = new K8sTasks()
     flags.directory = path.resolve(flags.directory, flags.chenamespace)
 
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
+    tasks.add(k8sTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
     tasks.add(cheTasks.verifyWorkspaceRunTask(flags, this))
     tasks.add(cheTasks.workspaceLogsTasks(flags, false))

--- a/src/commands/workspace/logs.ts
+++ b/src/commands/workspace/logs.ts
@@ -40,7 +40,6 @@ export default class Logs extends Command {
     const { flags } = this.parse(Logs)
     const cheTasks = new CheTasks(flags)
     const k8sTasks = new K8sTasks()
-    flags.directory = path.resolve(flags.directory, flags.chenamespace)
 
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
     tasks.add(k8sTasks.testApiTasks(flags, this))
@@ -48,7 +47,14 @@ export default class Logs extends Command {
     tasks.add(cheTasks.verifyWorkspaceRunTask(flags, this))
     tasks.add(cheTasks.workspaceLogsTasks(flags, false))
 
-    await tasks.run()
+    try {
+      await tasks.run()
+      this.log('Command workspace:logs has completed successfully.')
+    } catch (error) {
+      this.error(error)
+    } finally {
+      this.log(`Eclipse Che logs will be available in '${path.resolve(flags.directory)}'`)
+    }
 
     notifier.notify({
       title: 'chectl',

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -14,6 +14,7 @@ import { cli } from 'cli-ux'
 
 import { CheHelper } from '../../api/che'
 import { accessToken, cheNamespace, listrRenderer } from '../../common-flags'
+import { CheTasks } from '../../tasks/che'
 
 export default class Start extends Command {
   static description = 'create and start a Che workspace'
@@ -52,6 +53,7 @@ export default class Start extends Command {
     const Listr = require('listr')
     const notifier = require('node-notifier')
     const che = new CheHelper(flags)
+    const cheTasks = new CheTasks(flags)
     if (!flags.devfile && !flags.workspaceconfig) {
       this.error('workspace:start command is expecting a devfile or workspace configuration parameter.')
     }
@@ -75,6 +77,7 @@ export default class Start extends Command {
           task.title = await `${task.title}...${status} ${auth}`
         }
       },
+      ...cheTasks.workspaceLogsTasks(flags, true),
       {
         title: `Create workspace from Devfile ${flags.devfile}`,
         enabled: () => flags.devfile !== undefined,

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -11,6 +11,7 @@
 import { Command, flags } from '@oclif/command'
 import { string } from '@oclif/parser/lib/flags'
 import { cli } from 'cli-ux'
+import * as path from 'path'
 
 import { CheHelper } from '../../api/che'
 import { accessToken, cheNamespace, listrRenderer } from '../../common-flags'
@@ -38,6 +39,11 @@ export default class Start extends Command {
       description: 'workspace name: overrides the workspace name to use instead of the one defined in the devfile. Works only for devfile',
       required: false,
     }),
+    directory: string({
+      char: 'd',
+      description: 'Directory to store logs into',
+      default: './logs'
+    }),
     'access-token': accessToken,
     'listr-renderer': listrRenderer
   }
@@ -50,6 +56,7 @@ export default class Start extends Command {
 
   async run() {
     const { flags } = this.parse(Start)
+
     const Listr = require('listr')
     const notifier = require('node-notifier')
     const che = new CheHelper(flags)
@@ -100,9 +107,10 @@ export default class Start extends Command {
       let ctx = await tasks.run()
       this.log('\nWorkspace IDE URL:')
       cli.url(ctx.workspaceIdeURL, ctx.workspaceIdeURL)
-      this.log('\n')
     } catch (err) {
       this.error(err)
+    } finally {
+      this.log(`Eclipse Che logs will be available in '${path.resolve(flags.directory)}'`)
     }
 
     notifier.notify({

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -492,55 +492,67 @@ export class CheTasks {
   /**
    * Return tasks to collect Eclipse Che logs.
    */
-  serverLogsTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
+  serverLogsTasks(flags: any, follow: boolean): ReadonlyArray<Listr.ListrTask> {
     return [
       {
-        title: 'Retrieve Che logs',
+        title: `${follow ? 'Start following' : 'Read'} Che logs`,
         task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.cheSelector, flags.directory, command)
-          task.title = await `${task.title}...OK`
+          await this.che.readPodLogBySelector(flags.chenamespace, this.cheSelector, flags.directory, follow)
+          task.title = await `${task.title}...done`
         }
       },
       {
-        title: 'Retrieve Postgres logs',
+        title: `${follow ? 'Start following' : 'Read'} Postgres logs`,
         task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.postgresSelector, flags.directory, command)
-          task.title = await `${task.title}...OK`
+          await this.che.readPodLogBySelector(flags.chenamespace, this.postgresSelector, flags.directory, follow)
+          task.title = await `${task.title}...done`
         }
       },
       {
-        title: 'Retrieve Keycloak logs',
+        title: `${follow ? 'Start following' : 'Read'} Keycloak logs`,
         task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.keycloakSelector, flags.directory, command)
-          task.title = await `${task.title}...OK`
+          await this.che.readPodLogBySelector(flags.chenamespace, this.keycloakSelector, flags.directory, follow)
+          task.title = await `${task.title}...done`
         }
       },
       {
-        title: 'Retrieve Plugin registry logs',
+        title: `${follow ? 'Start following' : 'Read'} Plugin registry logs`,
         task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.pluginRegistrySelector, flags.directory, command)
-          task.title = await `${task.title}...OK`
+          await this.che.readPodLogBySelector(flags.chenamespace, this.pluginRegistrySelector, flags.directory, follow)
+          task.title = await `${task.title}...done`
         }
       },
       {
-        title: 'Retrieve Devfile registry logs',
+        title: `${follow ? 'Start following' : 'Read'} Devfile registry logs`,
         task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.devfileRegistrySelector, flags.directory, command)
-          task.title = await `${task.title}...OK`
+          await this.che.readPodLogBySelector(flags.chenamespace, this.devfileRegistrySelector, flags.directory, follow)
+          task.title = await `${task.title}...done`
+        }
+      },
+      {
+        title: `Eclipse Che logs will be available in '${flags.directory}'`,
+        task: async (task: any) => {
+          task.title = await `${task.title}...done`
         }
       }
     ]
   }
 
-  workspaceLogsTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
+  workspaceLogsTasks(flags: any, follow: boolean): ReadonlyArray<Listr.ListrTask> {
     return [
       {
         title: 'Retrieve Workspace logs',
         task: async (ctx: any, task: any) => {
           const workspaceId = ctx.pod.metadata!.labels!['che.workspace_id']
           const directory = path.resolve(flags.directory, workspaceId)
-          await this.che.readPodLog(flags.chenamespace, ctx.pod, directory, command)
-          task.title = await `${task.title}...OK`
+          await this.che.readPodLogByName(flags.chenamespace, ctx.pod.metadata.name, directory, follow)
+          task.title = await `${task.title}...done`
+        }
+      },
+      {
+        title: `Workspace logs will be available in '${flags.directory}'`,
+        task: async (task: any) => {
+          task.title = await `${task.title}...done`
         }
       }
     ]

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -547,7 +547,7 @@ export class CheTasks {
           if (followNew) {
             await this.che.followNewPodLog(flags.chenamespace, directory)
           } else {
-            await this.che.readPodLogByName(flags.chenamespace, ctx.pod.metadata.name, directory, false)
+            await this.che.readPodLogByName(flags.chenamespace, ctx.pod, directory, false)
           }
           task.title = await `${task.title}...done`
         }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -538,14 +538,14 @@ export class CheTasks {
     ]
   }
 
-  workspaceLogsTasks(flags: any, followNew: boolean): ReadonlyArray<Listr.ListrTask> {
+  workspaceLogsTasks(flags: any, follow: boolean): ReadonlyArray<Listr.ListrTask> {
     return [
       {
-        title: `${flags['follow-new'] ? '' : ''} Retrieve Workspace logs`,
+        title: `${follow ? 'Start following' : 'Read'} workspace logs`,
         task: async (ctx: any, task: any) => {
           const directory = path.resolve(flags.directory)
-          if (followNew) {
-            await this.che.followNewPodLog(flags.chenamespace, directory)
+          if (follow) {
+            await this.che.readAllNewPodLog(flags.chenamespace, directory)
           } else {
             await this.che.readPodLogByName(flags.chenamespace, ctx.pod, directory, false)
           }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -538,14 +538,17 @@ export class CheTasks {
     ]
   }
 
-  workspaceLogsTasks(flags: any, follow: boolean): ReadonlyArray<Listr.ListrTask> {
+  workspaceLogsTasks(flags: any, followNew: boolean): ReadonlyArray<Listr.ListrTask> {
     return [
       {
-        title: 'Retrieve Workspace logs',
+        title: `${flags['follow-new'] ? '' : ''} Retrieve Workspace logs`,
         task: async (ctx: any, task: any) => {
-          const workspaceId = ctx.pod.metadata!.labels!['che.workspace_id']
-          const directory = path.resolve(flags.directory, workspaceId)
-          await this.che.readPodLogByName(flags.chenamespace, ctx.pod.metadata.name, directory, follow)
+          const directory = path.resolve(flags.directory)
+          if (followNew) {
+            await this.che.followNewPodLog(flags.chenamespace, directory)
+          } else {
+            await this.che.readPodLogByName(flags.chenamespace, ctx.pod.metadata.name, directory, false)
+          }
           task.title = await `${task.title}...done`
         }
       },

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -9,7 +9,6 @@
  **********************************************************************/
 import { Command } from '@oclif/command'
 import * as Listr from 'listr'
-import * as path from 'path'
 
 import { CheHelper } from '../api/che'
 import { KubeHelper } from '../api/kube'
@@ -528,12 +527,6 @@ export class CheTasks {
           await this.che.readPodLogBySelector(flags.chenamespace, this.devfileRegistrySelector, flags.directory, follow)
           task.title = await `${task.title}...done`
         }
-      },
-      {
-        title: `Eclipse Che logs will be available in '${flags.directory}'`,
-        task: async (task: any) => {
-          task.title = await `${task.title}...done`
-        }
       }
     ]
   }
@@ -543,18 +536,11 @@ export class CheTasks {
       {
         title: `${follow ? 'Start following' : 'Read'} workspace logs`,
         task: async (ctx: any, task: any) => {
-          const directory = path.resolve(flags.directory)
           if (follow) {
-            await this.che.readAllNewPodLog(flags.chenamespace, directory)
+            await this.che.readAllNewPodLog(flags.chenamespace, flags.directory)
           } else {
-            await this.che.readPodLogByName(flags.chenamespace, ctx.pod, directory, false)
+            await this.che.readPodLogByName(flags.chenamespace, ctx.pod, flags.directory, false)
           }
-          task.title = await `${task.title}...done`
-        }
-      },
-      {
-        title: `Workspace logs will be available in '${flags.directory}'`,
-        task: async (task: any) => {
           task.title = await `${task.title}...done`
         }
       }

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -15,6 +15,9 @@ import { HelmTasks } from './helm'
 import { MinishiftAddonTasks } from './minishift-addon'
 import { OperatorTasks } from './operator'
 
+/**
+ * Tasks related to installation way.
+ */
 export class InstallerTasks {
   updateTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
     const operatorTasks = new OperatorTasks()

--- a/src/tasks/platforms/crc.ts
+++ b/src/tasks/platforms/crc.ts
@@ -17,7 +17,7 @@ import * as Listr from 'listr'
  * Helper for Code Ready Container
  */
 export class CRCHelper {
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if oc is installed',

--- a/src/tasks/platforms/docker-desktop.ts
+++ b/src/tasks/platforms/docker-desktop.ts
@@ -26,7 +26,7 @@ export class DockerDesktopTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if kubectl is installed',

--- a/src/tasks/platforms/k8s.ts
+++ b/src/tasks/platforms/k8s.ts
@@ -42,7 +42,7 @@ export class K8sTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if kubectl is installed',

--- a/src/tasks/platforms/microk8s.ts
+++ b/src/tasks/platforms/microk8s.ts
@@ -17,7 +17,7 @@ export class MicroK8sTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if kubectl is installed',

--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -17,7 +17,7 @@ export class MinikubeTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if kubectl is installed',

--- a/src/tasks/platforms/minishift.ts
+++ b/src/tasks/platforms/minishift.ts
@@ -17,7 +17,7 @@ export class MinishiftTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if oc is installed',

--- a/src/tasks/platforms/openshift.ts
+++ b/src/tasks/platforms/openshift.ts
@@ -17,7 +17,7 @@ export class OpenshiftTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  preflightCheckTasks(flags: any, command: Command): Listr {
     return new Listr([
       {
         title: 'Verify if oc is installed',

--- a/src/tasks/platforms/platform.ts
+++ b/src/tasks/platforms/platform.ts
@@ -18,6 +18,10 @@ import { MinikubeTasks } from './minikube'
 import { MinishiftTasks } from './minishift'
 import { OpenshiftTasks } from './openshift'
 
+/**
+ * Platform specific tasks.
+ *  - preflightCheck
+ */
 export class PlatformTasks {
   preflightCheckTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
     const minikubeTasks = new MinikubeTasks()
@@ -37,37 +41,37 @@ export class PlatformTasks {
     } else if (flags.platform === 'minikube') {
       task = {
         title: '✈️  Minikube preflight checklist',
-        task: () => minikubeTasks.startTasks(flags, command)
+        task: () => minikubeTasks.preflightCheckTasks(flags, command)
       }
     } else if (flags.platform === 'minishift') {
       task = {
         title: '✈️  Minishift preflight checklist',
-        task: () => minishiftTasks.startTasks(flags, command)
+        task: () => minishiftTasks.preflightCheckTasks(flags, command)
       }
     } else if (flags.platform === 'microk8s') {
       task = {
         title: '✈️  MicroK8s preflight checklist',
-        task: () => microk8sTasks.startTasks(flags, command)
+        task: () => microk8sTasks.preflightCheckTasks(flags, command)
       }
     } else if (flags.platform === 'openshift') {
       task = {
         title: '✈️  Openshift preflight checklist',
-        task: () => openshiftTasks.startTasks(flags, command)
+        task: () => openshiftTasks.preflightCheckTasks(flags, command)
       }
     } else if (flags.platform === 'k8s') {
       task = {
         title: '✈️  Kubernetes preflight checklist',
-        task: () => k8sTasks.startTasks(flags, command)
+        task: () => k8sTasks.preflightCheckTasks(flags, command)
       }
     } else if (flags.platform === 'docker-desktop') {
       task = {
         title: '✈️  Docker Desktop preflight checklist',
-        task: () => dockerDesktopTasks.startTasks(flags, command)
+        task: () => dockerDesktopTasks.preflightCheckTasks(flags, command)
       }
     } else if (flags.platform === 'crc') {
       task = {
         title: '✈️  CodeReady Containers preflight checklist',
-        task: () => crc.startTasks(flags, command)
+        task: () => crc.preflightCheckTasks(flags, command)
       }
     } else {
       task = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,15 +1673,15 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-minishift@git://github.com/minishift/minishift#master":
   version "0.0.0"
-  resolved "git://github.com/minishift/minishift#0efa5d527d77a7651eac75a4861097ab4a203f43"
+  resolved "git://github.com/minishift/minishift#83ebaab2c072bd1a1b37b8cdbf01cb1280669144"
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#d121ea81557abf19238309149d2926d7a0bb1df4"
+  resolved "git://github.com/eclipse/che-operator#8e572e70632e7aab10506ebb5be1a19bc7fdb98c"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#490413cd482f61878050accec0bf2d9ad094456d"
+  resolved "git://github.com/eclipse/che#688115587ba3887ee95437c59db73969cbb42996"
 
 editorconfig@^0.15.0:
   version "0.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,7 +1681,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#688115587ba3887ee95437c59db73969cbb42996"
+  resolved "git://github.com/eclipse/che#e5cfda1c58db958e628ba87c39d677864a155595"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
1. Introduce a new command: `server:logs` to collect Eclipse Che logs (except workspace logs)
2. Introduce  `workspace:logs` to collect workspace log
3. Automatically collect logs when Eclipse Che is being installed
4. Automatically collect logs when Eclipse Che Workspace is being started

```
logs
  |
  -- <namespace>
             |
              -------- <pod>
                            |
                            ----------- <container>.log
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15485
