### PR TITLE
fix: Delete minikube e2e auto test temporary

### DIFF
--- a/.ci/cico_chectl_prcheck.sh
+++ b/.ci/cico_chectl_prcheck.sh
@@ -67,7 +67,6 @@ run() {
 
         printInfo "Running e2e tests on ${platform} platform."
         yarn test --coverage=false --forceExit --testRegex=${CHECTL_REPO}/test/e2e/minishift.test.ts
-        #Clearing minishift installation from system
         yes | minishift delete --profile ${PROFILE}
         rm -rf ~/.minishift
       fi

--- a/.ci/cico_chectl_prcheck.sh
+++ b/.ci/cico_chectl_prcheck.sh
@@ -61,7 +61,7 @@ install_utilities() {
 run() {
   #Before to start to run the e2e tests we need to install all deps with yarn
   yarn --cwd ${CHECTL_REPO}
-  for platform in 'minishift' 'minikube'
+  for platform in 'minishift'
   do
       if [[ ${platform} == 'minishift' ]]; then
         minishift_installation

--- a/.ci/cico_chectl_prcheck.sh
+++ b/.ci/cico_chectl_prcheck.sh
@@ -54,7 +54,6 @@ install_utilities() {
   helm_install
   install_required_packages
   setup_kvm_machine_driver
-  start_libvirt
   install_node_deps
 }
 

--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -46,9 +46,6 @@ install_required_packages() {
     yum install -d1 --assumeyes epel-release
     yum update --assumeyes -d1
   fi
-  # Get all the deps in
-  printInfo 'Installing required virtualization packages installed'
-  yum -y install libvirt qemu-kvm
 }
 
 start_libvirt() {
@@ -62,13 +59,18 @@ install_node_deps() {
 }
 
 setup_kvm_machine_driver() {
-  printInfo "Installing docker machine kvm drivers"
+  echo "======== Start to install KVM virtual machine ========"
+
+  yum install -y qemu-kvm libvirt libvirt-python libguestfs-tools virt-install
+
   curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/v0.10.0/docker-machine-driver-kvm-centos7 -o /usr/local/bin/docker-machine-driver-kvm
   chmod +x /usr/local/bin/docker-machine-driver-kvm
-  check_libvirtd=$(systemctl is-active libvirtd)
-  if [ $check_libvirtd != 'active' ]; then
-    virsh net-start default
-  fi
+
+  systemctl enable libvirtd
+  systemctl start libvirtd
+
+  virsh net-list --all
+  echo "======== KVM has been installed successfully ========"
 }
 
 minishift_installation() {

--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -58,13 +58,13 @@ start_libvirt() {
 install_node_deps() {
   curl -sL https://rpm.nodesource.com/setup_10.x | bash -
   yum-config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
-  yum install -y nodejs yarn
+  yum install -y nodejs yarn git
 }
 
 setup_kvm_machine_driver() {
   printInfo "Installing docker machine kvm drivers"
-  curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/v0.10.0/docker-machine-driver-kvm-centos7 -o /usr/bin/docker-machine-driver-kvm
-  chmod +x /usr/bin/docker-machine-driver-kvm
+  curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/v0.10.0/docker-machine-driver-kvm-centos7 -o /usr/local/bin/docker-machine-driver-kvm
+  chmod +x /usr/local/bin/docker-machine-driver-kvm
   check_libvirtd=$(systemctl is-active libvirtd)
   if [ $check_libvirtd != 'active' ]; then
     virsh net-start default
@@ -74,7 +74,7 @@ setup_kvm_machine_driver() {
 minishift_installation() {
   printInfo "Downloading Minishift binaries"
   curl -L https://github.com/minishift/minishift/releases/download/v$MSFT_RELEASE/minishift-$MSFT_RELEASE-linux-amd64.tgz \
-    -o ${CHECTL_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar && tar -xvf ${CHECTL_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar -C /usr/bin --strip-components=1
+    -o ${CHECTL_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar && tar -xvf ${CHECTL_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar -C /usr/local/bin --strip-components=1
   echo "[INFO] Starting a new OC cluster."
   minishift profile set ${PROFILE}
   minishift start --memory=${RAM_MEMORY} && eval $(minishift oc-env)


### PR DESCRIPTION
Signed-off-by: flacatus <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
In ci.centos.org we are not available to install minikube because we are running under root user. 

### What issues does this PR fix or reference?

Temporary remove to run minikube installation from e2e tests.