### PR TITLE
feat: Add ability to duplicate some messages at the end of chectl output

### DIFF
--- a/src/tasks/component-installers/cert-manager.ts
+++ b/src/tasks/component-installers/cert-manager.ts
@@ -162,7 +162,7 @@ export class CertManagerTasks {
       },
       {
         title: 'Add local Eclipse Che CA certificate into browser',
-        task: async (_ctx: any, task: any) => {
+        task: async (ctx: any, task: any) => {
           const cheSecret = await this.kubeHelper.getSecret(CHE_TLS_SECRET_NAME, flags.chenamespace)
           if (cheSecret && cheSecret.data) {
             const cheCaCrt = Buffer.from(cheSecret.data['ca.crt'], 'base64').toString('ascii')
@@ -171,7 +171,9 @@ export class CertManagerTasks {
 
             const yellow = '\x1b[33m'
             const noColor = '\x1b[0m'
-            task.title = `❗${yellow}[MANUAL ACTION REQUIRED]${noColor} Please add local Eclipse Che CA certificate into your browser: ${cheCaPublicCertPath}`
+            const message = `❗${yellow}[MANUAL ACTION REQUIRED]${noColor} Please add local Eclipse Che CA certificate into your browser: ${cheCaPublicCertPath}`
+            task.title = message
+            ctx.highlightedMessages.push(message)
           } else {
             throw new Error('Failed to get Cert Manager CA secret')
           }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds functionality to print logs duplicates at the end of chectl output to avoid missing of the important messages by users.

Example with importing CA certificate:
![Screenshot from 2020-04-03 13-49-02](https://user-images.githubusercontent.com/15607393/78353406-a4ef5c00-75b2-11ea-914c-e67f3feb234d.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16277
