### PR TITLE
fix: Run basic e2e tests on every PR.

### DIFF
--- a/.ci/cico_chectl_prcheck.sh
+++ b/.ci/cico_chectl_prcheck.sh
@@ -49,11 +49,17 @@ cleanup() {
   rm -rf ~/.minishift ~/.kube ~/.minikube
 }
 
+#Call all necesaries dependencies to install from {PROJECT_PATH/.ci/ci.common.sh}
 install_utilities() {
   helm_install
+  install_required_packages
+  setup_kvm_machine_driver
+  start_libvirt
+  install_node_deps
 }
 
 run() {
+  #Before to start to run the e2e tests we need to install all deps with yarn
   yarn --cwd ${CHECTL_REPO}
   for platform in 'minishift' 'minikube'
   do
@@ -62,6 +68,7 @@ run() {
 
         printInfo "Running e2e tests on ${platform} platform."
         yarn test --coverage=false --forceExit --testRegex=${CHECTL_REPO}/test/e2e/minishift.test.ts
+        #Clearing minishift installation from system
         yes | minishift delete --profile ${PROFILE}
         rm -rf ~/.minishift
       fi

--- a/.ci/cico_chectl_prcheck.sh
+++ b/.ci/cico_chectl_prcheck.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+set -e -x
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+
+init() {
+  SCRIPT=$(readlink -f "$0")
+  SCRIPTPATH=$(dirname "$SCRIPT")
+  PROFILE=chectl-e2e-tests
+
+  # Environment to define the project absolute path.
+  if [[ ${WORKSPACE} ]] && [[ -d ${WORKSPACE} ]]; then
+    CHECTL_REPO=${WORKSPACE};
+  else
+    CHECTL_REPO=$(dirname "$SCRIPTPATH");
+  fi
+
+  #Create tmp path for binaries installations.
+  if [ ! -d "$CHECTL_REPO/tmp" ]; then mkdir -p "$CHECTL_REPO/tmp" && chmod 777 "$CHECTL_REPO/tmp"; fi
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+  result=$?
+  if [ "$result" != "0" ]; then
+    printError "Please check CI fail.Cleaning up minikube and minishift..."
+  fi
+  cleanup
+  exit $result
+}
+
+# cleanup temporary files or minikube/minishift installations.
+cleanup() {
+  set +e
+  yes | minishift delete --profile ${PROFILE}
+  minikube delete --profile ${PROFILE}
+  rm -rf ~/.minishift ~/.kube ~/.minikube
+}
+
+install_utilities() {
+  helm_install
+}
+
+run() {
+  yarn --cwd ${CHECTL_REPO}
+  for platform in 'minishift' 'minikube'
+  do
+      if [[ ${platform} == 'minishift' ]]; then
+        minishift_installation
+
+        printInfo "Running e2e tests on ${platform} platform."
+        yarn test --coverage=false --forceExit --testRegex=${CHECTL_REPO}/test/e2e/minishift.test.ts
+        yes | minishift delete --profile ${PROFILE}
+        rm -rf ~/.minishift
+      fi
+      if [[ ${platform} == 'minikube' ]]; then
+        minikube_installation
+
+        sleep 60
+        printInfo "Running e2e tests on ${platform} platform."
+        yarn test --coverage=false --forceExit --testRegex=${CHECTL_REPO}/test/e2e/minikube.test.ts
+      fi
+  done
+}
+
+init
+
+source ${CHECTL_REPO}/.ci/cico_common.sh
+install_utilities
+run

--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+RAM_MEMORY=8192
+MSFT_RELEASE="1.34.2"
+
+printInfo() {
+  set +x
+  echo ""
+  echo "[=============== [INFO] $1 ===============]"
+}
+
+printWarn() {
+  set +x
+  echo ""
+  echo "[=============== [WARN] $1 ===============]"
+}
+
+printError() {
+  set +x
+  echo ""
+  echo "[=============== [ERROR] $1 ===============]"
+}
+
+
+helm_install() {
+  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+}
+
+install_required_packages() {
+  # Install EPEL repo
+  # Get all the deps in
+  yum -y install libvirt qemu-kvm
+  printInfo 'Installing required virtualization packages installed'
+}
+
+start_libvirt() {
+  systemctl start libvirtd
+}
+
+setup_kvm_machine_driver() {
+  printInfo "Installing docker machine kvm drivers"
+  curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/v0.10.0/docker-machine-driver-kvm-centos7 -o /usr/bin/docker-machine-driver-kvm
+  chmod +x /usr/bin/docker-machine-driver-kvm
+  check_libvirtd=$(systemctl is-active libvirtd)
+  if [ $check_libvirtd != 'active' ]; then
+    virsh net-start default
+  fi
+}
+
+minishift_installation() {
+  printInfo "Downloading Minishift binaries"
+  curl -L https://github.com/minishift/minishift/releases/download/v$MSFT_RELEASE/minishift-$MSFT_RELEASE-linux-amd64.tgz \
+    -o ${CHECTL_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar && tar -xvf ${CHECTL_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar -C /usr/bin --strip-components=1
+  echo "[INFO] Starting a new OC cluster."
+  minishift profile set ${PROFILE}
+  minishift start --memory=${RAM_MEMORY} && eval $(minishift oc-env)
+  oc login -u system:admin
+  printInfo "Successfully installed and initialized minishift"
+}
+
+minikube_installation() {
+  if ! [ -x "$(command -v minikube)" ]; then
+    printInfo "Installing minikube..."
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.28.2/minikube-linux-amd64 > ${CHECTL_REPO}/tmp/minikube
+    chmod +x ${CHECTL_REPO}/tmp/minikube
+    cp ${CHECTL_REPO}/tmp/minikube /usr/local/bin/
+
+  else
+    printInfo "Minikube is already installed"
+  fi
+  minikube start --memory=${RAM_MEMORY} -p ${PROFILE}
+  minikube profile ${PROFILE}
+}

--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -38,13 +38,27 @@ helm_install() {
 
 install_required_packages() {
   # Install EPEL repo
+  if yum repolist | grep epel; then
+    printInfo "Epel already installed, skipping instalation."
+  else
+    #excluding mirror1.ci.centos.org
+    printInfo "Installing epel..."
+    yum install -d1 --assumeyes epel-release
+    yum update --assumeyes -d1
+  fi
   # Get all the deps in
-  yum -y install libvirt qemu-kvm
   printInfo 'Installing required virtualization packages installed'
+  yum -y install libvirt qemu-kvm
 }
 
 start_libvirt() {
   systemctl start libvirtd
+}
+
+install_node_deps() {
+  curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+  yum-config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
+  yum install -y nodejs yarn
 }
 
 setup_kvm_machine_driver() {

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -32,7 +32,7 @@ describe('e2e test', () => {
       .exit(0)
       .it('uses minikube as platform, helm as installer and auth is disabled', ctx => {
         expect(ctx.stdout).to.contain('Minikube preflight checklist')
-          .and.to.contain('Running Helm')
+          .and.to.contain('Running Helm to install Eclipse Che')
           .and.to.contain('Post installation checklist')
           .and.to.contain('Command server:start has completed successfully')
       })
@@ -43,7 +43,7 @@ describe('e2e test', () => {
       .it('stops Server on minikube successfully')
     test
       .stdout()
-      .command(['server:delete', '--listr-renderer=verbose'])
+      .command(['server:delete','--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
       .it('deletes Che resources on minikube successfully')
   })
@@ -73,9 +73,8 @@ describe('e2e test', () => {
       .exit(0)
       .it('stops Server on minikube successfully')
     test
-      .skip()
       .stdout()
-      .command(['server:delete', '--listr-renderer=verbose'])
+      .command(['server:delete','--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
       .it('deletes Che resources on minikube successfully')
   })

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -34,7 +34,7 @@ describe('e2e test', () => {
       .exit(0)
       .it('uses minishift as platform, minishift-addon as installer and auth is disabled', ctx => {
         expect(ctx.stdout).to.contain('Minishift preflight checklist')
-          .and.to.contain('Running the Che minishift-addon')
+          .and.to.contain('Running the Eclipse Che minishift-addon')
           .and.to.contain('Post installation checklist')
           .and.to.contain('Command server:start has completed successfully')
       })
@@ -45,7 +45,7 @@ describe('e2e test', () => {
       .it('stops Server on minishift successfully')
     test
       .stdout()
-      .command(['server:delete', '--listr-renderer=verbose'])
+      .command(['server:delete','--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
       .it('deletes Che resources on minishift successfully')
   })
@@ -75,9 +75,8 @@ describe('e2e test', () => {
       .exit(0)
       .it('stops Server on Minishift successfully')
     test
-      .skip()
       .stdout()
-      .command(['server:delete', '--listr-renderer=verbose'])
+      .command(['server:delete', '--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
       .it('deletes Che resources on Minishift successfully')
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,7 +1469,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#e59b582d872dd7b714d2542463cbfee638512d3d"
+  resolved "git://github.com/eclipse/che#2ef1d2bfe4cb60bf3feabc116b752d11d3a6977e"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Create setup scripts which execute e2e tests in minikube platform and also minishift. The basic e2e test cover the basic install of Eclipse Che without security enabled, Install che with multiuser enabled and auth.Also the test include the deletion of che deployments.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15815
