### PR TITLE
feat: add nickboldt to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Global Owners
-* @l0rd @rhopp @benoitf @vparfonov @azatsarynnyy
+* @l0rd @rhopp @benoitf @vparfonov @azatsarynnyy @nickboldt
 


### PR DESCRIPTION
add nickboldt to CODEOWNERS to I can approve/merge https://github.com/che-incubator/chectl/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+chore dependabot PRs

Change-Id: I418668b78e6b04efeedf68b3e5ea82cbf5ab9ae7
Signed-off-by: nickboldt <nboldt@redhat.com>