### PR TITLE
fix: Fall back to CR default value of tls support if tls flag is omitted

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1139,8 +1139,8 @@ export class KubeHelper {
       yamlCr.spec.server.cheDebug = flags.debug ? flags.debug.toString() : 'false'
 
       yamlCr.spec.auth.openShiftoAuth = flags['os-oauth']
-      yamlCr.spec.server.tlsSupport = flags.tls
       if (flags.tls) {
+        yamlCr.spec.server.tlsSupport = flags.tls
         yamlCr.spec.k8s.tlsSecretName = 'che-tls'
       }
       yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -76,8 +76,7 @@ export default class Start extends Command {
       description: `Enable TLS encryption.
                     Note, that this option is turned on by default for kubernetes infrastructure.
                     If it is needed to provide own certificate, 'che-tls' secret with TLS certificate must be created in the configured namespace. Otherwise, it will be automatically generated.
-                    For OpenShift, router will use default cluster certificates.`,
-      default: false
+                    For OpenShift, router will use default cluster certificates.`
     }),
     'self-signed-cert': flags.boolean({
       description: `Authorize usage of self signed certificates for encryption.


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Removes default value of `tls` flag for `chectl server:start` command.
This change allows to use default `tlsSupport` value which comes from Che operator CR in case if the `tls` flag wasn't specified in `chectl`.


