### PR TITLE
fix(helm): don't set workspace namespace for helm installer

### DIFF
--- a/src/tasks/installers/helm.ts
+++ b/src/tasks/installers/helm.ts
@@ -331,7 +331,6 @@ error: E_COMMAND_FAILED`)
 
     setOptions.push(`--set global.ingressDomain=${flags.domain}`)
     setOptions.push(`--set cheImage=${flags.cheimage}`)
-    setOptions.push(`--set global.cheWorkspacesNamespace=${flags.chenamespace}`)
 
     let command = `helm upgrade --install che --force --namespace ${flags.chenamespace} ${setOptions.join(' ')} ${multiUserFlag} ${tlsFlag} ${destDir}`
 


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Don't set namespace for workspaces when using helm installer. Helm charts already has reasonable default, which should be used and chectl should not interfere with it. Setting workspaces namespace can be implemented as new chectl parameter, but it's not in scope of this task.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15440
