### PR TITLE
fix: Store server logs into system tmp directory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ USAGE
   $ chectl server:logs
 
 OPTIONS
-  -d, --directory=directory                [default: ./logs] Directory to store logs into
+  -d, --directory=directory                Directory to store logs into
   -h, --help                               show CLI help
 
   -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Che server is supposed to be
@@ -225,7 +225,7 @@ OPTIONS
       Domain of the Kubernetes cluster (e.g. example.k8s-cluster.com or <local-ip>.nip.io)
 
   -d, --directory=directory
-      [default: ./logs] Directory to store logs into
+      Directory to store logs into
 
   -h, --help
       show CLI help
@@ -423,7 +423,7 @@ USAGE
   $ chectl workspace:logs
 
 OPTIONS
-  -d, --directory=directory                [default: ./logs] Directory to store logs into
+  -d, --directory=directory                Directory to store logs into
   -h, --help                               show CLI help
 
   -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Che server is supposed to be

--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -10,8 +10,10 @@
 
 import { Command, flags } from '@oclif/command'
 import { string } from '@oclif/parser/lib/flags'
+import * as fs from 'fs-extra'
 import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
+import * as os from 'os'
 import * as path from 'path'
 
 import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
@@ -28,13 +30,14 @@ export default class Logs extends Command {
     'deployment-name': cheDeployment,
     directory: string({
       char: 'd',
-      description: 'Directory to store logs into',
-      default: './logs'
+      description: 'Directory to store logs into'
     })
   }
 
   async run() {
     const { flags } = this.parse(Logs)
+    const ctx: any = {}
+    ctx.directory = path.resolve(os.tmpdir(), flags.directory ? flags.directory : fs.mkdtempSync('chectl-logs-'))
     const cheTasks = new CheTasks(flags)
     const k8sTasks = new K8sTasks()
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
@@ -44,12 +47,12 @@ export default class Logs extends Command {
     tasks.add(cheTasks.serverLogsTasks(flags, false))
 
     try {
-      await tasks.run()
+      await tasks.run(ctx)
       this.log('Command server:logs has completed successfully.')
     } catch (error) {
       this.error(error)
     } finally {
-      this.log(`Eclipse Che logs will be available in '${path.resolve(flags.directory)}'`)
+      this.log(`Eclipse Che logs will be available in '${ctx.directory}'`)
     }
 
     notifier.notify({

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -13,6 +13,7 @@ import { string } from '@oclif/parser/lib/flags'
 import * as fs from 'fs-extra'
 import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
+import * as os from 'os'
 import * as path from 'path'
 
 import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
@@ -111,8 +112,7 @@ export default class Start extends Command {
     }),
     directory: string({
       char: 'd',
-      description: 'Directory to store logs into',
-      default: './logs'
+      description: 'Directory to store logs into'
     })
   }
 
@@ -187,6 +187,8 @@ export default class Start extends Command {
 
   async run() {
     const { flags } = this.parse(Start)
+    const ctx: any = {}
+    ctx.directory = path.resolve(os.tmpdir(), flags.directory ? flags.directory : fs.mkdtempSync('chectl-logs-'))
     const listrOptions: Listr.ListrOptions = { renderer: (flags['listr-renderer'] as any), collapse: false, showSubtasks: true } as Listr.ListrOptions
 
     const cheTasks = new CheTasks(flags)
@@ -225,7 +227,6 @@ export default class Start extends Command {
     }], listrOptions)
 
     try {
-      const ctx: any = {}
       await preInstallTasks.run(ctx)
 
       if (!ctx.isCheDeployed) {
@@ -250,7 +251,7 @@ export default class Start extends Command {
     } catch (err) {
       this.error(err)
     } finally {
-      this.log(`Eclipse Che logs will be available in '${path.resolve(flags.directory)}'`)
+      this.log(`Eclipse Che logs will be available in '${ctx.directory}'`)
     }
 
     notifier.notify({

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -495,36 +495,36 @@ export class CheTasks {
     return [
       {
         title: `${follow ? 'Start following' : 'Read'} Che logs`,
-        task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.cheSelector, flags.directory, follow)
+        task: async (ctx: any, task: any) => {
+          await this.che.readPodLogBySelector(flags.chenamespace, this.cheSelector, ctx.directory, follow)
           task.title = await `${task.title}...done`
         }
       },
       {
         title: `${follow ? 'Start following' : 'Read'} Postgres logs`,
-        task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.postgresSelector, flags.directory, follow)
+        task: async (ctx: any, task: any) => {
+          await this.che.readPodLogBySelector(flags.chenamespace, this.postgresSelector, ctx.directory, follow)
           task.title = await `${task.title}...done`
         }
       },
       {
         title: `${follow ? 'Start following' : 'Read'} Keycloak logs`,
-        task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.keycloakSelector, flags.directory, follow)
+        task: async (ctx: any, task: any) => {
+          await this.che.readPodLogBySelector(flags.chenamespace, this.keycloakSelector, ctx.directory, follow)
           task.title = await `${task.title}...done`
         }
       },
       {
         title: `${follow ? 'Start following' : 'Read'} Plugin registry logs`,
-        task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.pluginRegistrySelector, flags.directory, follow)
+        task: async (ctx: any, task: any) => {
+          await this.che.readPodLogBySelector(flags.chenamespace, this.pluginRegistrySelector, ctx.directory, follow)
           task.title = await `${task.title}...done`
         }
       },
       {
         title: `${follow ? 'Start following' : 'Read'} Devfile registry logs`,
-        task: async (_ctx: any, task: any) => {
-          await this.che.readPodLogBySelector(flags.chenamespace, this.devfileRegistrySelector, flags.directory, follow)
+        task: async (ctx: any, task: any) => {
+          await this.che.readPodLogBySelector(flags.chenamespace, this.devfileRegistrySelector, ctx.directory, follow)
           task.title = await `${task.title}...done`
         }
       }
@@ -537,9 +537,9 @@ export class CheTasks {
         title: `${flags.follow ? 'Start following' : 'Read'} workspace logs`,
         task: async (ctx: any, task: any) => {
           if (flags.follow) {
-            await this.che.readAllNewPodLog(flags.chenamespace, flags.directory)
+            await this.che.readAllNewPodLog(flags.chenamespace, ctx.directory)
           } else {
-            await this.che.readPodLogByName(flags.chenamespace, ctx.pod, flags.directory, false)
+            await this.che.readPodLogByName(flags.chenamespace, ctx.pod, ctx.directory, false)
           }
           task.title = await `${task.title}...done`
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,7 +1681,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#42e796f06795c9761ef32e7568671ace86759455"
+  resolved "git://github.com/eclipse/che#a5dcbfbb7009600c607f38cd2c806fcadde4c580"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
This PR allows to store Eclipse Che logs into a system tmp directory by default


