### PR TITLE
fix: up che name so it's always 'Eclipse Che'...

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ OPTIONS
   -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Eclipse Che server is supposed to
                                            be deployed
 
-  --debug-port=debug-port                  [default: 8000] Eclipse Che Server debug port
+  --debug-port=debug-port                  [default: 8000] Eclipse Che server debug port
 
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 ```
@@ -235,7 +235,7 @@ _See code: [src/commands/server/logs.ts](https://github.com/che-incubator/chectl
 
 ## `chectl server:start`
 
-start Eclipse Che Server
+start Eclipse Che server
 
 ```
 USAGE
@@ -255,16 +255,16 @@ OPTIONS
       show CLI help
 
   -i, --cheimage=cheimage
-      [default: quay.io/eclipse/che-server:nightly] Che server container image
+      [default: quay.io/eclipse/che-server:nightly] Eclipse Che server container image
 
   -m, --multiuser
-      Starts che in multi-user mode
+      Starts Eclipse Che in multi-user mode
 
   -n, --chenamespace=chenamespace
       [default: che] Kubernetes namespace where Eclipse Che server is supposed to be deployed
 
   -o, --cheboottimeout=cheboottimeout
-      (required) [default: 40000] Che server bootstrap timeout (in milliseconds)
+      (required) [default: 40000] Eclipse Che server bootstrap timeout (in milliseconds)
 
   -p, --platform=minikube|minishift|k8s|openshift|microk8s|docker-desktop|crc
       Type of Kubernetes platform. Valid values are "minikube", "minishift", "k8s (for kubernetes)", "openshift", "crc 
@@ -293,7 +293,7 @@ OPTIONS
       the installer is the operator
 
   --debug
-      Enables the debug mode for Che server. To debug Eclipse Che Server from localhost use 'server:debug' command.
+      Enables the debug mode for Eclipse Che server. To debug Eclipse Che server from localhost use 'server:debug' command.
 
   --deployment-name=deployment-name
       [default: che] Eclipse Che deployment name
@@ -317,11 +317,11 @@ OPTIONS
       The URL of the external plugin registry.
 
   --postgres-pvc-storage-class-name=postgres-pvc-storage-class-name
-      persistent volume storage class name to use to store Eclipse Che Postgres database
+      persistent volume storage class name to use to store Eclipse Che postgres database
 
   --self-signed-cert
       Authorize usage of self signed certificates for encryption.
-                           This is the flag for Che to propagate the certificate to components, so they will trust it.
+                           This is the flag for Eclipse Che to propagate the certificate to components, so they will trust it.
                            Note that `che-tls` secret with CA certificate must be created in the configured namespace.
 
   --skip-version-check
@@ -335,7 +335,7 @@ _See code: [src/commands/server/start.ts](https://github.com/che-incubator/chect
 
 ## `chectl server:stop`
 
-stop Eclipse Che Server
+stop Eclipse Che server
 
 ```
 USAGE
@@ -349,7 +349,7 @@ OPTIONS
 
   --access-token=access-token              Eclipse Che OIDC Access Token
 
-  --che-selector=che-selector              [default: app=che,component=che] Selector for Eclipse Che Server resources
+  --che-selector=che-selector              [default: app=che,component=che] Selector for Eclipse Che server resources
 
   --deployment-name=deployment-name        [default: che] Eclipse Che deployment name
 
@@ -360,7 +360,7 @@ _See code: [src/commands/server/stop.ts](https://github.com/che-incubator/chectl
 
 ## `chectl server:update`
 
-update Eclipse Che Server
+update Eclipse Che server
 
 ```
 USAGE

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     ],
     "topics": {
       "server": {
-        "description": "control Che server"
+        "description": "control Eclipse Che server"
       },
       "workspace": {
         "description": "control Che workspaces"

--- a/src/commands/devfile/generate.ts
+++ b/src/commands/devfile/generate.ts
@@ -73,7 +73,7 @@ export default class Generate extends Command {
       required: false,
     }),
     plugin: string({
-      description: 'Che plugin to include in the workspace. The format is JSON. For example this is a valid Che Plugin specification: {"type": "TheEndpointName.ChePlugin", "alias": "java-ls", "id": "redhat/java/0.38.0"}',
+      description: 'Eclipse Che plugin to include in the workspace. The format is JSON. For example this is a valid Eclipse Che plugin specification: {"type": "TheEndpointName.ChePlugin", "alias": "java-ls", "id": "redhat/java/0.38.0"}',
       env: 'CHE_PLUGIN',
       required: false,
     }),

--- a/src/commands/server/debug.ts
+++ b/src/commands/server/debug.ts
@@ -24,7 +24,7 @@ export default class Debug extends Command {
     chenamespace: cheNamespace,
     'listr-renderer': listrRenderer,
     'debug-port': integer({
-      description: 'Eclipse Che Server debug port',
+      description: 'Eclipse Che server debug port',
       default: 8000
     })
   }
@@ -43,7 +43,7 @@ export default class Debug extends Command {
 
     try {
       await tasks.run(ctx)
-      this.log(`Eclipse Che Server debug is available on localhost:${flags['debug-port']}.`)
+      this.log(`Eclipse Che server debug is available on localhost:${flags['debug-port']}.`)
       this.log('The program keeps running to enable port forwarding.')
     } catch (error) {
       this.error(error)

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -24,7 +24,7 @@ import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
 
 export default class Start extends Command {
-  static description = 'start Eclipse Che Server'
+  static description = 'start Eclipse Che server'
 
   static flags = {
     help: flags.help({ char: 'h' }),
@@ -81,7 +81,7 @@ export default class Start extends Command {
     }),
     'self-signed-cert': flags.boolean({
       description: `Authorize usage of self signed certificates for encryption.
-                    This is the flag for Che to propagate the certificate to components, so they will trust it.
+                    This is the flag for Eclipse Che to propagate the certificate to components, so they will trust it.
                     Note that \`che-tls\` secret with CA certificate must be created in the configured namespace.`,
       default: false
     }),
@@ -102,7 +102,7 @@ export default class Start extends Command {
       default: ''
     }),
     debug: boolean({
-      description: 'Enables the debug mode for Eclipse Che server. To debug Eclipse Che Server from localhost use \'server:debug\' command.',
+      description: 'Enables the debug mode for Eclipse Che server. To debug Eclipse Che server from localhost use \'server:debug\' command.',
       default: false
     }),
     'os-oauth': flags.boolean({
@@ -132,7 +132,7 @@ export default class Start extends Command {
       default: ''
     }),
     'postgres-pvc-storage-class-name': string({
-      description: 'persistent volume storage class name to use to store Eclipse Che Postgres database',
+      description: 'persistent volume storage class name to use to store Eclipse Che postgres database',
       default: ''
     }),
     'skip-version-check': flags.boolean({
@@ -215,7 +215,7 @@ export default class Start extends Command {
     if (flags.installer) {
       if (flags.installer === 'minishift-addon') {
         if (flags.platform !== 'minishift') {
-          this.error(`🛑 Current platform is ${flags.platform}. Minishift addon is only available on top of Minishift platform.`)
+          this.error(`🛑 Current platform is ${flags.platform}. Minishift-addon is only available for Minishift.`)
         }
       } else if (flags.installer === 'helm') {
         if (flags.platform !== 'k8s' && flags.platform !== 'minikube' && flags.platform !== 'microk8s' && flags.platform !== 'docker-desktop') {

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -33,7 +33,7 @@ export default class Start extends Command {
     'deployment-name': cheDeployment,
     cheimage: string({
       char: 'i',
-      description: 'Che server container image',
+      description: 'Eclipse Che server container image',
       default: DEFAULT_CHE_IMAGE,
       env: 'CHE_CONTAINER_IMAGE'
     }),
@@ -53,7 +53,7 @@ export default class Start extends Command {
     }),
     cheboottimeout: string({
       char: 'o',
-      description: 'Che server bootstrap timeout (in milliseconds)',
+      description: 'Eclipse Che server bootstrap timeout (in milliseconds)',
       default: '40000',
       required: true,
       env: 'CHE_SERVER_BOOT_TIMEOUT'
@@ -68,7 +68,7 @@ export default class Start extends Command {
     }),
     multiuser: flags.boolean({
       char: 'm',
-      description: 'Starts che in multi-user mode',
+      description: 'Starts Eclipse Che in multi-user mode',
       default: false
     }),
     tls: flags.boolean({
@@ -102,7 +102,7 @@ export default class Start extends Command {
       default: ''
     }),
     debug: boolean({
-      description: 'Enables the debug mode for Che server. To debug Eclipse Che Server from localhost use \'server:debug\' command.',
+      description: 'Enables the debug mode for Eclipse Che server. To debug Eclipse Che Server from localhost use \'server:debug\' command.',
       default: false
     }),
     'os-oauth': flags.boolean({

--- a/src/commands/server/stop.ts
+++ b/src/commands/server/stop.ts
@@ -16,14 +16,14 @@ import { CheTasks } from '../../tasks/che'
 import { ApiTasks } from '../../tasks/platforms/api'
 
 export default class Stop extends Command {
-  static description = 'stop Eclipse Che Server'
+  static description = 'stop Eclipse Che server'
 
   static flags = {
     help: flags.help({ char: 'h' }),
     chenamespace: cheNamespace,
     'deployment-name': cheDeployment,
     'che-selector': string({
-      description: 'Selector for Eclipse Che Server resources',
+      description: 'Selector for Eclipse Che server resources',
       default: 'app=che,component=che',
       env: 'CHE_SELECTOR'
     }),
@@ -52,7 +52,7 @@ export default class Stop extends Command {
         title: 'Deployment doesn\'t exist',
         enabled: (ctx: any) => !ctx.isCheDeployed,
         task: async () => {
-          await this.error(`E_BAD_DEPLOY - Deployment do not exist.\nA Deployment named "${flags['deployment-name']}" exist in namespace \"${flags.chenamespace}\", Eclipse Che Server cannot be stopped.\nFix with: verify the namespace where Eclipse Che is running (oc get projects)\nhttps://github.com/eclipse/che`, { code: 'E_BAD_DEPLOY' })
+          await this.error(`E_BAD_DEPLOY - Deployment do not exist.\nA Deployment named "${flags['deployment-name']}" exist in namespace \"${flags.chenamespace}\", Eclipse Che server cannot be stopped.\nFix with: verify the namespace where Eclipse Che is running (oc get projects)\nhttps://github.com/eclipse/che`, { code: 'E_BAD_DEPLOY' })
         }
       },
       {
@@ -61,7 +61,7 @@ export default class Stop extends Command {
         task: async () => { }
       },
       {
-        title: 'Eclipse Che server Pod is not ready. It may be failing to start. Skipping shutdown request',
+        title: 'Eclipse Che server pod is not ready. It may be failing to start. Skipping shutdown request',
         enabled: (ctx: any) => (ctx.isNotReadyYet),
         task: async () => { }
       }

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -24,7 +24,7 @@ import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
 
 export default class Update extends Command {
-  static description = 'update Eclipse Che Server'
+  static description = 'update Eclipse Che server'
 
   static flags = {
     installer: string({
@@ -132,8 +132,8 @@ export default class Update extends Command {
         if (!flags['skip-version-check']) {
           await cli.anykey(`      Found deployed Eclipse Che with operator [${ctx.deployedCheOperatorImage}]:${ctx.deployedCheOperatorTag}.
       You are going to update it to [${ctx.newCheOperatorImage}]:${ctx.newCheOperatorTag}.
-      Note that Che Operator will update component images (server, plugin registry) only if their values
-      are not overridden in eclipse-che Customer Resource. So, you may need to remove them manually.
+      Note that Eclipse Che operator will update component images (server, plugin registry) only if their values
+      are not overridden in eclipse-che Custom Resource. So, you may need to remove them manually.
       Press q to quit or any key to continue`)
         }
 

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -132,7 +132,7 @@ export default class Update extends Command {
         if (!flags['skip-version-check']) {
           await cli.anykey(`      Found deployed Eclipse Che with operator [${ctx.deployedCheOperatorImage}]:${ctx.deployedCheOperatorTag}.
       You are going to update it to [${ctx.newCheOperatorImage}]:${ctx.newCheOperatorTag}.
-      Note that Che Operator will update components images (che server, plugin registry) only if their values
+      Note that Che Operator will update component images (server, plugin registry) only if their values
       are not overridden in eclipse-che Customer Resource. So, you may need to remove them manually.
       Press q to quit or any key to continue`)
         }

--- a/src/commands/workspace/inject.ts
+++ b/src/commands/workspace/inject.ts
@@ -35,7 +35,7 @@ export default class Inject extends Command {
     }),
     workspace: string({
       char: 'w',
-      description: 'Target workspace. Can be omitted if only one Workspace is running'
+      description: 'Target workspace. Can be omitted if only one workspace is running'
     }),
     container: string({
       char: 'c',

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -57,7 +57,7 @@ export default class Start extends Command {
     }
     const tasks = new Listr([
       {
-        title: 'Retrieving Eclipse Che Server URL',
+        title: 'Retrieving Eclipse Che server URL',
         task: async (ctx: any, task: any) => {
           ctx.cheURL = await che.cheURL(flags.chenamespace)
           task.title = await `${task.title}... ${ctx.cheURL}`
@@ -67,7 +67,7 @@ export default class Start extends Command {
         title: 'Verify if Eclipse Che server is running',
         task: async (ctx: any, task: any) => {
           if (!await che.isCheServerReady(ctx.cheURL)) {
-            this.error(`E_SRV_NOT_RUNNING - Eclipse Che Server is not available by ${ctx.cheURL}`, { code: 'E_SRV_NOT_RUNNNG' })
+            this.error(`E_SRV_NOT_RUNNING - Eclipse Che server is not available by ${ctx.cheURL}`, { code: 'E_SRV_NOT_RUNNNG' })
           }
           const status = await che.getCheServerStatus(ctx.cheURL)
           ctx.isAuthEnabled = await che.isAuthenticationEnabled(ctx.cheURL)

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -91,7 +91,7 @@ export class CheTasks {
         task: () => this.kubeTasks.podStartTasks(command, this.cheSelector, this.cheNamespace)
       },
       {
-        title: 'Retrieving Eclipse Che Server URL',
+        title: 'Retrieving Eclipse Che server URL',
         task: async (ctx: any, task: any) => {
           ctx.cheURL = await this.che.cheURL(flags.chenamespace)
           task.title = await `${task.title}... ${ctx.cheURL}`
@@ -117,7 +117,7 @@ export class CheTasks {
         title: `Verify if Eclipse Che is deployed into namespace \"${this.cheNamespace}\"`,
         task: async (ctx: any, task: any) => {
           if (await this.kube.deploymentExist(this.cheDeploymentName, this.cheNamespace)) {
-            // helm chart and Che Operator use a deployment
+            // helm chart and Eclipse Che operator use a deployment
             ctx.isCheDeployed = true
             ctx.isCheReady = await this.kube.deploymentReady(this.cheDeploymentName, this.cheNamespace)
             if (!ctx.isCheReady) {
@@ -163,7 +163,7 @@ export class CheTasks {
             return new Listr([
               {
                 enabled: () => ctx.isCheDeployed,
-                title: `Found ${ctx.isCheStopped ? 'stopped' : 'running'} che deployment`,
+                title: `Found ${ctx.isCheStopped ? 'stopped' : 'running'} Eclipse Che deployment`,
                 task: () => { }
               },
               {
@@ -412,7 +412,7 @@ export class CheTasks {
         }
       },
       {
-        title: 'Delete configmaps che and che-operator',
+        title: 'Delete configmaps for Eclipse Che server and operator',
         task: async (_ctx: any, task: any) => {
           if (await this.kube.getConfigMap('che', flags.chenamespace)) {
             await this.kube.deleteConfigMap('che', flags.chenamespace)
@@ -568,11 +568,11 @@ export class CheTasks {
   debugTask(flags: any): ReadonlyArray<Listr.ListrTask> {
     return [
       {
-        title: 'Find Che Server pod',
+        title: 'Find Eclipse Che server pod',
         task: async (ctx: any, task: any) => {
           const chePods = await this.kube.listNamespacedPod(flags.chenamespace, undefined, this.cheSelector)
           if (chePods.items.length === 0) {
-            throw new Error(`Che Server pod not found in the namespace '${flags.chenamespace}'`)
+            throw new Error(`Eclipse Che server pod not found in the namespace '${flags.chenamespace}'`)
           }
           ctx.podName = chePods.items[0].metadata!.name!
           task.title = `${task.title}...done`
@@ -583,7 +583,7 @@ export class CheTasks {
         task: async (task: any) => {
           const configMap = await this.kube.getConfigMap('che', flags.chenamespace)
           if (!configMap || configMap.data!.CHE_DEBUG_SERVER !== 'true') {
-            throw new Error('Che Server should be redeployed with \'--debug\' flag')
+            throw new Error('Eclipse Che server should be redeployed with \'--debug\' flag')
           }
 
           task.title = `${task.title}...done`

--- a/src/tasks/component-installers/cert-manager.ts
+++ b/src/tasks/component-installers/cert-manager.ts
@@ -125,7 +125,7 @@ export class CertManagerTasks {
         }
       },
       {
-        title: 'Set up Che certificates issuer',
+        title: 'Set up Eclipse Che certificates issuer',
         task: async (_ctx: any, task: any) => {
           const cheClusterIssuerExists = await this.kubeHelper.clusterIssuerExists('che-cluster-issuer')
           if (!cheClusterIssuerExists) {
@@ -142,7 +142,7 @@ export class CertManagerTasks {
         title: 'Request self-signed certificate',
         task: async (ctx: any, task: any) => {
           if (ctx.cheCertificateExists) {
-            throw new Error('Che certificate already exists.')
+            throw new Error('Eclipse Che certificate already exists.')
           }
 
           const certificateTemplatePath = path.join(flags.templates, '/cert-manager/che-certificate.yml')
@@ -161,7 +161,7 @@ export class CertManagerTasks {
         }
       },
       {
-        title: 'Add local Che CA certificate into browser',
+        title: 'Add local Eclipse Che CA certificate into browser',
         task: async (_ctx: any, task: any) => {
           const cheSecret = await this.kubeHelper.getSecret(CHE_TLS_SECRET_NAME, flags.chenamespace)
           if (cheSecret && cheSecret.data) {
@@ -171,7 +171,7 @@ export class CertManagerTasks {
 
             const yellow = '\x1b[33m'
             const noColor = '\x1b[0m'
-            task.title = `❗${yellow}[MANUAL ACTION REQUIRED]${noColor} Please add local Che CA certificate into your browser: ${cheCaPublicCertPath}`
+            task.title = `❗${yellow}[MANUAL ACTION REQUIRED]${noColor} Please add local Eclipse Che CA certificate into your browser: ${cheCaPublicCertPath}`
           } else {
             throw new Error('Failed to get Cert Manager CA secret')
           }

--- a/src/tasks/installers/helm.ts
+++ b/src/tasks/installers/helm.ts
@@ -72,7 +72,7 @@ export class HelmTasks {
         }
       },
       {
-        title: 'Check Che TLS certificate',
+        title: 'Check Eclipse Che TLS certificate',
         task: async (ctx: any, task: any) => {
           const cheTlsSecret = await this.kubeHelper.getSecret(CHE_TLS_SECRET_NAME, flags.chenamespace)
 
@@ -85,7 +85,7 @@ export class HelmTasks {
 
             task.title = `${task.title}...self-signed certificate secret found`
           } else {
-            // TLS certificate for Che hasn't been added into the cluster manually, so we need to take care about it automatically
+            // TLS certificate for Eclipse Che hasn't been added into the cluster manually, so we need to take care about it automatically
             ctx.cheCertificateExists = false
             // Set self-signed certificate flag to true as we are going to generate one
             flags['self-signed-cert'] = true
@@ -160,7 +160,7 @@ export class HelmTasks {
         }
       },
       {
-        title: 'Preparing Che Helm Chart',
+        title: 'Preparing Eclipse Che Helm Chart',
         task: async (_ctx: any, task: any) => {
           await this.prepareCheHelmChart(flags, command.config.cacheDir)
           task.title = `${task.title}...done.`
@@ -174,7 +174,7 @@ export class HelmTasks {
         }
       },
       {
-        title: 'Deploying Che Helm Chart',
+        title: 'Deploying Eclipse Che Helm Chart',
         task: async (ctx: any, task: any) => {
           await this.upgradeCheHelmChart(ctx, flags, command.config.cacheDir)
           task.title = `${task.title}...done.`
@@ -188,7 +188,7 @@ export class HelmTasks {
    */
   deleteTasks(_flags: any): ReadonlyArray<Listr.ListrTask> {
     return [{
-      title: 'Purge che Helm chart',
+      title: 'Purge Eclipse Che Helm chart',
       enabled: (ctx: any) => !ctx.isOpenShift,
       task: async (_ctx: any, task: any) => {
         if (await !commandExists.sync('helm')) {

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -27,7 +27,7 @@ export class InstallerTasks {
 
     // let task: Listr.ListrTask
     if (flags.installer === 'operator') {
-      title = '🏃‍  Running the Che Operator Update'
+      title = '🏃‍  Running the Eclipse Che Operator Update'
       task = () => {
         return operatorTasks.updateTasks(flags, command)
       }
@@ -50,7 +50,7 @@ export class InstallerTasks {
 
     // let task: Listr.ListrTask
     if (flags.installer === 'operator') {
-      title = '🏃‍  Running the Che Operator Update'
+      title = '🏃‍  Running the Eclipse Che Operator Update'
       task = () => {
         return operatorTasks.preUpdateTasks(flags, command)
       }
@@ -78,7 +78,7 @@ export class InstallerTasks {
       title = '🏃‍  Running Helm to install Eclipse Che'
       task = () => helmTasks.startTasks(flags, command)
     } else if (flags.installer === 'operator') {
-      title = '🏃‍  Running the Che Operator'
+      title = '🏃‍  Running the Eclipse Che Operator'
       task = () => {
         // The operator installs Eclipse Che multiuser only
         if (!flags.multiuser) {

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -27,7 +27,7 @@ export class InstallerTasks {
 
     // let task: Listr.ListrTask
     if (flags.installer === 'operator') {
-      title = '🏃‍  Running the Eclipse Che Operator Update'
+      title = '🏃‍  Running the Eclipse Che operator Update'
       task = () => {
         return operatorTasks.updateTasks(flags, command)
       }
@@ -50,7 +50,7 @@ export class InstallerTasks {
 
     // let task: Listr.ListrTask
     if (flags.installer === 'operator') {
-      title = '🏃‍  Running the Eclipse Che Operator Update'
+      title = '🏃‍  Running the Eclipse Che operator Update'
       task = () => {
         return operatorTasks.preUpdateTasks(flags, command)
       }
@@ -78,9 +78,9 @@ export class InstallerTasks {
       title = '🏃‍  Running Helm to install Eclipse Che'
       task = () => helmTasks.startTasks(flags, command)
     } else if (flags.installer === 'operator') {
-      title = '🏃‍  Running the Eclipse Che Operator'
+      title = '🏃‍  Running the Eclipse Che operator'
       task = () => {
-        // The operator installs Eclipse Che multiuser only
+        // The operator installs Eclipse Che in multiuser mode only
         if (!flags.multiuser) {
           command.warn("Eclipse Che will be deployed in Multi-User mode as 'operator' installer supports only that mode.")
           flags.multiuser = true

--- a/src/tasks/installers/minishift-addon.ts
+++ b/src/tasks/installers/minishift-addon.ts
@@ -30,7 +30,7 @@ export class MinishiftAddonTasks {
         task: async (_ctx: any, task: any) => {
           const version = await this.grabVersion()
           if (version < 133) {
-            command.error('The minishift che addon is requiring minishift version >= 1.33.0. Please update your minishift installation with "minishift update" command.')
+            command.error('The Eclipse Che minishift-addon requires minishift version >= 1.33.0. Please update your minishift installation with "minishift update" command.')
           }
           task.title = `${task.title}...done.`
         }
@@ -50,14 +50,14 @@ export class MinishiftAddonTasks {
         }
       },
       {
-        title: 'Check che addon is available',
+        title: 'Check Eclipse Che addon is available',
         task: async (_ctx: any, task: any) => {
           await this.installAddonIfMissing(resourcesPath)
           task.title = `${task.title}...done.`
         }
       },
       {
-        title: 'Apply Che addon',
+        title: 'Apply Eclipse Che addon',
         task: async (ctx: any, task: any) => {
           await this.applyAddon(flags)
           ctx.isCheDeployed = true
@@ -74,7 +74,7 @@ export class MinishiftAddonTasks {
    */
   deleteTasks(_flags: any): ReadonlyArray<Listr.ListrTask> {
     return [{
-      title: 'Remove Che minishift addon',
+      title: 'Remove Eclipse Che minishift-addon',
       enabled: (ctx: any) => ctx.isOpenShift,
       task: async (_ctx: any, task: any) => {
         if (!commandExists.sync('minishift')) {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -163,13 +163,13 @@ export class OperatorTasks {
         }
       },
       {
-        title: `Create Eclipse Che Cluster ${this.operatorCheCluster} in namespace ${flags.chenamespace}`,
+        title: `Create Eclipse Che cluster ${this.operatorCheCluster} in namespace ${flags.chenamespace}`,
         task: async (ctx: any, task: any) => {
           const exist = await kube.cheClusterExist(this.operatorCheCluster, flags.chenamespace)
           if (exist) {
             task.title = `${task.title}...It already exists.`
           } else {
-            // Eclipse Che Operator supports only Multi-User Che
+            // Eclipse Che operator supports only Multi-User Che
             ctx.isCheDeployed = true
             ctx.isPostgresDeployed = true
             ctx.isKeycloakDeployed = true
@@ -307,7 +307,7 @@ export class OperatorTasks {
         }
       },
       {
-        title: `Updating Eclipse Che Cluster CRD ${this.cheClusterCrd}`,
+        title: `Updating Eclipse Che cluster CRD ${this.cheClusterCrd}`,
         task: async (_ctx: any, task: any) => {
           const crd = await kube.getCrd(this.cheClusterCrd)
           const yamlFilePath = this.resourcesPath + 'crds/org_v1_che_crd.yaml'
@@ -355,7 +355,7 @@ export class OperatorTasks {
   }
 
   /**
-   * Returns list of tasks which remove Eclipse Che Operator related resources
+   * Returns list of tasks which remove Eclipse Che operator related resources
    */
   deleteTasks(flags: any): ReadonlyArray<Listr.ListrTask> {
     let kh = new KubeHelper(flags)

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -169,7 +169,7 @@ export class OperatorTasks {
           if (exist) {
             task.title = `${task.title}...It already exists.`
           } else {
-            // Che Operator supports only Multi-User Che
+            // Eclipse Che Operator supports only Multi-User Che
             ctx.isCheDeployed = true
             ctx.isPostgresDeployed = true
             ctx.isKeycloakDeployed = true
@@ -355,7 +355,7 @@ export class OperatorTasks {
   }
 
   /**
-   * Returns list of tasks which remove Che Operator related resources
+   * Returns list of tasks which remove Eclipse Che Operator related resources
    */
   deleteTasks(flags: any): ReadonlyArray<Listr.ListrTask> {
     let kh = new KubeHelper(flags)

--- a/test/api/che.test.ts
+++ b/test/api/che.test.ts
@@ -23,7 +23,7 @@ let kube = ch.kube
 let oc = ch.oc
 let k8sApi = new CoreV1Api()
 
-describe('Che helper', () => {
+describe('Eclipse Che helper', () => {
   describe('cheURL', () => {
     fancy
       .stub(ch, 'cheNamespaceExist', () => true)
@@ -31,7 +31,7 @@ describe('Che helper', () => {
       .stub(kube, 'ingressExist', () => true)
       .stub(kube, 'getIngressProtocol', () => 'https')
       .stub(kube, 'getIngressHost', () => 'example.org')
-      .it('computes Che URL on K8s', async () => {
+      .it('computes Eclipse Che URL on K8s', async () => {
         const cheURL = await ch.cheURL('che-namespace')
         expect(cheURL).to.equals('https://example.org')
       })
@@ -41,14 +41,14 @@ describe('Che helper', () => {
       .stub(kube, 'ingressExist', () => false)
       .do(() => ch.cheURL('che-namespace'))
       .catch(err => expect(err.message).to.match(/ERR_INGRESS_NO_EXIST/))
-      .it('fails fetching che URL when ingress does not exist')
+      .it('fails fetching Eclipse Che URL when ingress does not exist')
     fancy
       .stub(ch, 'cheNamespaceExist', () => true)
       .stub(kube, 'isOpenShift', () => true)
       .stub(oc, 'routeExist', () => true)
       .stub(oc, 'getRouteProtocol', () => 'https')
       .stub(oc, 'getRouteHost', () => 'example.org')
-      .it('computes Che URL on OpenShift', async () => {
+      .it('computes Eclipse Che URL on OpenShift', async () => {
         const cheURL = await ch.cheURL('che-namespace')
         expect(cheURL).to.equals('https://example.org')
       })
@@ -58,19 +58,19 @@ describe('Che helper', () => {
       .stub(oc, 'routeExist', () => false)
       .do(() => ch.cheURL('che-namespace'))
       .catch(/ERR_ROUTE_NO_EXIST/)
-      .it('fails fetching che URL when route does not exist')
+      .it('fails fetching Eclipse Che URL when route does not exist')
     fancy
       .stub(ch, 'cheNamespaceExist', () => false)
       .do(() => ch.cheURL('che-namespace'))
       .catch(err => expect(err.message).to.match(/ERR_NAMESPACE_NO_EXIST/))
-      .it('fails fetching che URL when namespace does not exist')
+      .it('fails fetching Eclipse Che URL when namespace does not exist')
   })
   describe('isCheServerReady', () => {
     fancy
       .nock(cheURL, api => api
         .get('/api/system/state')
         .reply(200))
-      .it('detects if Che server is ready', async () => {
+      .it('detects if Eclipse Che server is ready', async () => {
         const res = await ch.isCheServerReady(cheURL)
         expect(res).to.equal(true)
       })
@@ -79,7 +79,7 @@ describe('Che helper', () => {
         .get('/api/system/state')
         .delayConnection(1000)
         .reply(200))
-      .it('detects if Che server is NOT ready', async () => {
+      .it('detects if Eclipse Che server is NOT ready', async () => {
         const res = await ch.isCheServerReady(cheURL, 500)
         expect(res).to.equal(false)
       })
@@ -88,7 +88,7 @@ describe('Che helper', () => {
         .get('/api/system/state')
         .delayConnection(1000)
         .reply(200))
-      .it('waits until Che server is ready', async () => {
+      .it('waits until Eclipse Che server is ready', async () => {
         const res = await ch.isCheServerReady(cheURL, 2000)
         expect(res).to.equal(true)
       })
@@ -100,7 +100,7 @@ describe('Che helper', () => {
         .reply(503)
         .get('/api/system/state')
         .reply(200))
-      .it('continues requesting until Che server is ready', async () => {
+      .it('continues requesting until Eclipse Che server is ready', async () => {
         const res = await ch.isCheServerReady(cheURL, 2000)
         expect(res).to.equal(true)
       })
@@ -112,7 +112,7 @@ describe('Che helper', () => {
         .reply(404)
         .get('/api/system/state')
         .reply(503))
-      .it('continues requesting but fails if Che server is NOT ready after timeout', async () => {
+      .it('continues requesting but fails if Eclipse Che server is NOT ready after timeout', async () => {
         const res = await ch.isCheServerReady(cheURL, 20)
         expect(res).to.equal(false)
       })

--- a/test/commands/server/start.test.ts
+++ b/test/commands/server/start.test.ts
@@ -13,7 +13,7 @@ describe('start', () => {
   test
     .stdout()
     .command(['start'])
-    .it('starts Eclipse Che Server', ctx => {
+    .it('starts Eclipse Che server', ctx => {
       expect(ctx.stdout).to.contain('Successfully started')
     })
 })

--- a/test/commands/server/stop.test.ts
+++ b/test/commands/server/stop.test.ts
@@ -13,7 +13,7 @@ describe('stop', () => {
   test
     .stdout()
     .command(['stop'])
-    .it('stop Eclipse Che Server', ctx => {
+    .it('stop Eclipse Che server', ctx => {
       expect(ctx.stdout).to.contain('Successfully stopped')
     })
 })

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -45,7 +45,7 @@ describe('e2e test', () => {
       .stdout()
       .command(['server:delete','--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
-      .it('deletes Che resources on minikube successfully')
+      .it('deletes Eclipse Che resources on minikube successfully')
   })
   describe('server:start mulituser', () => {
     test
@@ -54,7 +54,7 @@ describe('e2e test', () => {
       .exit(0)
       .it('uses minikube as platform, operator as installer and auth is enabled', ctx => {
         expect(ctx.stdout).to.contain('Minikube preflight checklist')
-          .and.to.contain('Running the Che Operator')
+          .and.to.contain('Running the Eclipse Che operator')
           .and.to.contain('Post installation checklist')
           .and.to.contain('Command server:start has completed successfully')
       })
@@ -76,6 +76,6 @@ describe('e2e test', () => {
       .stdout()
       .command(['server:delete','--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
-      .it('deletes Che resources on minikube successfully')
+      .it('deletes Eclipse Che resources on minikube successfully')
   })
 })

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -47,7 +47,7 @@ describe('e2e test', () => {
       .stdout()
       .command(['server:delete','--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
-      .it('deletes Che resources on minishift successfully')
+      .it('deletes Eclipse Che resources on minishift successfully')
   })
   describe('server:start mulituser', () => {
     test
@@ -56,7 +56,7 @@ describe('e2e test', () => {
       .exit(0)
       .it('uses minishift as platform, operator as installer and auth is enabled', ctx => {
         expect(ctx.stdout).to.contain('Minishift preflight checklist')
-          .and.to.contain('Running the Che Operator')
+          .and.to.contain('Running the Eclipse Che operator')
           .and.to.contain('Post installation checklist')
           .and.to.contain('Command server:start has completed successfully')
       })
@@ -78,6 +78,6 @@ describe('e2e test', () => {
       .stdout()
       .command(['server:delete', '--skip-deletion-check', '--listr-renderer=verbose'])
       .exit(0)
-      .it('deletes Che resources on Minishift successfully')
+      .it('deletes Eclipse Che resources on Minishift successfully')
   })
 })


### PR DESCRIPTION
fix up che name so it's always 'Eclipse Che' and is therefore easier to replace when transforming into crwctl; tweak english in a few places too

Change-Id: I331b91ee645ad15547ff81f7b6dbed3ebe4d77a1
Signed-off-by: nickboldt <nboldt@redhat.com>