### PR TITLE
fix: Ignores templates folder if it doesn't contain che-operator templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ OPTIONS
       https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/
 
   -t, --templates=templates
-      [default: templates] Path to the templates folder
+      Path to the templates folder
 
   --che-operator-cr-patch-yaml=che-operator-cr-patch-yaml
       Path to a yaml file that overrides the default values in CheCluster CR used by the operator. This parameter is used 

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -41,7 +41,6 @@ export default class Start extends Command {
     templates: string({
       char: 't',
       description: 'Path to the templates folder',
-      default: Start.getTemplatesDir(),
       env: 'CHE_TEMPLATES_FOLDER'
     }),
     'devfile-registry-url': string({
@@ -153,18 +152,6 @@ export default class Start extends Command {
     })
   }
 
-  static getTemplatesDir(): string {
-    // return local templates folder if present
-    const TEMPLATES = 'templates'
-    const templatesDir = path.resolve(TEMPLATES)
-    const exists = fs.pathExistsSync(`${templatesDir}/che-operator`)
-    if (exists) {
-      return TEMPLATES
-    }
-    // else use the location from modules
-    return path.join(__dirname, '../../../templates')
-  }
-
   setPlaformDefaults(flags: any) {
     if (flags.platform === 'minishift') {
       if (!flags.multiuser && flags.installer === '') {
@@ -201,6 +188,25 @@ export default class Start extends Command {
     // TODO when tls by default is implemented for all platforms, make `tls` flag turned on by default.
     if (flags.installer === 'helm' && (flags.platform === 'k8s' || flags.platform === 'minikube' || flags.platform === 'microk8s')) {
       flags.tls = true
+    }
+
+    if (!flags.templates) {
+      // use local templates folder if present
+      const templates = 'templates'
+      const templatesDir = path.resolve(templates)
+      if (flags.installer === 'operator') {
+        if (fs.pathExistsSync(`${templatesDir}/che-operator`)) {
+          flags.templates = templatesDir
+        }
+      } else if (flags.installer === 'minishift-addon') {
+        if (fs.pathExistsSync(`${templatesDir}/minishift-addon/`)) {
+          flags.templates = templatesDir
+        }
+      }
+
+      if (!flags.templates) {
+        flags.templates = path.join(__dirname, '../../../templates')
+      }
     }
   }
 

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -157,7 +157,7 @@ export default class Start extends Command {
     // return local templates folder if present
     const TEMPLATES = 'templates'
     const templatesDir = path.resolve(TEMPLATES)
-    const exists = fs.pathExistsSync(templatesDir)
+    const exists = fs.pathExistsSync(`${templatesDir}/che-operator`)
     if (exists) {
       return TEMPLATES
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,11 +1521,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#56c6806b20055566b8d590f9b7fe6daf4805bed2"
+  resolved "git://github.com/eclipse/che-operator#e976064e182efb70ef697d68e4fbe74bff3d0de7"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#5c004a220619e59c75890ae90eb42e70c27e1322"
+  resolved "git://github.com/eclipse/che#eb9a2ab9b616ae82c790dfa78116d45fed63d954"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
chectl detects that local `templates` folder exists and tries to copy resources from it. But if it just an arbitrary folder of any project then chectl fails. PR adds additional check that templates` folder should contain `che-operator` or `minishift-addon` subfolder depending on installer type.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16555
