### PR TITLE
fix: Update yarn.lock to use latest operator templates

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,11 +1521,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#e976064e182efb70ef697d68e4fbe74bff3d0de7"
+  resolved "git://github.com/eclipse/che-operator#bc47b7b1afc6a255bcec1a27a9a6cf36b1ad7e5f"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#bf62877c12ae1cbc0174bd42a683e6151a46d48e"
+  resolved "git://github.com/eclipse/che#417eb0347356124eb636e979e8bed48b491694e8"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Updates yarn.lock, so chectl uses latest operator version (templates from it)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16798
