### PR TITLE
feat: add snippet about how to obtain user access...

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,16 @@ OPTIONS
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 ```
 
+To obtain a user access token from the indentity provider (eg, Keycloak or Red Hat Single Sign-On), using `oc` or `kubectl` with `curl` and `jq`:
+
+```
+KEYCLOAK_URL=$(kubectl get route/keycloak -n ${cheNamespace} -o jsonpath='{.spec.host}')
+USER_ACCESS_TOKEN=$(curl -X POST $KEYCLOAK_URL/auth/realms/che/protocol/openid-connect/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=${username}" -d "password=${password}" 
+  -d "grant_type=password" -d "client_id=che-public" | jq -r .access_token)
+```
+
 _See code: [src/commands/server/stop.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/stop.ts)_
 
 ## `chectl server:update`


### PR DESCRIPTION
add snippet about how to obtain user access token when stopping a che/crw server

Change-Id: I4bdddabb6f2329264887e9380202e1b9e7118833
Signed-off-by: nickboldt <nboldt@redhat.com>