### PR TITLE
fix: Fix non-Helm installers

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -236,7 +236,7 @@ export default class Start extends Command {
     ctx.listrOptions = listrOptions
 
     // TODO when tls by default is implemented for all platforms, make `tls` flag turned on by default.
-    if (flags.platform === 'k8s' || flags.platform === 'minikube' || flags.platform === 'microk8s') {
+    if (flags.installer === 'helm' && (flags.platform === 'k8s' || flags.platform === 'minikube' || flags.platform === 'microk8s')) {
       flags.tls = true
     }
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Fixes condition which sets TLS by default flag, so it will not be forced for other than Helm installers any more.

