### PR TITLE
fix: Fall back to CR default value of tls support if tls flag is omitted

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -964,8 +964,8 @@ export class KubeHelper {
       yamlCr.spec.server.cheDebug = flags.debug ? flags.debug.toString() : 'false'
 
       yamlCr.spec.auth.openShiftoAuth = flags['os-oauth']
-      yamlCr.spec.server.tlsSupport = flags.tls
       if (flags.tls) {
+        yamlCr.spec.server.tlsSupport = flags.tls
         yamlCr.spec.k8s.tlsSecretName = 'che-tls'
       }
       yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -75,8 +75,7 @@ export default class Start extends Command {
       char: 's',
       description: `Enable TLS encryption.
                     Note that for kubernetes 'che-tls' with TLS certificate must be created in the configured namespace.
-                    For OpenShift, router will use default cluster certificates.`,
-      default: false
+                    For OpenShift, router will use default cluster certificates.`
     }),
     'self-signed-cert': flags.boolean({
       description: 'Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate must be created in the configured namespace.',


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Backports https://github.com/che-incubator/chectl/pull/561 to `7.9.x` branch

