### PR TITLE
fix:  use this.fooSelector instead of invalid selectors

### DIFF
--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -299,7 +299,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment(this.keycloakSelector, this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.keycloakDeploymentName, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale keycloak deployment. ${error.message}`)
@@ -319,7 +319,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isPostgresDeployed && !ctx.isPostgresStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment(this.postgresSelector, this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.postgresDeploymentName, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale postgres deployment. ${error.message}`)
@@ -339,7 +339,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isDevfileRegistryDeployed && !ctx.isDevfileRegistryStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment(this.devfileRegistrySelector, this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.devfileRegistryDeploymentName, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale devfile-registry deployment. ${error.message}`)
@@ -359,7 +359,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isPluginRegistryDeployed && !ctx.isPluginRegistryStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment(this.pluginRegistrySelector, this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.pluginRegistryDeploymentName, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale plugin-registry deployment. ${error.message}`)

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -299,7 +299,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment('keycloak', this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.keycloakSelector, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale keycloak deployment. ${error.message}`)
@@ -310,7 +310,7 @@ export class CheTasks {
       title: 'Wait until Keycloak pod is deleted',
       enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
       task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted('app=keycloak', this.cheNamespace)
+        await this.kube.waitUntilPodIsDeleted(this.keycloakSelector, this.cheNamespace)
         task.title = `${task.title}...done.`
       }
     },
@@ -319,7 +319,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isPostgresDeployed && !ctx.isPostgresStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment('postgres', this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.postgresSelector, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale postgres deployment. ${error.message}`)
@@ -330,7 +330,7 @@ export class CheTasks {
       title: 'Wait until Postgres pod is deleted',
       enabled: (ctx: any) => ctx.isPostgresDeployed && !ctx.isPostgresStopped,
       task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted('app=postgres', this.cheNamespace)
+        await this.kube.waitUntilPodIsDeleted(this.postgresSelector, this.cheNamespace)
         task.title = `${task.title}...done.`
       }
     },
@@ -339,7 +339,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isDevfileRegistryDeployed && !ctx.isDevfileRegistryStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment('devfile-registry', this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.devfileRegistrySelector, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale devfile-registry deployment. ${error.message}`)
@@ -359,7 +359,7 @@ export class CheTasks {
       enabled: (ctx: any) => ctx.isPluginRegistryDeployed && !ctx.isPluginRegistryStopped,
       task: async (_ctx: any, task: any) => {
         try {
-          await this.kube.scaleDeployment('plugin-registry', this.cheNamespace, 0)
+          await this.kube.scaleDeployment(this.pluginRegistrySelector, this.cheNamespace, 0)
           task.title = await `${task.title}...done`
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale plugin-registry deployment. ${error.message}`)


### PR DESCRIPTION
fix deployment selections to use this.fooSelector instead of invalid selectors

Change-Id: Ie97fc3c6378e158032109ee6e4ee5e23053146ab
Signed-off-by: nickboldt <nboldt@redhat.com>