### PR TITLE
fix: Fallback to default Che tls secret only if CR has empty value for it

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1141,7 +1141,9 @@ export class KubeHelper {
       yamlCr.spec.auth.openShiftoAuth = flags['os-oauth']
       if (flags.tls) {
         yamlCr.spec.server.tlsSupport = flags.tls
-        yamlCr.spec.k8s.tlsSecretName = 'che-tls'
+        if (!yamlCr.spec.k8s.tlsSecretName) {
+          yamlCr.spec.k8s.tlsSecretName = 'che-tls'
+        }
       }
       yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
       yamlCr.spec.k8s.ingressDomain = flags.domain


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Uses default `che-tls` secret name for securing Che only if Che CR has no value specified.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16280
