### PR TITLE
feat: Add domain checks for Kubernetes family infrastructures

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -140,6 +140,10 @@ export default class Start extends Command {
     'skip-version-check': flags.boolean({
       description: 'Skip minimal versions check.',
       default: false
+    }),
+    'skip-cluster-availability-check': flags.boolean({
+      description: 'Skip cluster availability check. The check is a simple request to ensure the cluster is reachable.',
+      default: false
     })
   }
 

--- a/src/tasks/platforms/common-platform-tasks.ts
+++ b/src/tasks/platforms/common-platform-tasks.ts
@@ -1,0 +1,75 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as http from 'http'
+import * as https from 'https'
+import * as Listr from 'listr'
+
+export namespace CommonPlatformTasks {
+  /**
+   * Checks whether cluster on which Che is being deployed accessible.
+   * Requires flags.domain to be set.
+   */
+  export function getPingClusterTask(flags: any): Listr.ListrTask {
+    return {
+      title: 'Check if cluster accessible',
+      skip: () => flags['skip-cluster-availability-check'],
+      task: async (_ctx: any, task: any) => {
+        const domain: string = flags.domain
+        if (!domain) {
+          task.title = `${task.title}... "--domain" flag is not set. Cannot check cluster availability.'`
+          return
+        }
+
+        if (! await checkHttpServer(domain, 80) && ! await checkHttpsServer(domain, 443)) {
+          throw new Error(`Cannot reach cluster at "${domain}". To skip this check add "--skip-cluster-availability-check" flag.`)
+        }
+
+        task.title = `${task.title}... ok`
+      }
+    }
+  }
+
+  /**
+   * Sends request to given server to check if it is accessible.
+   */
+  function checkHttpServer(host: string, port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      http.get({ host, port }, response => {
+        // It is ok to have 404, but not 5xx
+        if (response.statusCode && response.statusCode / 100 < 5) {
+          resolve(true)
+        }
+        resolve(false)
+      }).on('error', () => {
+        resolve(false)
+      })
+    })
+  }
+
+  function checkHttpsServer(host: string, port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      https.get({ host, port }, response => {
+        // It is ok to have 404, but not 5xx
+        if (response.statusCode && response.statusCode / 100 < 5) {
+          resolve(true)
+        }
+        resolve(false)
+      }).on('error', (err: any) => {
+        if (err.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+          // Connection is estabilished but the server has self-signed certificate, it's ok.
+          resolve(true)
+        }
+        resolve(false)
+      })
+    })
+  }
+
+}

--- a/src/tasks/platforms/k8s.ts
+++ b/src/tasks/platforms/k8s.ts
@@ -15,6 +15,8 @@ import * as Listr from 'listr'
 import { KubeHelper } from '../../api/kube'
 import { VersionHelper } from '../../api/version'
 
+import { CommonPlatformTasks } from './common-platform-tasks'
+
 export class K8sTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
@@ -52,6 +54,7 @@ export class K8sTasks {
           task.title = `${task.title}...set to ${flags.domain}.`
         }
       },
+      CommonPlatformTasks.getPingClusterTask(flags)
     ],
       { renderer: flags['listr-renderer'] as any }
     )

--- a/src/tasks/platforms/microk8s.ts
+++ b/src/tasks/platforms/microk8s.ts
@@ -15,6 +15,8 @@ import * as Listr from 'listr'
 
 import { VersionHelper } from '../../api/version'
 
+import { CommonPlatformTasks } from './common-platform-tasks'
+
 export class MicroK8sTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
@@ -94,6 +96,7 @@ export class MicroK8sTasks {
           task.title = `${task.title}...${flags.domain}.`
         }
       },
+      CommonPlatformTasks.getPingClusterTask(flags)
     ], { renderer: flags['listr-renderer'] as any })
   }
 

--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -15,6 +15,8 @@ import * as Listr from 'listr'
 
 import { VersionHelper } from '../../api/version'
 
+import { CommonPlatformTasks } from './common-platform-tasks'
+
 export class MinikubeTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
@@ -77,6 +79,7 @@ export class MinikubeTasks {
           task.title = `${task.title}...${flags.domain}.`
         }
       },
+      CommonPlatformTasks.getPingClusterTask(flags)
     ], { renderer: flags['listr-renderer'] as any })
   }
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds check whether Kubernetes cluster is reachable when installing Che.
The check could be disabled by `--skip-cluster-check` flag.

### What issues does this PR fix or reference?
https://github.com/che-incubator/chectl/pull/613
