### PR TITLE
feat: Allows to override default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ OPTIONS
       [default: templates] Path to the templates folder
 
   --che-operator-cr-patch-yaml=che-operator-cr-patch-yaml
-      Path to a yaml file that overrides the default value a CheCluster used by the operator. This parameter is used only 
-      when the installer is the operator.
+      Path to a yaml file that overrides the default values in CheCluster CR used by the operator. This parameter is used 
+      only when the installer is the operator.
 
   --che-operator-cr-yaml=che-operator-cr-yaml
       Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ OPTIONS
   -t, --templates=templates
       [default: templates] Path to the templates folder
 
-  --che-operator-cr-patch=che-operator-cr-patch
+  --che-operator-cr-patch-yaml=che-operator-cr-patch-yaml
       Path to a yaml file that overrides the default value a CheCluster used by the operator. This parameter is used only 
       when the installer is the operator.
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ OPTIONS
   -t, --templates=templates
       [default: templates] Path to the templates folder
 
+  --che-operator-cr-patch=che-operator-cr-patch
+      Path to a yaml file that overrides the default value a CheCluster used by the operator. This parameter is used only 
+      when the installer is the operator.
+
   --che-operator-cr-yaml=che-operator-cr-yaml
       Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer 
       is the operator.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "^8.1.0",
     "listr": "^0.14.3",
     "listr-verbose-renderer": "^0.6.0",
+    "lodash": "^4.17.13",
     "mkdirp": "^0.5.1",
     "node-notifier": "^6.0.0",
     "tslib": "^1"

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -15,6 +15,7 @@ import { cli } from 'cli-ux'
 import * as fs from 'fs'
 import https = require('https')
 import * as yaml from 'js-yaml'
+import { merge } from 'lodash'
 import * as net from 'net'
 import { Writable } from 'stream'
 
@@ -949,9 +950,11 @@ export class KubeHelper {
 
   async createCheClusterFromFile(filePath: string, flags: any, useDefaultCR: boolean) {
     let yamlCr = this.safeLoadFromYamlFile(filePath)
+    yamlCr = this.overrideDefaultValues(yamlCr, flags['che-operator-cr-patch'])
+
     const cheNamespace = flags.chenamespace
     if (useDefaultCR) {
-      // If we don't use an explicitely provided CheCluster CR,
+      // If we don't use an explicitly provided CheCluster CR,
       // then let's modify the default example CR with values
       // derived from the other parameters
       const cheImage = flags.cheimage
@@ -998,6 +1001,15 @@ export class KubeHelper {
       return await customObjectsApi.createNamespacedCustomObject('org.eclipse.che', 'v1', cheNamespace, 'checlusters', yamlCr)
     } catch (e) {
       throw this.wrapK8sClientError(e)
+    }
+  }
+
+  overrideDefaultValues(yamlCr: any, filePath: string): any {
+    if (filePath) {
+      const patchCr = this.safeLoadFromYamlFile(filePath)
+      return merge(yamlCr, patchCr)
+    } else {
+      return yamlCr
     }
   }
 

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -950,7 +950,7 @@ export class KubeHelper {
 
   async createCheClusterFromFile(filePath: string, flags: any, useDefaultCR: boolean) {
     let yamlCr = this.safeLoadFromYamlFile(filePath)
-    yamlCr = this.overrideDefaultValues(yamlCr, flags['che-operator-cr-patch'])
+    yamlCr = this.overrideDefaultValues(yamlCr, flags['che-operator-cr-patch-yaml'])
 
     const cheNamespace = flags.chenamespace
     if (useDefaultCR) {

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -114,6 +114,10 @@ export default class Start extends Command {
       description: 'Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer is the operator.',
       default: ''
     }),
+    'che-operator-cr-patch': string({
+      description: 'Path to a yaml file that overrides the default value a CheCluster used by the operator. This parameter is used only when the installer is the operator.',
+      default: ''
+    }),
     directory: string({
       char: 'd',
       description: 'Directory to store logs into',
@@ -131,7 +135,7 @@ export default class Start extends Command {
     'skip-version-check': flags.boolean({
       description: 'Skip minimal versions check.',
       default: false
-    }),
+    })
   }
 
   static getTemplatesDir(): string {

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -114,8 +114,8 @@ export default class Start extends Command {
       description: 'Path to a yaml file that defines a CheCluster used by the operator. This parameter is used only when the installer is the operator.',
       default: ''
     }),
-    'che-operator-cr-patch': string({
-      description: 'Path to a yaml file that overrides the default value a CheCluster used by the operator. This parameter is used only when the installer is the operator.',
+    'che-operator-cr-patch-yaml': string({
+      description: 'Path to a yaml file that overrides the default values in CheCluster CR used by the operator. This parameter is used only when the installer is the operator.',
       default: ''
     }),
     directory: string({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,7 +1680,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#980379f3865dc339fd22c8aeaa8785c70012fd37"
+  resolved "git://github.com/eclipse/che#ad91e77d13bb9861cd1a3ece70f00f6f3b395ac1"
 
 editorconfig@^0.15.0:
   version "0.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,7 +1680,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#ad91e77d13bb9861cd1a3ece70f00f6f3b395ac1"
+  resolved "git://github.com/eclipse/che#06b84a6f06059d56fc90a711777d2745acd7f1c6"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Allows to override default values of custom resources by providing a patch file.

patch.yaml
```yaml
spec:
  storage:
    pvcStrategy: 'per-workspace'
```

```bash
chectl server:start  --che-operator-cr-patch-yaml=patch.yaml ....
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15684
