### PR TITLE
fix: Set k8s.ingressDomain only if it used

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1146,7 +1146,9 @@ export class KubeHelper {
         }
       }
       yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
-      yamlCr.spec.k8s.ingressDomain = flags.domain
+      if (flags.domain) {
+        yamlCr.spec.k8s.ingressDomain = flags.domain
+      }
       const pluginRegistryUrl = flags['plugin-registry-url']
       if (pluginRegistryUrl) {
         yamlCr.spec.server.pluginRegistryUrl = pluginRegistryUrl


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
If we try to deploy Eclipse Che on openShift cluster and default CR doesn't contain `spec.k8s` section then installation will failed, so PR sets `spec.k8s.ingressDomain` only if `--domain` flags is used.


