### PR TITLE
docs: Fix links to Che installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ OPTIONS
                            If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise 
       Che won't be able to start.
                            Please see docs for more details: 
-      https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/
+      https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/
 
   -t, --templates=templates
       Path to the templates folder

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -79,7 +79,7 @@ export default class Start extends Command {
                     The only exception is Helm installer. In that case the secret will be generated automatically.
                     For OpenShift, router will use default cluster certificates.
                     If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise Che won't be able to start.
-                    Please see docs for more details: https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/`
+                    Please see docs for more details: https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/`
     }),
     'self-signed-cert': flags.boolean({
       description: `Authorize usage of self signed certificates for encryption.

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -85,7 +85,7 @@ export class OperatorTasks {
             `Che TLS mode is turned on, but required "${cheSecretName}" secret is not pre-created in "${flags.chenamespace}" namespace, so Eclipse Che cannot be started. \n` +
             'This is not bug in Eclipse Che and such behavior is expected. \n' +
             'Please refer to Che documentation for more informations: ' +
-            'https://www.eclipse.org/che/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/'
+            'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/'
           throw new Error(errorMessage)
         }
       },


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Fixes links to Che installation with self-signed certificates docs.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16682
