### PR TITLE
fix: Use the correct message to print the current k8s context

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -32,7 +32,7 @@ export class KubeHelper {
   static initializeKubeConfig(): KubeConfig {
     const kc = new KubeConfig()
     kc.loadFromDefault()
-    cli.info(`Set current context to '${kc.currentContext}'`)
+    cli.info(`› Current Kubernetes context: '${kc.currentContext}'`)
     return kc
   }
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Fix the message to print current k8s context
```bash
$ ./run workspace:list
› Current kuberntetes context: 'minikube'
Id                        Name Namespace Status  Created                  Updated  
...
```

