### PR TITLE
Use TLS secrets autogeneration mechanism in chectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ USAGE
 
 OPTIONS
   -a, --installer=helm|operator|olm|minishift-addon
-      Installer type
+      [default: operator] Installer type
 
   -b, --domain=domain
       Domain of the Kubernetes cluster (e.g. example.k8s-cluster.com or <local-ip>.nip.io)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,9 +20,15 @@ export const CA_CERT_GENERATION_JOB_IMAGE = 'quay.io/eclipse/che-cert-manager-ca
 export const CERT_MANAGER_NAMESPACE_NAME = 'cert-manager'
 export const CHE_TLS_SECRET_NAME = 'che-tls'
 export const CHE_ROOT_CA_SECRET_NAME = 'self-signed-certificate'
+export const DEFAULT_CA_CERT_FILE_NAME = 'cheCA.crt'
 
 export const operatorCheCluster = 'eclipse-che'
 export const CHE_CLUSTER_CR_NAME = 'eclipse-che'
 
 export const defaultOpenshiftMarketPlaceNamespace = 'openshift-marketplace'
 export const defaultOLMKubernetesNamespace = 'olm'
+
+// Documentation links
+export const DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT = 'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/'
+export const DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER = 'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates'
+export const DOCS_LINK_AUTH_TO_CHE_SERVER_VIA_OPENID = ' https://www.eclipse.org/che/docs/che-7/authenticating-users/#authenticating-to-the-che-server-using-openid_authenticating-to-the-che-server'

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -13,6 +13,7 @@ import * as Listr from 'listr'
 import { CheHelper } from '../api/che'
 import { KubeHelper } from '../api/kube'
 import { OpenShiftHelper } from '../api/openshift'
+import { DOCS_LINK_AUTH_TO_CHE_SERVER_VIA_OPENID } from '../constants'
 
 import { KubeTasks } from './kube'
 
@@ -255,7 +256,8 @@ export class CheTasks {
       enabled: (ctx: any) => !ctx.isCheStopped,
       task: async (ctx: any, task: any) => {
         if (ctx.isAuthEnabled && !this.cheAccessToken) {
-          command.error('E_AUTH_REQUIRED - Eclipse Che authentication is enabled and an access token need to be provided (flag --access-token).\nFor instructions to retrieve a valid access token refer to https://www.eclipse.org/che/docs/pages/che-7/administration-guide/proc_authenticating-to-the-che-server-using-openid.html')
+          command.error('E_AUTH_REQUIRED - Eclipse Che authentication is enabled and an access token need to be provided (flag --access-token). ' +
+                        `For instructions to retrieve a valid access token refer to ${DOCS_LINK_AUTH_TO_CHE_SERVER_VIA_OPENID}`)
         }
         try {
           const cheURL = await this.che.cheURL(this.cheNamespace)

--- a/src/tasks/installers/helm.ts
+++ b/src/tasks/installers/helm.ts
@@ -78,8 +78,11 @@ export class HelmTasks {
           const cheTlsSecret = await this.kubeHelper.getSecret(CHE_TLS_SECRET_NAME, flags.chenamespace)
 
           if (cheTlsSecret && cheTlsSecret.data) {
-            if (!cheTlsSecret.data['tls.crt'] || !cheTlsSecret.data['tls.key'] || !cheTlsSecret.data['ca.crt']) {
-              throw new Error('"che-tls" secret is found but it is invalid. The valid self-signed certificate should contain "tls.crt", "tls.key" and "ca.crt" entries.')
+            if (!cheTlsSecret.data['tls.crt'] || !cheTlsSecret.data['tls.key']) {
+              throw new Error('"che-tls" secret is found but it is invalid. The valid self-signed certificate should contain "tls.crt" and "tls.key" entries.')
+            }
+            if (flags['self-signed-cert'] && !cheTlsSecret.data['ca.crt']) {
+              throw new Error(`"ca.crt" should be present in ${CHE_TLS_SECRET_NAME} secret in case of using self-signed certificate with helm installer.`)
             }
 
             ctx.cheCertificateExists = true

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -17,7 +17,7 @@ import { CatalogSource, Subscription } from '../../api/typings/olm'
 import { DEFAULT_CHE_IMAGE, DEFAULT_CHE_OLM_PACKAGE_NAME, defaultOLMKubernetesNamespace, defaultOpenshiftMarketPlaceNamespace, OLM_STABLE_CHANNEL_NAME } from '../../constants'
 import { isKubernetesPlatformFamily } from '../../util'
 
-import { checkPreCreatedTls, checkTlsSertificate, copyOperatorResources, createEclipeCheCluster, createNamespaceTask } from './common-tasks'
+import { checkTlsCertificate, copyOperatorResources, createEclipeCheCluster, createNamespaceTask } from './common-tasks'
 
 export class OLMTasks {
   private readonly customCatalogSourceName = 'eclipse-che-custom-catalog-source'
@@ -36,8 +36,7 @@ export class OLMTasks {
       this.isOlmPreInstalledTask(command, kube),
       copyOperatorResources(flags, command.config.cacheDir),
       createNamespaceTask(flags),
-      checkPreCreatedTls(flags, kube),
-      checkTlsSertificate(flags),
+      checkTlsCertificate(flags),
       {
         title: 'Create operator group',
         task: async (_ctx: any, task: any) => {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -17,7 +17,7 @@ import * as Listr from 'listr'
 import { KubeHelper } from '../../api/kube'
 import { CHE_CLUSTER_CR_NAME } from '../../constants'
 
-import { checkPreCreatedTls, checkTlsSertificate, copyOperatorResources, createEclipeCheCluster, createNamespaceTask } from './common-tasks'
+import { checkTlsCertificate, copyOperatorResources, createEclipeCheCluster, createNamespaceTask } from './common-tasks'
 
 export class OperatorTasks {
   operatorServiceAccount = 'che-operator'
@@ -37,8 +37,7 @@ export class OperatorTasks {
     return new Listr([
       copyOperatorResources(flags, command.config.cacheDir),
       createNamespaceTask(flags),
-      checkPreCreatedTls(flags, kube),
-      checkTlsSertificate(flags),
+      checkTlsCertificate(flags),
       {
         title: `Create ServiceAccount ${this.operatorServiceAccount} in namespace ${flags.chenamespace}`,
         task: async (ctx: any, task: any) => {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes usable the work done in https://github.com/eclipse/che/issues/16546.
So now, a user may just run:
```sh
chectl server:start --platform=<platform> --self-signed-certificated
```
At the end of the command execution log will be a message with path to self-signed certificate which should be imported into user's browser and link to the [docs](https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates) how to do it.

Despite the work done toward TLS direction, it is still possible _(but deprecated)_ to use no-tls mode. As usual, create `patch.yaml` with following content:
```yaml
spec:
  server:
    tlsSupport: false
```
and then pass `--che-operator-cr-patch-yaml=/path/to/pathc.yaml` to `chectl`.

In case of using Openshift like infrastuctures with self-signed certiicate, where the certificate is embedded into cluster, `chectl` will retrieve it as was described above.

**This PR sets `operator` installer as default one.**

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16052

### What was tested
I've tested Che deployment process and a workspace start:
 - on `Minikube`:
    - `operator` installer
    - `helm` installer
    - `operator` installer in no-tls mode
 - on `CRC`:
    - `operator` installer
    - `olm` installer