### PR TITLE
feat: Add basic TLS configuration checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ OPTIONS
                            Note, this option is turned on by default.
                            For Kubernetes infrastructure, it is required to provide own certificate: 'che-tls' secret with 
       TLS certificate must be pre-created in the configured namespace.
+                           The only exception is Helm installer. In that case the secret will be generated automatically.
                            For OpenShift, router will use default cluster certificates.
                            If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise 
       Che won't be able to start.

--- a/README.md
+++ b/README.md
@@ -273,10 +273,14 @@ OPTIONS
 
   -s, --tls
       Enable TLS encryption.
-                           Note, that this option is turned on by default for kubernetes infrastructure.
-                           If it is needed to provide own certificate, 'che-tls' secret with TLS certificate must be 
-      created in the configured namespace. Otherwise, it will be automatically generated.
+                           Note, this option is turned on by default.
+                           For Kubernetes infrastructure, it is required to provide own certificate: 'che-tls' secret with 
+      TLS certificate must be pre-created in the configured namespace.
                            For OpenShift, router will use default cluster certificates.
+                           If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise 
+      Che won't be able to start.
+                           Please see docs for more details: 
+      https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/
 
   -t, --templates=templates
       [default: templates] Path to the templates folder

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -76,6 +76,7 @@ export default class Start extends Command {
       description: `Enable TLS encryption.
                     Note, this option is turned on by default.
                     For Kubernetes infrastructure, it is required to provide own certificate: 'che-tls' secret with TLS certificate must be pre-created in the configured namespace.
+                    The only exception is Helm installer. In that case the secret will be generated automatically.
                     For OpenShift, router will use default cluster certificates.
                     If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise Che won't be able to start.
                     Please see docs for more details: https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/`

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -74,9 +74,11 @@ export default class Start extends Command {
     tls: flags.boolean({
       char: 's',
       description: `Enable TLS encryption.
-                    Note, that this option is turned on by default for kubernetes infrastructure.
-                    If it is needed to provide own certificate, 'che-tls' secret with TLS certificate must be created in the configured namespace. Otherwise, it will be automatically generated.
-                    For OpenShift, router will use default cluster certificates.`
+                    Note, this option is turned on by default.
+                    For Kubernetes infrastructure, it is required to provide own certificate: 'che-tls' secret with TLS certificate must be pre-created in the configured namespace.
+                    For OpenShift, router will use default cluster certificates.
+                    If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise Che won't be able to start.
+                    Please see docs for more details: https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/`
     }),
     'self-signed-cert': flags.boolean({
       description: `Authorize usage of self signed certificates for encryption.

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -68,7 +68,7 @@ export class OperatorTasks {
         task: async (_: any, task: any) => {
           // Che is being deployed on Kubernetes infrastructure
 
-          if (!(flags.tls || await this.checkCrForTls(flags))) {
+          if (! await this.checkTlsMode(flags)) {
             // No TLS mode, skip this check
             return
           }
@@ -94,7 +94,7 @@ export class OperatorTasks {
         // If the flag is set no need to check if it is required
         skip: () => flags['self-signed-cert'],
         task: async (_: any, task: any) => {
-          if (!(flags.tls || await this.checkCrForTls(flags))) {
+          if (! await this.checkTlsMode(flags)) {
             // No TLS mode, skip this check
             return
           }
@@ -119,6 +119,8 @@ export class OperatorTasks {
           }
 
           // TODO check the secret certificate if it is commonly trusted.
+          cli.info('TLS mode is turned on, however we failed to determine whether self-signed certificate is used. \n\
+                   Please rerun chectl with "--self-signed-cert" option if it is the case, otherwise Eclipse Che will fail to start.')
         }
       },
       {
@@ -563,7 +565,7 @@ export class OperatorTasks {
    * Checks if TLS is disabled via operator custom resource.
    * Returns true if TLS is enabled (or omitted) and false if it is explicitly disabled.
    */
-  private async checkCrForTls(flags: any): Promise<boolean> {
+  private async checkTlsMode(flags: any): Promise<boolean> {
     if (flags['che-operator-cr-yaml']) {
       const cheOperatorCrYamlPath = flags['che-operator-cr-yaml']
       if (fs.existsSync(cheOperatorCrYamlPath)) {
@@ -582,6 +584,11 @@ export class OperatorTasks {
           return false
         }
       }
+    }
+
+    // If tls flag is undefined we suppose that tls is turned on
+    if (flags.tls === false) {
+      return false
     }
 
     // TLS is on

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,3 +23,11 @@ export function getClusterClientCommand(): string {
 
   throw new Error('No cluster CLI client is installed.')
 }
+
+export function isKubernetesPlatformFamily(platform: string): boolean {
+  return platform === 'k8s' || platform === 'minikube' || platform === 'microk8s'
+}
+
+export function isOpenshiftPlatformFamily(platform: string): boolean {
+  return platform === 'openshift' || platform === 'minishift' || platform === 'crc'
+}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds basic checks for TLS configuration of operator installer:
 - For Kubernetes infrastructure family in case of TLS it is required to have pre-created secret. If it is not provided the expanded error message will be shown along with link to the corresponding docs section:
![tls-checks](https://user-images.githubusercontent.com/15607393/77422077-90061200-6dd5-11ea-9feb-5bdf32fbb5ad.png)

 - Does basic check for `--self-signed-flag` option presence and automatically adds the flag if it is clear that self-signed certificate is used. However this check doesn't perform certificate analyzation directly, so it cannot catch all invalid cases, but only most frequent ones. I think that full certificate analyzation is out of scope of this PR, but left todo mark in the code.

Also corrects description for `--tls` flag.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16396
