### PR TITLE
fix: Fix starting multiple che instances in the same cluster

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -255,8 +255,14 @@ export class KubeHelper {
     }
   }
 
-  async createClusterRoleFromFile(filePath: string) {
+  async createClusterRoleFromFile(filePath: string, roleName?: string) {
     const yamlRole = this.safeLoadFromYamlFile(filePath) as V1ClusterRole
+    if (!yamlRole.metadata || !yamlRole.metadata.name) {
+      throw new Error(`Cluster Role read from ${filePath} must have name specified`)
+    }
+    if (roleName) {
+      yamlRole.metadata!.name = roleName
+    }
     const k8sRbacAuthApi = this.kc.makeApiClient(RbacAuthorizationV1Api)
     try {
       const res = await k8sRbacAuthApi.createClusterRole(yamlRole)
@@ -270,11 +276,14 @@ export class KubeHelper {
     }
   }
 
-  async replaceClusterRoleFromFile(filePath: string) {
+  async replaceClusterRoleFromFile(filePath: string, roleName?: string) {
     const yamlRole = this.safeLoadFromYamlFile(filePath) as V1ClusterRole
     const k8sRbacAuthApi = this.kc.makeApiClient(RbacAuthorizationV1Api)
     if (!yamlRole.metadata || !yamlRole.metadata.name) {
       throw new Error(`Cluster Role read from ${filePath} must have name specified`)
+    }
+    if (roleName) {
+      yamlRole.metadata!.name = roleName
     }
     try {
       const res = await k8sRbacAuthApi.replaceClusterRole(yamlRole.metadata.name, yamlRole)

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -383,15 +383,6 @@ export class OperatorTasks {
       }
     },
     {
-      title: `Delete CRD ${this.cheClusterCrd}`,
-      task: async (_ctx: any, task: any) => {
-        if (await kh.crdExist(this.cheClusterCrd)) {
-          await kh.deleteCrd(this.cheClusterCrd)
-        }
-        task.title = await `${task.title}...OK`
-      }
-    },
-    {
       title: `Delete role binding ${this.operatorRoleBinding}`,
       task: async (_ctx: any, task: any) => {
         if (await kh.roleBindingExist(this.operatorRoleBinding, flags.chenamespace)) {


### PR DESCRIPTION
### What does this PR do?
Provide unique clusterrole and clusterrole binding per che instance in the same cluster. Use namespace suffix for this purpose: `${che-role-name}-namespace` and `${che-rolebinding-name}-namespace`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15345
Mostly for https://issues.redhat.com/browse/CRW-505?focusedCommentId=13816159&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel
