### PR TITLE
refactor: Separate testApiTasks to improve syncing with downstream

### DIFF
--- a/src/commands/server/debug.ts
+++ b/src/commands/server/debug.ts
@@ -14,7 +14,7 @@ import * as Listr from 'listr'
 
 import { cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 
 export default class Debug extends Command {
   static description = 'Enable local debug of Eclipse Che server'
@@ -34,10 +34,10 @@ export default class Debug extends Command {
     const ctx: any = {}
 
     const cheTasks = new CheTasks(flags)
-    const k8sTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
 
-    tasks.add(k8sTasks.testApiTasks(flags, this))
+    tasks.add(apiTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
     tasks.add(cheTasks.debugTask(flags))
 

--- a/src/commands/server/delete.ts
+++ b/src/commands/server/delete.ts
@@ -19,7 +19,7 @@ import { CheTasks } from '../../tasks/che'
 import { HelmTasks } from '../../tasks/installers/helm'
 import { MinishiftAddonTasks } from '../../tasks/installers/minishift-addon'
 import { OperatorTasks } from '../../tasks/installers/operator'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 
 export default class Delete extends Command {
   static description = 'delete any Eclipse Che related resource: Kubernetes/OpenShift/Helm'
@@ -39,7 +39,7 @@ export default class Delete extends Command {
 
     const notifier = require('node-notifier')
 
-    const k8sTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
     const helmTasks = new HelmTasks()
     const msAddonTasks = new MinishiftAddonTasks()
     const operatorTasks = new OperatorTasks()
@@ -49,7 +49,7 @@ export default class Delete extends Command {
       { renderer: flags['listr-renderer'] as any }
     )
 
-    tasks.add(k8sTasks.testApiTasks(flags, this))
+    tasks.add(apiTasks.testApiTasks(flags, this))
     tasks.add(operatorTasks.deleteTasks(flags))
     tasks.add(cheTasks.deleteTasks(flags))
     tasks.add(helmTasks.deleteTasks(flags))

--- a/src/commands/server/logs.ts
+++ b/src/commands/server/logs.ts
@@ -17,7 +17,7 @@ import * as path from 'path'
 
 import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 
 export default class Logs extends Command {
   static description = 'Collect Eclipse Che logs'
@@ -39,10 +39,10 @@ export default class Logs extends Command {
     const ctx: any = {}
     ctx.directory = path.resolve(flags.directory ? flags.directory : path.resolve(os.tmpdir(), 'chectl-logs', Date.now().toString()))
     const cheTasks = new CheTasks(flags)
-    const k8sTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
 
-    tasks.add(k8sTasks.testApiTasks(flags, this))
+    tasks.add(apiTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
     tasks.add(cheTasks.serverLogsTasks(flags, false))
     tasks.add(cheTasks.namespaceEventsTask(flags.chenamespace, this, false))

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -20,7 +20,7 @@ import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
 import { DEFAULT_CHE_IMAGE, DEFAULT_CHE_OPERATOR_IMAGE } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { InstallerTasks } from '../../tasks/installers/installer'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
 
 export default class Start extends Command {
@@ -212,14 +212,14 @@ export default class Start extends Command {
     const cheTasks = new CheTasks(flags)
     const platformTasks = new PlatformTasks()
     const installerTasks = new InstallerTasks()
-    const k8sTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
 
     // Platform Checks
     let platformCheckTasks = new Listr(platformTasks.preflightCheckTasks(flags, this), listrOptions)
 
     // Checks if Eclipse Che is already deployed
     let preInstallTasks = new Listr(undefined, listrOptions)
-    preInstallTasks.add(k8sTasks.testApiTasks(flags, this))
+    preInstallTasks.add(apiTasks.testApiTasks(flags, this))
     preInstallTasks.add({
       title: '👀  Looking for an already existing Eclipse Che instance',
       task: () => new Listr(cheTasks.checkIfCheIsInstalledTasks(flags, this))

--- a/src/commands/server/stop.ts
+++ b/src/commands/server/stop.ts
@@ -13,7 +13,7 @@ import { string } from '@oclif/parser/lib/flags'
 
 import { accessToken, cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 
 export default class Stop extends Command {
   static description = 'stop Eclipse Che Server'
@@ -36,7 +36,7 @@ export default class Stop extends Command {
     const Listr = require('listr')
     const notifier = require('node-notifier')
     const cheTasks = new CheTasks(flags)
-    const kubeTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
 
     let tasks = new Listr(undefined,
       {
@@ -45,7 +45,7 @@ export default class Stop extends Command {
       }
     )
 
-    tasks.add(kubeTasks.testApiTasks(flags, this))
+    tasks.add(apiTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.checkIfCheIsInstalledTasks(flags, this))
     tasks.add([
       {

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -20,7 +20,7 @@ import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
 import { DEFAULT_CHE_OPERATOR_IMAGE } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { InstallerTasks } from '../../tasks/installers/installer'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
 
 export default class Update extends Command {
@@ -95,7 +95,7 @@ export default class Update extends Command {
     const cheTasks = new CheTasks(flags)
     const platformTasks = new PlatformTasks()
     const installerTasks = new InstallerTasks()
-    const k8sTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
 
     // Platform Checks
     let platformCheckTasks = new Listr(platformTasks.preflightCheckTasks(flags, this), listrOptions)
@@ -104,7 +104,7 @@ export default class Update extends Command {
 
     // Checks if Eclipse Che is already deployed
     let preInstallTasks = new Listr(undefined, listrOptions)
-    preInstallTasks.add(k8sTasks.testApiTasks(flags, this))
+    preInstallTasks.add(apiTasks.testApiTasks(flags, this))
     preInstallTasks.add({
       title: '👀  Looking for an already existing Eclipse Che instance',
       task: () => new Listr(cheTasks.checkIfCheIsInstalledTasks(flags, this))

--- a/src/commands/workspace/logs.ts
+++ b/src/commands/workspace/logs.ts
@@ -17,7 +17,7 @@ import * as path from 'path'
 
 import { listrRenderer } from '../../common-flags'
 import { CheTasks } from '../../tasks/che'
-import { K8sTasks } from '../../tasks/platforms/k8s'
+import { ApiTasks } from '../../tasks/platforms/api'
 
 export default class Logs extends Command {
   static description = 'Collect workspace(s) logs'
@@ -47,10 +47,10 @@ export default class Logs extends Command {
     const { flags } = this.parse(Logs)
     ctx.directory = path.resolve(flags.directory ? flags.directory : path.resolve(os.tmpdir(), 'chectl-logs', Date.now().toString()))
     const cheTasks = new CheTasks(flags)
-    const k8sTasks = new K8sTasks()
+    const apiTasks = new ApiTasks()
 
     const tasks = new Listr([], { renderer: flags['listr-renderer'] as any })
-    tasks.add(k8sTasks.testApiTasks(flags, this))
+    tasks.add(apiTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.workspaceLogsTasks(flags.namespace, flags.workspace))
 
     try {

--- a/src/tasks/platforms/api.ts
+++ b/src/tasks/platforms/api.ts
@@ -1,0 +1,39 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { Command } from '@oclif/command'
+import * as Listr from 'listr'
+
+import { KubeHelper } from '../../api/kube'
+
+export class ApiTasks {
+   /**
+    * Returns tasks which tests if K8s or OpenShift API is configured in the current context.
+    *
+    * `isOpenShift` property is provisioned into context.
+    */
+  testApiTasks(flags: any, command: Command): Listr.ListrTask {
+    let kube = new KubeHelper(flags)
+    return {
+      title: 'Verify Kubernetes API',
+      task: async (ctx: any, task: any) => {
+        try {
+          await kube.checkKubeApi()
+          ctx.isOpenShift = await kube.isOpenShift()
+          task.title = await `${task.title}...OK`
+          if (ctx.isOpenShift) {
+            task.title = await `${task.title} (it's OpenShift)`
+          }
+        } catch (error) {
+          command.error(`Failed to connect to Kubernetes API. ${error.message}`)
+        }
+      }
+    }
+  }
+}

--- a/src/tasks/platforms/k8s.ts
+++ b/src/tasks/platforms/k8s.ts
@@ -17,30 +17,6 @@ import { VersionHelper } from '../../api/version'
 
 export class K8sTasks {
   /**
-   * Returns tasks which tests if K8s or OpenShift API is configured in the current context.
-   *
-   * `isOpenShift` property is provisioned into context.
-   */
-  testApiTasks(flags: any, command: Command): Listr.ListrTask {
-    let kube = new KubeHelper(flags)
-    return {
-      title: 'Verify Kubernetes API',
-      task: async (ctx: any, task: any) => {
-        try {
-          await kube.checkKubeApi()
-          ctx.isOpenShift = await kube.isOpenShift()
-          task.title = await `${task.title}...OK`
-          if (ctx.isOpenShift) {
-            task.title = await `${task.title} (it's OpenShift)`
-          }
-        } catch (error) {
-          command.error(`Failed to connect to Kubernetes API. ${error.message}`)
-        }
-      }
-    }
-  }
-
-  /**
    * Returns tasks list which perform preflight platform checks.
    */
   preflightCheckTasks(flags: any, command: Command): Listr {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,7 +1680,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#980379f3865dc339fd22c8aeaa8785c70012fd37"
+  resolved "git://github.com/eclipse/che#8eefc8ab12a7b8f5d010b88aaab1389b6b15fb42"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Move testApiTasks in a new ApiTask class to make it easier to sync in CRW downstream (as K8sTask is not present in it)

### What issues does this PR fix or reference?

