### PR TITLE
feat: Implement kube config injection on openshift cluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
     "postpack": "rm -f oclif.manifest.json",
     "format": "tsfmt -r --useTsfmt tsfmt.json",
     "tslint-fix": "tslint --fix -p test -t stylish",
-    "version": "oclif-dev readme && git add README.md"
+    "version": "oclif-dev readme && git add README.md",
+    "watch": "tsc --watch"
   },
   "types": "lib/index.d.ts",
   "jest": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,25 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as commandExists from 'command-exists'
+
+export const KUBERNETES_CLI = 'kubectl'
+export const OPENSHIFT_CLI = 'oc'
+
+export function getClusterClientCommand(): string {
+  const clusterClients = [KUBERNETES_CLI, OPENSHIFT_CLI]
+  for (const command of clusterClients) {
+    if (commandExists.sync(command)) {
+      return command
+    }
+  }
+
+  throw new Error('No cluster CLI client is installed.')
+}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Implements injection of Kubernetes config from host into Che workspace for Openshift infrastructure.
Also implements config injection for Openshift cluster with kubectl (yes, `kubectl` and `oc` is not interchangeable in all cases).

### How to test
Start your cluster, deploy Che on it. When ready run the following command:
```sh
chectl workspace:inject -k -c <container-name>
```

If one wants to test specific CLI tool (`oc` or `kubectl`) with the cluster, then one need to remove other options from CLI list in `getClusterClientCommand` function in `src/util.ts` file.

To be able to test in some local clusters which has 'bad' TLS certificate, one need to relogin with `--insecure-skip-tls-verify` option and run `chectl` (as described above) before autologout. For example, for CRC, the command might look like:
```sh
oc logout --insecure-skip-tls-verify && oc login -u kubeadmin -p BdTY8-Vra64-gD3cI-dAPS6 https://api.crc.testing:6443 --insecure-skip-tls-verify && ./run workspace:inject -k -c nodejs
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15987
