### PR TITLE
fix: Don't wait keycloak pod if externalIdentityProvider is set

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -998,7 +998,8 @@ export class KubeHelper {
     }
     const customObjectsApi = this.kc.makeApiClient(CustomObjectsApi)
     try {
-      return await customObjectsApi.createNamespacedCustomObject('org.eclipse.che', 'v1', cheNamespace, 'checlusters', yamlCr)
+      const { body } = await customObjectsApi.createNamespacedCustomObject('org.eclipse.che', 'v1', cheNamespace, 'checlusters', yamlCr)
+      return body
     } catch (e) {
       throw this.wrapK8sClientError(e)
     }

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -179,7 +179,9 @@ export class OperatorTasks {
             ctx.isDevfileRegistryDeployed = !(flags['devfile-registry-url'] as boolean)
 
             const yamlFilePath = flags['che-operator-cr-yaml'] === '' ? this.resourcesPath + 'crds/org_v1_che_cr.yaml' : flags['che-operator-cr-yaml']
-            await kube.createCheClusterFromFile(yamlFilePath, flags, flags['che-operator-cr-yaml'] === '')
+            const cr = await kube.createCheClusterFromFile(yamlFilePath, flags, flags['che-operator-cr-yaml'] === '')
+            ctx.isKeycloakReady = ctx.isKeycloakReady || cr.spec.auth.externalIdentityProvider
+
             task.title = `${task.title}...done.`
           }
         }


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Don't wait keycloak pod if externalIdentityProvider is set


