### PR TITLE
feat: Force user to change default Che admin password after first login

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1146,6 +1146,9 @@ export class KubeHelper {
       yamlCr.spec.server.cheDebug = flags.debug ? flags.debug.toString() : 'false'
 
       yamlCr.spec.auth.openShiftoAuth = flags['os-oauth']
+      if (!yamlCr.spec.auth.openShiftoAuth && flags.multiuser) {
+        yamlCr.spec.auth.updateAdminPassword = true
+      }
       if (flags.tls) {
         yamlCr.spec.server.tlsSupport = flags.tls
         if (!yamlCr.spec.k8s.tlsSecretName) {

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -87,6 +87,10 @@ export function createEclipeCheCluster(flags: any, kube: KubeHelper): ListrTask 
           flags.multiuser = false
         }
 
+        if (cr.spec.auth && cr.spec.auth.updateAdminPassword) {
+          ctx.highlightedMessages.push('You will be asked to change the default Che admin password on the first login.')
+        }
+
         task.title = `${task.title}...done.`
       }
     }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
If user deploys Che using chectl with default CR and OAuth is not enabled, force user to change Che admin password from default `admin:admin` on first login.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14082
