### PR TITLE
fix: use consistent variable name for all minishiftAddonTasks

### DIFF
--- a/src/commands/server/delete.ts
+++ b/src/commands/server/delete.ts
@@ -41,7 +41,7 @@ export default class Delete extends Command {
 
     const apiTasks = new ApiTasks()
     const helmTasks = new HelmTasks(flags)
-    const msAddonTasks = new MinishiftAddonTasks()
+    const minishiftAddonTasks = new MinishiftAddonTasks()
     const operatorTasks = new OperatorTasks()
     const cheTasks = new CheTasks(flags)
 
@@ -53,7 +53,7 @@ export default class Delete extends Command {
     tasks.add(operatorTasks.deleteTasks(flags))
     tasks.add(cheTasks.deleteTasks(flags))
     tasks.add(helmTasks.deleteTasks(flags))
-    tasks.add(msAddonTasks.deleteTasks(flags))
+    tasks.add(minishiftAddonTasks.deleteTasks(flags))
 
     const kc = new KubeConfig()
     kc.loadFromDefault()


### PR DESCRIPTION
use consistent variable name for all minishiftAddonTasks

Change-Id: I86ea46af0218f4332e58a8ecefc820209eb2cb02
Signed-off-by: nickboldt <nboldt@redhat.com>