### PR TITLE
fix: Improve deployment of Cert Manager to support older Kubernetes versions

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -69,8 +69,8 @@ export class KubeHelper {
     }
   }
 
-  async applyResource(yamlPath: string): Promise<void> {
-    const command = `kubectl apply -f ${yamlPath}`
+  async applyResource(yamlPath: string, opts = ''): Promise<void> {
+    const command = `kubectl apply -f ${yamlPath} ${opts}`
     await execa(command, { timeout: 30000, shell: true })
   }
 

--- a/src/tasks/component-installers/cert-manager.ts
+++ b/src/tasks/component-installers/cert-manager.ts
@@ -47,7 +47,8 @@ export class CertManagerTasks {
         enabled: ctx => !ctx.certManagerInstalled,
         task: async (ctx: any, task: any) => {
           const yamlPath = path.join(flags.templates, '..', 'installers', 'cert-manager.yml')
-          await this.kubeHelper.applyResource(yamlPath)
+          // Apply additional --validate=false flag to be able to deploy Cert Manager on Kubernetes v1.15.4 or below
+          await this.kubeHelper.applyResource(yamlPath, '--validate=false')
           ctx.certManagerInstalled = true
 
           task.title = `${task.title}...done`


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Fixes deployment of Cert Manager to be able to use Kubernetes v1.15.4 or older.

Tested with Kubernetes v1.12.0
