### PR TITLE
feat: Persisted volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,13 @@ OPTIONS
   --devfile-registry-url=devfile-registry-url
       The URL of the external Devfile registry.
 
+  --host-persisted-volume-storage-class-name=host-persisted-volume-storage-class-name
+      Storage class name to configure Eclipse Che volume. Parameter is used only when installer is operator.
+
+  --host-persisted-volume-storage-class-path=host-persisted-volume-storage-class-path
+      Storage class path to the yaml to configure Eclipse Che data volume. Parameter is used only when installer is 
+      operator.
+
   --k8spodreadytimeout=k8spodreadytimeout
       [default: 130000] Waiting time for Pod Ready Kubernetes (in milliseconds)
 
@@ -283,6 +290,9 @@ OPTIONS
 
   --plugin-registry-url=plugin-registry-url
       The URL of the external plugin registry.
+
+  --pvc-host-volume-path=pvc-host-volume-path
+      Host volume path to store Eclipse Che data. Parameter is used only when installer is operator.
 
   --self-signed-cert
       Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate 

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -118,6 +118,10 @@ export default class Start extends Command {
       description: 'Storage class name to configure Eclipse Che volume. Parameter is used only when installer is operator.',
       default: ''
     }),
+    'host-persisted-volume-storage-class-path': string({
+      description: 'Storage class path to the yaml to configure Eclipse Che data volume. Parameter is used only when installer is operator.',
+      default: ''
+    }),
     'pvc-host-volume-path': string({
       description: 'Host volume path to store Eclipse Che data. Parameter is used only when installer is operator.',
       default: ''

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -114,16 +114,12 @@ export default class Start extends Command {
       description: 'Directory to store logs into',
       default: './logs'
     }),
-    // 'host-persistent-volume-name': string({
-    //   description: 'Path to the already created persisted volume in the node host. Parameter is used only when installer is operator.',
-    //   default: ''
-    // }),
     'host-persisted-volume-storage-class-name': string({
-      description: 'Path to a yaml file that defines node host persisted volume storage class. Parameter is used only when installer is operator.',
+      description: 'Storage class name to configure Eclipse Che volume. Parameter is used only when installer is operator.',
       default: ''
     }),
     'pvc-host-volume-path': string({
-      description: 'Path to a yaml file that defines node host persisted volume storage class. Parameter is used only when installer is operator.',
+      description: 'Host volume path to store Eclipse Che data. Parameter is used only when installer is operator.',
       default: ''
     }),
   }

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -113,7 +113,19 @@ export default class Start extends Command {
       char: 'd',
       description: 'Directory to store logs into',
       default: './logs'
-    })
+    }),
+    // 'host-persistent-volume-name': string({
+    //   description: 'Path to the already created persisted volume in the node host. Parameter is used only when installer is operator.',
+    //   default: ''
+    // }),
+    'host-persisted-volume-storage-class-name': string({
+      description: 'Path to a yaml file that defines node host persisted volume storage class. Parameter is used only when installer is operator.',
+      default: ''
+    }),
+    'pvc-host-volume-path': string({
+      description: 'Path to a yaml file that defines node host persisted volume storage class. Parameter is used only when installer is operator.',
+      default: ''
+    }),
   }
 
   static getTemplatesDir(): string {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -191,6 +191,8 @@ export class OperatorTasks {
           if (!storageClassExists) {
             throw new Error(`Storage class with name "${storageClassName}" doesn't exist!`)
           }
+
+          flags['host-persisted-volume-storage-class-name'] = storageClassName
           task.title = `${task.title}... Used pvc "${volumePath}" and storage class "${storageClassName}".`
         }
       },

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -170,13 +170,13 @@ export class OperatorTasks {
           }
           return false
         },
-        task:  async (_ctx: any, task: any) => {
+        task: async (_ctx: any, task: any) => {
           let volumePath = flags['pvc-host-volume-path']
 
           const storageClassYamlPath = flags['host-persisted-volume-storage-class-path']
           if (storageClassYamlPath) {
             const storageClass = await kube.readClassStorage(storageClassYamlPath)
-            const storageExists = await kube.storageClassExists(storageClass.metadata!.name!)
+            const storageExists = await kube.isStorageClassExists(storageClass.metadata!.name!)
             if (!storageExists) {
               await kube.createStorageClass(storageClassYamlPath)
             }
@@ -187,7 +187,7 @@ export class OperatorTasks {
           }
 
           const storageClassName = flags['host-persisted-volume-storage-class-name'] || 'standard'
-          const storageClassExists = await kube.storageClassExists(storageClassName)
+          const storageClassExists = await kube.isStorageClassExists(storageClassName)
           if (!storageClassExists) {
             throw new Error(`Storage class with name "${storageClassName}" doesn't exist!`)
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,7 +1681,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#42e796f06795c9761ef32e7568671ace86759455"
+  resolved "git://github.com/eclipse/che#a5dcbfbb7009600c607f38cd2c806fcadde4c580"
 
 editorconfig@^0.15.0:
   version "0.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,7 +1681,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#dfdc304120cb3286071f4f8a0ded2df0d9b805e4"
+  resolved "git://github.com/eclipse/che#ccc956b51e6e936c88b1efec7cd8d6fb3d0f04ea"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
### What does this PR do?
Add ability to configure host volume path for Che postgres data volume in the node cluster. By default host volume path it is `/tmp/hostpath-provisioner`. Some infrastructures(lxd) tear down data for such paths after node restart. 

After this changes user can configure host volume path by argument `--pvc-host-volume-path`:

```shell
chectl server:start -m -p minikube -a operator --che-operator-image=aandrienko/che-operator:latest  --pvc-host-volume-path=/data/volume
```
Also user can specify storage class by name `--host-persisted-volume-storage-class-name`:

```shell
chectl  server:start -m -p minikube -a operator --che-operator-image=aandrienko/che-operator:latest  --pvc-host-volume-path=/data/volume --host-persisted-volume-storage-class-name=standard
```

or by path  to the yaml file `--host-persisted-volume-storage-class-path`

```shell
chectl  server:start -m -p minikube -a operator --che-operator-image=aandrienko/che-operator:latest  --pvc-host-volume-path=/data/volume --host-persisted-volume-storage-class-path=/home/user/customStorageClass.yaml
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15157

### Warning: Depends on che-operator changes.
