### PR TITLE
fix: Set dependency on the latest version of che-operator and che

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,11 +1676,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#41f00fff311ce341623d1682ac349a0d0d1826e5"
+  resolved "git://github.com/eclipse/che-operator#e9c5d3f312f07d73187075fcdd36423aae374edc"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#06b84a6f06059d56fc90a711777d2745acd7f1c6"
+  resolved "git://github.com/eclipse/che#444378684f44401898cfef95a3d37634464a891b"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Set dependency on the latest version of che-operator and che

### What issues does this PR fix or reference?
Fix PR check
