### PR TITLE
fix: Use timestamp as a subfolder for Eclipse Che logs

### DIFF
--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -10,7 +10,6 @@
 
 import { Command, flags } from '@oclif/command'
 import { string } from '@oclif/parser/lib/flags'
-import * as fs from 'fs-extra'
 import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
 import * as os from 'os'
@@ -37,7 +36,7 @@ export default class Logs extends Command {
   async run() {
     const { flags } = this.parse(Logs)
     const ctx: any = {}
-    ctx.directory = path.resolve(os.tmpdir(), flags.directory ? flags.directory : fs.mkdtempSync('chectl-logs-'))
+    ctx.directory = path.resolve(flags.directory ? flags.directory : path.resolve(os.tmpdir(), 'chectl-logs', Date.now().toString()))
     const cheTasks = new CheTasks(flags)
     const k8sTasks = new K8sTasks()
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -188,7 +188,7 @@ export default class Start extends Command {
   async run() {
     const { flags } = this.parse(Start)
     const ctx: any = {}
-    ctx.directory = path.resolve(os.tmpdir(), flags.directory ? flags.directory : fs.mkdtempSync('chectl-logs-'))
+    ctx.directory = path.resolve(flags.directory ? flags.directory : path.resolve(os.tmpdir(), 'chectl-logs', Date.now().toString()))
     const listrOptions: Listr.ListrOptions = { renderer: (flags['listr-renderer'] as any), collapse: false, showSubtasks: true } as Listr.ListrOptions
 
     const cheTasks = new CheTasks(flags)

--- a/src/commands/workspace/logs.ts
+++ b/src/commands/workspace/logs.ts
@@ -10,7 +10,6 @@
 
 import { Command, flags } from '@oclif/command'
 import { string } from '@oclif/parser/lib/flags'
-import * as fs from 'fs-extra'
 import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
 import * as os from 'os'
@@ -44,7 +43,7 @@ export default class Logs extends Command {
   async run() {
     const ctx: any = {}
     const { flags } = this.parse(Logs)
-    ctx.directory = path.resolve(os.tmpdir(), flags.directory ? flags.directory : fs.mkdtempSync('chectl-logs-'))
+    ctx.directory = path.resolve(flags.directory ? flags.directory : path.resolve(os.tmpdir(), 'chectl-logs', Date.now().toString()))
     const cheTasks = new CheTasks(flags)
     const k8sTasks = new K8sTasks()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,7 +1681,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#a5dcbfbb7009600c607f38cd2c806fcadde4c580"
+  resolved "git://github.com/eclipse/che#dfdc304120cb3286071f4f8a0ded2df0d9b805e4"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Use timestamp as a subfolder for Eclipse Che logs


