### PR TITLE
feat: Add workspace:create command instead of workspace:start

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "tslib": "^1"
   },
   "devDependencies": {
+    "@eclipse-che/api": "latest",
     "@oclif/dev-cli": "^1",
     "@oclif/test": "^1",
     "@oclif/tslint": "^3",

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -205,14 +205,14 @@ export class CheHelper {
     let response
 
     const headers: {[key: string]: string} = {}
-    if (accessToken && accessToken.length > 0) {
+    if (accessToken) {
       headers.Authorization = accessToken
     }
     try {
       response = await this.axios.post(endpoint, undefined, { headers })
     } catch (error) {
       if (error.response && error.response.status === 404) {
-        throw new Error('E_WORKSPACE_NOT_EXIST')
+        throw new Error(`E_WORKSPACE_NOT_EXIST - workspace with "${workspaceId}" id doesn't exist`)
       } else {
         throw this.getCheApiError(error, endpoint)
       }

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -199,12 +199,17 @@ export class CheHelper {
     }
   }
 
-  async startWorkspace(cheNamespace: string, workspaceId: string): Promise<void> {
+  async startWorkspace(cheNamespace: string, workspaceId: string, accessToken?: string): Promise<void> {
     const cheUrl = await this.cheURL(cheNamespace)
     const endpoint = `${cheUrl}/api/workspace/${workspaceId}/runtime`
     let response
+
+    const headers: {[key: string]: string} = {}
+    if (accessToken && accessToken.length > 0) {
+      headers.Authorization = accessToken
+    }
     try {
-      response = await this.axios.post(endpoint)
+      response = await this.axios.post(endpoint, undefined, { headers })
     } catch (error) {
       if (error.response && error.response.status === 404) {
         throw new Error('E_WORKSPACE_NOT_EXIST')

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2019-2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
+
+import { che as chetypes } from '@eclipse-che/api'
 import { CoreV1Api, KubeConfig, V1Pod, Watch } from '@kubernetes/client-node'
 import axios, { AxiosInstance } from 'axios'
 import * as cp from 'child_process'
@@ -197,13 +199,32 @@ export class CheHelper {
     }
   }
 
-  async createWorkspaceFromDevfile(namespace: string | undefined, devfilePath = '', workspaceName: string | undefined, accessToken = ''): Promise<string> {
+  async startWorkspace(cheNamespace: string, workspaceId: string): Promise<void> {
+    const cheUrl = await this.cheURL(cheNamespace)
+    const endpoint = `${cheUrl}/api/workspace/${workspaceId}/runtime`
+    let response
+    try {
+      response = await this.axios.post(endpoint)
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        throw new Error('E_WORKSPACE_NOT_EXIST')
+      } else {
+        throw this.getCheApiError(error, endpoint)
+      }
+    }
+
+    if (!response || response.status !== 200 || !response.data) {
+      throw new Error('E_BAD_RESP_CHE_API')
+    }
+  }
+
+  async createWorkspaceFromDevfile(namespace: string | undefined, devfilePath = '', workspaceName: string | undefined, accessToken = ''): Promise<chetypes.workspace.Workspace> {
     if (!await this.cheNamespaceExist(namespace)) {
       throw new Error('E_BAD_NS')
     }
     let url = await this.cheURL(namespace)
     let endpoint = `${url}/api/workspace/devfile`
-    let devfile
+    let devfile: string | undefined
     let response
     const headers: any = { 'Content-Type': 'text/yaml' }
     if (accessToken && accessToken.length > 0) {
@@ -217,17 +238,31 @@ export class CheHelper {
         json.metadata.name = workspaceName
         devfile = yaml.dump(json)
       }
+
       response = await this.axios.post(endpoint, devfile, { headers })
     } catch (error) {
-      if (!devfile) { throw new Error(`E_NOT_FOUND_DEVFILE - ${devfilePath} - ${error.message}`) }
-      if (error.response && error.response.status === 400) {
-        throw new Error(`E_BAD_DEVFILE_FORMAT - Message: ${error.response.data.message}`)
+      if (!devfile) {
+        throw new Error(`E_NOT_FOUND_DEVFILE - ${devfilePath} - ${error.message}`)
       }
+
+      if (error.response) {
+        if (error.response.status === 400) {
+          throw new Error(`E_BAD_DEVFILE_FORMAT - Message: ${error.response.data.message}`)
+        }
+        if (error.response.status === 409) {
+          let message = ''
+          if (error.response.data) {
+            message = error.response.data.message
+          }
+          throw new Error(`E_CONFLICT - Message: ${message}`)
+        }
+      }
+
       throw this.getCheApiError(error, endpoint)
     }
-    if (response && response.data && response.data.links && response.data.links.ide) {
-      let ideURL = response.data.links.ide
-      return this.buildDashboardURL(ideURL)
+
+    if (response && response.data) {
+      return response.data as chetypes.workspace.Workspace
     } else {
       throw new Error('E_BAD_RESP_CHE_SERVER')
     }

--- a/src/commands/workspace/create.ts
+++ b/src/commands/workspace/create.ts
@@ -1,0 +1,110 @@
+/*********************************************************************
+ * Copyright (c) 2019-2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { Command, flags } from '@oclif/command'
+import { boolean, string } from '@oclif/parser/lib/flags'
+import { cli } from 'cli-ux'
+import * as Listr from 'listr'
+import * as notifier from 'node-notifier'
+
+import { CheHelper } from '../../api/che'
+import { accessToken, cheNamespace, listrRenderer } from '../../common-flags'
+export default class Create extends Command {
+  static description = 'Creates a workspace from devfile'
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    chenamespace: cheNamespace,
+    devfile: string({
+      char: 'f',
+      description: 'path or URL to a valid devfile',
+      env: 'DEVFILE_PATH',
+      required: true,
+    }),
+    name: string({
+      description: 'workspace name: overrides the workspace name to use instead of the one defined in the devfile. Works only for devfile',
+      required: false,
+    }),
+    start: boolean({
+      char: 's',
+      description: 'Starts the workspace after creation',
+      default: false
+    }),
+    'access-token': accessToken,
+    'listr-renderer': listrRenderer
+  }
+
+  async run() {
+    const { flags } = this.parse(Create)
+
+    const tasks = this.getWorkspaceCreateTasks(flags)
+    try {
+      let ctx = await tasks.run()
+      this.log('\nWorkspace IDE URL:')
+      cli.url(ctx.workspaceIdeURL, ctx.workspaceIdeURL)
+    } catch (err) {
+      this.error(err)
+    }
+
+    notifier.notify({
+      title: 'chectl',
+      message: 'Command workspace:create has completed successfully.'
+    })
+
+    this.exit(0)
+  }
+
+  getWorkspaceCreateTasks(flags: any): Listr<any> {
+    const che = new CheHelper(flags)
+    return new Listr([
+      {
+        title: 'Retrieving Eclipse Che server URL',
+        task: async (ctx: any, task: any) => {
+          ctx.cheURL = await che.cheURL(flags.chenamespace)
+          task.title = await `${task.title}... ${ctx.cheURL}`
+        }
+      },
+      {
+        title: 'Verify if Eclipse Che server is running',
+        task: async (ctx: any, task: any) => {
+          if (!await che.isCheServerReady(ctx.cheURL)) {
+            this.error(`E_SRV_NOT_RUNNING - Eclipse Che server is not available by ${ctx.cheURL}`, { code: 'E_SRV_NOT_RUNNNG' })
+          }
+          const status = await che.getCheServerStatus(ctx.cheURL)
+          ctx.isAuthEnabled = await che.isAuthenticationEnabled(ctx.cheURL)
+          const auth = ctx.isAuthEnabled ? '(auth enabled)' : '(auth disabled)'
+          task.title = await `${task.title}...${status} ${auth}`
+        }
+      },
+      {
+        title: `Create workspace from Devfile ${flags.devfile}`,
+        task: async (ctx: any) => {
+          if (ctx.isAuthEnabled && !flags['access-token']) {
+            this.error('E_AUTH_REQUIRED - Eclipse Che authentication is enabled and an access token needs to be provided (flag --access-token).')
+          }
+          const workspaceConfig = await che.createWorkspaceFromDevfile(flags.chenamespace, flags.devfile, flags.name, flags['access-token'])
+          ctx.workspaceId = workspaceConfig.id
+          if (workspaceConfig.links && workspaceConfig.links.ide) {
+            ctx.workspaceIdeURL = await che.buildDashboardURL(workspaceConfig.links.ide)
+          }
+        }
+      }, {
+        title: 'Start workspace',
+        enabled: () => flags.start,
+        task: async (ctx: any, task: any) => {
+          await che.startWorkspace(flags.chenamespace, ctx.workspaceId)
+          task.title = `${task.title}... Done`
+        }
+      }
+    ], { renderer: flags['listr-renderer'] as any })
+
+  }
+
+}

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2019-2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,72 +8,29 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { Command, flags } from '@oclif/command'
-import { string } from '@oclif/parser/lib/flags'
 import { cli } from 'cli-ux'
+import * as notifier from 'node-notifier'
 
-import { CheHelper } from '../../api/che'
-import { accessToken, cheNamespace, listrRenderer } from '../../common-flags'
-export default class Start extends Command {
-  static description = 'create and start a workspace'
+import Create from './create'
 
-  static flags = {
-    help: flags.help({ char: 'h' }),
-    chenamespace: cheNamespace,
-    devfile: string({
-      char: 'f',
-      description: 'path or URL to a valid devfile',
-      env: 'DEVFILE_PATH',
-      required: true,
-    }),
-    name: string({
-      description: 'workspace name: overrides the workspace name to use instead of the one defined in the devfile. Works only for devfile',
-      required: false,
-    }),
-    'access-token': accessToken,
-    'listr-renderer': listrRenderer
-  }
-
-  async checkToken(flags: any, ctx: any) {
-    if (ctx.isAuthEnabled && !flags['access-token']) {
-      this.error('E_AUTH_REQUIRED - Eclipse Che authentication is enabled and an access token need to be provided (flag --access-token).')
-    }
-  }
+export default class Start extends Create {
+  static description = 'Creates and starts workspace from devfile'
 
   async run() {
-    const { flags } = this.parse(Start)
+    const { flags } = this.parse(Create)
+    flags.start = true
 
-    const Listr = require('listr')
-    const notifier = require('node-notifier')
-    const che = new CheHelper(flags)
-    const tasks = new Listr([
+    const tasks = this.getWorkspaceCreateTasks(flags)
+    tasks.add(
       {
-        title: 'Retrieving Eclipse Che server URL',
-        task: async (ctx: any, task: any) => {
-          ctx.cheURL = await che.cheURL(flags.chenamespace)
-          task.title = await `${task.title}... ${ctx.cheURL}`
-        }
-      },
-      {
-        title: 'Verify if Eclipse Che server is running',
-        task: async (ctx: any, task: any) => {
-          if (!await che.isCheServerReady(ctx.cheURL)) {
-            this.error(`E_SRV_NOT_RUNNING - Eclipse Che server is not available by ${ctx.cheURL}`, { code: 'E_SRV_NOT_RUNNNG' })
-          }
-          const status = await che.getCheServerStatus(ctx.cheURL)
-          ctx.isAuthEnabled = await che.isAuthenticationEnabled(ctx.cheURL)
-          const auth = ctx.isAuthEnabled ? '(auth enabled)' : '(auth disabled)'
-          task.title = await `${task.title}...${status} ${auth}`
-        }
-      },
-      {
-        title: `Create workspace from Devfile ${flags.devfile}`,
-        task: async (ctx: any) => {
-          await this.checkToken(flags, ctx)
-          ctx.workspaceIdeURL = await che.createWorkspaceFromDevfile(flags.chenamespace, flags.devfile, flags.name, flags['access-token'])
+        title: 'Warning',
+        task: (_: any, task: any) => {
+          const yellow = '\x1b[33m'
+          const noColor = '\x1b[0m'
+          task.title = `${yellow}This command is deprecated. Please use 'workspace:create --start' instead ${noColor}`
         }
       }
-    ], { renderer: flags['listr-renderer'] as any })
+    )
 
     try {
       let ctx = await tasks.run()

--- a/src/commands/workspace/start.ts
+++ b/src/commands/workspace/start.ts
@@ -14,24 +14,15 @@ import * as notifier from 'node-notifier'
 import Create from './create'
 
 export default class Start extends Create {
-  static description = 'Creates and starts workspace from devfile'
+  static description = 'Creates and starts workspace from a devfile'
 
   async run() {
     const { flags } = this.parse(Create)
     flags.start = true
 
     const tasks = this.getWorkspaceCreateTasks(flags)
-    tasks.add(
-      {
-        title: 'Warning',
-        task: (_: any, task: any) => {
-          const yellow = '\x1b[33m'
-          const noColor = '\x1b[0m'
-          task.title = `${yellow}This command is deprecated. Please use 'workspace:create --start' instead ${noColor}`
-        }
-      }
-    )
 
+    cli.warn('This command is deprecated. Please use "workspace:create --start" instead')
     try {
       let ctx = await tasks.run()
       this.log('\nWorkspace IDE URL:')

--- a/test/api/che.test.ts
+++ b/test/api/che.test.ts
@@ -142,7 +142,7 @@ describe('Eclipse Che helper', () => {
         .replyWithFile(201, __dirname + '/replies/create-workspace-from-valid-devfile.json', { 'Content-Type': 'application/json' }))
       .it('succeds creating a workspace from a valid devfile', async () => {
         const res = await ch.createWorkspaceFromDevfile(namespace, __dirname + '/requests/devfile.valid', undefined)
-        expect(res).to.equal('https://che-che.192.168.64.39.nip.io/dashboard/#/ide/che/chectl')
+        expect(res.links!.ide).to.equal('https://che-che.192.168.64.39.nip.io/che/chectl')
       })
     fancy
       .stub(ch, 'cheNamespaceExist', () => true)
@@ -172,7 +172,7 @@ describe('Eclipse Che helper', () => {
         .replyWithFile(201, __dirname + '/replies/create-workspace-from-valid-devfile.json', { 'Content-Type': 'application/json' }))
       .it('succeeds creating a workspace from a remote devfile', async () => {
         const res = await ch.createWorkspaceFromDevfile(namespace, devfileServerURL + '/devfile.yaml', undefined)
-        expect(res).to.equal('https://che-che.192.168.64.39.nip.io/dashboard/#/ide/che/chectl')
+        expect(res.links!.ide).to.equal('https://che-che.192.168.64.39.nip.io/che/chectl')
       })
     fancy
       .stub(ch, 'cheNamespaceExist', () => true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@eclipse-che/api@latest":
+  version "7.5.0-SNAPSHOT"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.5.0-SNAPSHOT.tgz#bf0c5be60354e34c73bc52b2e18be8680ce8d900"
+
 "@fimbul/bifrost@^0.21.0":
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.21.0.tgz#d0fafa25938fda475657a6a1e407a21bbe02c74e"


### PR DESCRIPTION
### What does this PR do?
Adds new `workspace:create` command to `chectl`, which is supposed to replace `worspace:start` which become deprecated.

`workspace:create` command has `--start` option which starts the workspace right after creation.

In case of using `workspace:start` command, deprecation warning will be shown:
![output](https://user-images.githubusercontent.com/15607393/77091197-ec051b00-6a10-11ea-9ac4-501326ce1e28.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14344
