### PR TITLE
fix: Reuse domain for server:update command

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1191,13 +1191,13 @@ export class KubeHelper {
     }
   }
 
-  async cheClusterExist(name = '', namespace = ''): Promise<boolean> {
+  async getCheCluster(name: string, namespace: string): Promise<any | undefined> {
     const customObjectsApi = this.kc.makeApiClient(CustomObjectsApi)
     try {
       const { body } = await customObjectsApi.getNamespacedCustomObject('org.eclipse.che', 'v1', namespace, 'checlusters', name)
-      return this.compare(body, name)
+      return body
     } catch {
-      return false
+      return
     }
   }
 

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -16,12 +16,14 @@ import * as Listr from 'listr'
 import * as notifier from 'node-notifier'
 import * as path from 'path'
 
+import { KubeHelper } from '../../api/kube'
 import { cheDeployment, cheNamespace, listrRenderer } from '../../common-flags'
-import { DEFAULT_CHE_OPERATOR_IMAGE } from '../../constants'
+import { CHE_CLUSTER_CR_NAME, DEFAULT_CHE_OPERATOR_IMAGE } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
+import { isKubernetesPlatformFamily } from '../../util'
 
 export default class Update extends Command {
   static description = 'update Eclipse Che server'
@@ -125,6 +127,9 @@ export default class Update extends Command {
       if (!ctx.isCheDeployed) {
         this.error('Eclipse Che deployment is not found. Use `chectl server:start` to initiate new deployment.')
       } else {
+        if (isKubernetesPlatformFamily(flags.platform!)) {
+          await this.setDomainFlag(flags)
+        }
         await platformCheckTasks.run(ctx)
 
         await preUpdateTasks.run(ctx)
@@ -150,5 +155,13 @@ export default class Update extends Command {
     })
 
     this.exit(0)
+  }
+
+  async setDomainFlag(flags: any): Promise<void> {
+    const kubeHelper = new KubeHelper()
+    const cheCluster = await kubeHelper.getCheCluster(CHE_CLUSTER_CR_NAME, flags.chenamespace)
+    if (cheCluster && cheCluster.spec.k8s && cheCluster.spec.k8s.ingressDomain) {
+      flags.domain = cheCluster.spec.k8s.ingressDomain
+    }
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,4 @@ export const CA_CERT_GENERATION_JOB_IMAGE = 'quay.io/eclipse/che-cert-manager-ca
 
 export const CERT_MANAGER_NAMESPACE_NAME = 'cert-manager'
 export const CHE_TLS_SECRET_NAME = 'che-tls'
+export const CHE_CLUSTER_CR_NAME = 'eclipse-che'

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -19,6 +19,7 @@ import * as path from 'path'
 
 import { CheHelper } from '../../api/che'
 import { KubeHelper } from '../../api/kube'
+import { CHE_CLUSTER_CR_NAME } from '../../constants'
 import { isKubernetesPlatformFamily } from '../../util'
 
 export class OperatorTasks {
@@ -29,7 +30,6 @@ export class OperatorTasks {
   operatorClusterRoleBinding = 'che-operator'
   cheClusterCrd = 'checlusters.org.eclipse.che'
   operatorName = 'che-operator'
-  operatorCheCluster = 'eclipse-che'
   resourcesPath = ''
 
   /**
@@ -226,10 +226,10 @@ export class OperatorTasks {
         }
       },
       {
-        title: `Create Eclipse Che cluster ${this.operatorCheCluster} in namespace ${flags.chenamespace}`,
+        title: `Create Eclipse Che cluster ${CHE_CLUSTER_CR_NAME} in namespace ${flags.chenamespace}`,
         task: async (ctx: any, task: any) => {
-          const exist = await kube.cheClusterExist(this.operatorCheCluster, flags.chenamespace)
-          if (exist) {
+          const cheCluster = await kube.getCheCluster(CHE_CLUSTER_CR_NAME, flags.chenamespace)
+          if (cheCluster) {
             task.title = `${task.title}...It already exists.`
           } else {
             // Eclipse Che operator supports only Multi-User Che
@@ -427,11 +427,11 @@ export class OperatorTasks {
   deleteTasks(flags: any): ReadonlyArray<Listr.ListrTask> {
     let kh = new KubeHelper(flags)
     return [{
-      title: `Delete the CR ${this.operatorCheCluster} of type ${this.cheClusterCrd}`,
+      title: `Delete the CR ${CHE_CLUSTER_CR_NAME} of type ${this.cheClusterCrd}`,
       task: async (_ctx: any, task: any) => {
         if (await kh.crdExist(this.cheClusterCrd) &&
-          await kh.cheClusterExist(this.operatorCheCluster, flags.chenamespace)) {
-          await kh.deleteCheCluster(this.operatorCheCluster, flags.chenamespace)
+          await kh.getCheCluster(CHE_CLUSTER_CR_NAME, flags.chenamespace)) {
+          await kh.deleteCheCluster(CHE_CLUSTER_CR_NAME, flags.chenamespace)
           await cli.wait(2000) //wait a couple of secs for the finalizers to be executed
           task.title = await `${task.title}...OK`
         } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,11 +1670,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#bbc7579a555700d10cec89f964582412fc07bcf6"
+  resolved "git://github.com/eclipse/che-operator#a8c155409d1024ed90771a02f3a5e4a333db649f"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#812f75c143910834f7313a7ad6c9218430506541"
+  resolved "git://github.com/eclipse/che#c9e6cca19f57df40d9e1cdf5d6c65eb670bcaa1c"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Allow to use domain flag for server:update command


