### PR TITLE
chore(deps-dev): Adding s390x support to chectl

### DIFF
--- a/installers/cert-manager.yml
+++ b/installers/cert-manager.yml
@@ -1,10 +1,34 @@
 # This file is copied from:
-#  https://github.com/jetstack/cert-manager/releases/download/v0.12.0/cert-manager.yaml
+#  https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.yaml
 ---
+# Copyright YEAR The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificaterequests.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.0'
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -27,6 +51,15 @@ spec:
     type: date
   group: cert-manager.io
   preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
   names:
     kind: CertificateRequest
     listKind: CertificateRequestList
@@ -38,8 +71,15 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
       description: CertificateRequest is a type to represent a Certificate Signing
         Request
       type: object
@@ -179,23 +219,27 @@ spec:
                     - "False"
                     - Unknown
                   type:
-                    description: Type of the condition, currently ('Ready').
+                    description: Type of the condition, currently ('Ready', 'InvalidRequest').
                     type: string
             failureTime:
               description: FailureTime stores the time that this CertificateRequest
                 failed. This is used to influence garbage collection and back-off.
               type: string
               format: date-time
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
 ---
+# Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.0'
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -221,6 +265,15 @@ spec:
     type: date
   group: cert-manager.io
   preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
   names:
     kind: Certificate
     listKind: CertificateList
@@ -232,214 +285,717 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: Certificate is a type to represent a Certificate from ACME
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateSpec defines the desired state of Certificate. A
-            valid Certificate requires at least one of a CommonName, DNSName, or URISAN
-            to be valid.
-          type: object
-          required:
-          - issuerRef
-          - secretName
-          properties:
-            commonName:
-              description: CommonName is a common name to be used on the Certificate.
-                The CommonName should have a length of 64 characters or fewer to avoid
-                generating invalid CSRs.
-              type: string
-            dnsNames:
-              description: DNSNames is a list of subject alt names to be used on the
-                Certificate.
-              type: array
-              items:
-                type: string
-            duration:
-              description: Certificate default Duration
-              type: string
-            ipAddresses:
-              description: IPAddresses is a list of IP addresses to be used on the
-                Certificate
-              type: array
-              items:
-                type: string
-            isCA:
-              description: IsCA will mark this Certificate as valid for signing. This
-                implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this certificate.
-                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the Certificate will
-                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times.
-              type: object
-              required:
-              - name
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-            keyAlgorithm:
-              description: KeyAlgorithm is the private key algorithm of the corresponding
-                private key for this certificate. If provided, allowed values are
-                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
-                not provided, key size of 256 will be used for "ecdsa" key algorithm
-                and key size of 2048 will be used for "rsa" key algorithm.
-              type: string
-              enum:
-              - rsa
-              - ecdsa
-            keyEncoding:
-              description: KeyEncoding is the private key cryptography standards (PKCS)
-                for this certificate's private key to be encoded in. If provided,
-                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
-                respectively. If KeyEncoding is not specified, then PKCS#1 will be
-                used by default.
-              type: string
-              enum:
-              - pkcs1
-              - pkcs8
-            keySize:
-              description: KeySize is the key bit size of the corresponding private
-                key for this certificate. If provided, value must be between 2048
-                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
-                to "ecdsa".
-              type: integer
-            organization:
-              description: Organization is the organization to be used on the Certificate
-              type: array
-              items:
-                type: string
-            renewBefore:
-              description: Certificate renew before expiration duration
-              type: string
-            secretName:
-              description: SecretName is the name of the secret resource to store
-                this secret in
-              type: string
-            uriSANs:
-              description: URISANs is a list of URI Subject Alternative Names to be
-                set on this Certificate.
-              type: array
-              items:
-                type: string
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              type: array
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-                  Valid KeyUsage values are as follows: "signing", "digital signature",
-                  "content commitment", "key encipherment", "key agreement", "data
-                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
-                  only", "any", "server auth", "client auth", "code signing", "email
-                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
-                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
-                  sgc"'
-                type: string
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-        status:
-          description: CertificateStatus defines the observed state of Certificate
-          type: object
-          properties:
-            conditions:
-              type: array
-              items:
-                description: CertificateCondition contains condition information for
-                  an Certificate.
-                type: object
-                required:
-                - status
-                - type
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-            lastFailureTime:
-              type: string
-              format: date-time
-            notAfter:
-              description: The expiration time of the certificate stored in the secret
-                named by this resource in spec.secretName.
-              type: string
-              format: date-time
-  version: v1alpha2
   versions:
   - name: v1alpha2
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: Certificate is a type to represent a Certificate from ACME
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                type: string
+                enum:
+                - rsa
+                - ecdsa
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                type: string
+                enum:
+                - pkcs1
+                - pkcs8
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                type: integer
+                maximum: 8192
+                minimum: 0
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+              organization:
+                description: Organization is the organization to be used on the Certificate
+                type: array
+                items:
+                  type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+              lastFailureTime:
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
+  - name: v1alpha3
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: Certificate is a type to represent a Certificate from ACME
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                type: string
+                enum:
+                - rsa
+                - ecdsa
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                type: string
+                enum:
+                - pkcs1
+                - pkcs8
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                type: integer
+                maximum: 8192
+                minimum: 0
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizations:
+                    description: Organizations to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+              lastFailureTime:
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
 ---
+# Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: challenges.acme.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.0'
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -461,6 +1017,15 @@ spec:
     type: date
   group: acme.cert-manager.io
   preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
   names:
     kind: Challenge
     listKind: ChallengeList
@@ -469,8 +1034,15 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
       description: Challenge is a type to represent a Challenge request with an ACME
         server
       type: object
@@ -496,6 +1068,7 @@ spec:
           - dnsName
           - issuerRef
           - key
+          - solver
           - token
           - type
           - url
@@ -506,7 +1079,9 @@ spec:
               type: string
             dnsName:
               description: DNSName is the identifier that this challenge is for, e.g.
-                example.com.
+                example.com. If the requested DNSName is a 'wildcard', this field
+                MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                it must be `example.com`.
               type: string
             issuerRef:
               description: IssuerRef references a properly configured ACME-type Issuer
@@ -525,7 +1100,13 @@ spec:
                 name:
                   type: string
             key:
-              description: Key is the ACME challenge key for this challenge
+              description: 'Key is the ACME challenge key for this challenge For HTTP01
+                challenges, this is the value that must be responded with to complete
+                the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
+                from acme server for challenge>`. For DNS01 challenges, this is the
+                base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                from acme server for challenge>` text that must be set as the TXT
+                record content.'
               type: string
             solver:
               description: Solver contains the domain solving configuration that should
@@ -615,15 +1196,16 @@ spec:
                         containing the configuration for Azure DNS
                       type: object
                       required:
-                      - clientID
-                      - clientSecretSecretRef
                       - resourceGroupName
                       - subscriptionID
-                      - tenantID
                       properties:
                         clientID:
+                          description: if both this and ClientSecret are left unset
+                            MSI will be used
                           type: string
                         clientSecretSecretRef:
+                          description: if both this and ClientID are left unset MSI
+                            will be used
                           type: object
                           required:
                           - name
@@ -650,6 +1232,8 @@ spec:
                         subscriptionID:
                           type: string
                         tenantID:
+                          description: when specifying ClientID and ClientSecret then
+                            this field is also needed
                           type: string
                     clouddns:
                       description: ACMEIssuerDNS01ProviderCloudDNS is a structure
@@ -743,8 +1327,11 @@ spec:
                       - nameserver
                       properties:
                         nameserver:
-                          description: 'The IP address of the DNS supporting RFC2136.
-                            Required. Note: FQDN is not a valid value, only IP.'
+                          description: The IP address or hostname of an authoritative
+                            DNS server supporting RFC2136 in the form host:port. If
+                            the host is an IPv6 address it must be enclosed in square
+                            brackets (e.g [2001:db8::1]) ; port is optional. This
+                            field is required.
                           type: string
                         tsigAlgorithm:
                           description: 'The TSIG Algorithm configured in the DNS supporting
@@ -867,6 +1454,31 @@ spec:
                             resources to solve ACME challenges that use this challenge
                             solver. Only one of 'class' or 'name' may be specified.
                           type: string
+                        ingressTemplate:
+                          description: Optional ingress template used to configure
+                            the ACME challenge solver ingress used for HTTP01 challenges
+                          type: object
+                          properties:
+                            metadata:
+                              description: ObjectMeta overrides for the ingress used
+                                to solve HTTP01 challenges. Only the 'labels' and
+                                'annotations' fields may be set. If labels or annotations
+                                overlap with in-built values, the values here will
+                                override the in-built values.
+                              type: object
+                              properties:
+                                annotations:
+                                  description: Annotations that should be added to
+                                    the created ACME HTTP01 solver ingress.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                labels:
+                                  description: Labels that should be added to the
+                                    created ACME HTTP01 solver ingress.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
                         name:
                           description: The name of the ingress resource that should
                             have ACME challenge solving routes inserted into it in
@@ -1773,11 +2385,12 @@ spec:
                       additionalProperties:
                         type: string
             token:
-              description: Token is the ACME challenge token for this challenge.
+              description: Token is the ACME challenge token for this challenge. This
+                is the raw value returned from the ACME server.
               type: string
             type:
               description: Type is the type of ACME challenge this resource represents,
-                e.g. "dns01" or "http01"
+                e.g. "dns01" or "http01".
               type: string
             url:
               description: URL is the URL of the ACME Challenge resource for this
@@ -1786,7 +2399,7 @@ spec:
               type: string
             wildcard:
               description: Wildcard will be true if this challenge is for a wildcard
-                identifier, for example '*.example.com'
+                identifier, for example '*.example.com'.
               type: boolean
         status:
           type: object
@@ -1822,16 +2435,20 @@ spec:
               - invalid
               - expired
               - errored
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
 ---
+# Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.0'
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -1850,6 +2467,15 @@ spec:
     type: date
   group: cert-manager.io
   preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
   names:
     kind: ClusterIssuer
     listKind: ClusterIssuerList
@@ -1858,8 +2484,15 @@ spec:
   scope: Cluster
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
       type: object
       properties:
         apiVersion:
@@ -1889,6 +2522,48 @@ spec:
                 email:
                   description: Email is the email for this account
                   type: string
+                externalAccountBinding:
+                  description: ExternalAccountBinding is a reference to a CA external
+                    account of the ACME server.
+                  type: object
+                  required:
+                  - keyAlgorithm
+                  - keyID
+                  - keySecretRef
+                  properties:
+                    keyAlgorithm:
+                      description: keyAlgorithm is the MAC key algorithm that the
+                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                      type: string
+                      enum:
+                      - HS256
+                      - HS384
+                      - HS512
+                    keyID:
+                      description: keyID is the ID of the CA key that the External
+                        Account is bound to.
+                      type: string
+                    keySecretRef:
+                      description: keySecretRef is a Secret Key Selector referencing
+                        a data item in a Kubernetes Secret which holds the symmetric
+                        MAC key of the External Account Binding. The `key` is the
+                        index string that is paired with the key data in the Secret
+                        and should not be confused with the key data itself, or indeed
+                        with the External Account Binding keyID above. The secret
+                        key stored in the Secret **must** be un-padded, base64 URL
+                        encoded data.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
                 privateKeySecretRef:
                   description: PrivateKey is the name of a secret containing the private
                     key for this user account.
@@ -2008,15 +2683,16 @@ spec:
                               containing the configuration for Azure DNS
                             type: object
                             required:
-                            - clientID
-                            - clientSecretSecretRef
                             - resourceGroupName
                             - subscriptionID
-                            - tenantID
                             properties:
                               clientID:
+                                description: if both this and ClientSecret are left
+                                  unset MSI will be used
                                 type: string
                               clientSecretSecretRef:
+                                description: if both this and ClientID are left unset
+                                  MSI will be used
                                 type: object
                                 required:
                                 - name
@@ -2045,6 +2721,8 @@ spec:
                               subscriptionID:
                                 type: string
                               tenantID:
+                                description: when specifying ClientID and ClientSecret
+                                  then this field is also needed
                                 type: string
                           clouddns:
                             description: ACMEIssuerDNS01ProviderCloudDNS is a structure
@@ -2147,9 +2825,11 @@ spec:
                             - nameserver
                             properties:
                               nameserver:
-                                description: 'The IP address of the DNS supporting
-                                  RFC2136. Required. Note: FQDN is not a valid value,
-                                  only IP.'
+                                description: The IP address or hostname of an authoritative
+                                  DNS server supporting RFC2136 in the form host:port.
+                                  If the host is an IPv6 address it must be enclosed
+                                  in square brackets (e.g [2001:db8::1]) ; port is
+                                  optional. This field is required.
                                 type: string
                               tsigAlgorithm:
                                 description: 'The TSIG Algorithm configured in the
@@ -2281,6 +2961,32 @@ spec:
                                   use this challenge solver. Only one of 'class' or
                                   'name' may be specified.
                                 type: string
+                              ingressTemplate:
+                                description: Optional ingress template used to configure
+                                  the ACME challenge solver ingress used for HTTP01
+                                  challenges
+                                type: object
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the ingress
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        description: Annotations that should be added
+                                          to the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      labels:
+                                        description: Labels that should be added to
+                                          the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
                               name:
                                 description: The name of the ingress resource that
                                   should have ACME challenge solving routes inserted
@@ -3293,12 +3999,29 @@ spec:
               required:
               - secretName
               properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
                 secretName:
                   description: SecretName is the name of the secret used to sign Certificates
                     issued by this Issuer.
                   type: string
             selfSigned:
               type: object
+              properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
             vault:
               type: object
               required:
@@ -3413,7 +4136,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for
@@ -3442,7 +4164,7 @@ spec:
                   - url
                   properties:
                     caBundle:
-                      description: CABundle is a PEM encoded TLS certifiate to use
+                      description: CABundle is a PEM encoded TLS certificate to use
                         to verify connections to the TPP instance. If specified, system
                         roots will not be used and the issuing CA for the TPP instance
                         must be verifiable using the provided root. If not specified,
@@ -3520,16 +4242,20 @@ spec:
                   type:
                     description: Type of the condition, currently ('Ready').
                     type: string
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
 ---
+# Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.0'
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -3548,6 +4274,15 @@ spec:
     type: date
   group: cert-manager.io
   preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
   names:
     kind: Issuer
     listKind: IssuerList
@@ -3556,8 +4291,15 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
       type: object
       properties:
         apiVersion:
@@ -3587,6 +4329,48 @@ spec:
                 email:
                   description: Email is the email for this account
                   type: string
+                externalAccountBinding:
+                  description: ExternalAccountBinding is a reference to a CA external
+                    account of the ACME server.
+                  type: object
+                  required:
+                  - keyAlgorithm
+                  - keyID
+                  - keySecretRef
+                  properties:
+                    keyAlgorithm:
+                      description: keyAlgorithm is the MAC key algorithm that the
+                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                      type: string
+                      enum:
+                      - HS256
+                      - HS384
+                      - HS512
+                    keyID:
+                      description: keyID is the ID of the CA key that the External
+                        Account is bound to.
+                      type: string
+                    keySecretRef:
+                      description: keySecretRef is a Secret Key Selector referencing
+                        a data item in a Kubernetes Secret which holds the symmetric
+                        MAC key of the External Account Binding. The `key` is the
+                        index string that is paired with the key data in the Secret
+                        and should not be confused with the key data itself, or indeed
+                        with the External Account Binding keyID above. The secret
+                        key stored in the Secret **must** be un-padded, base64 URL
+                        encoded data.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
                 privateKeySecretRef:
                   description: PrivateKey is the name of a secret containing the private
                     key for this user account.
@@ -3706,15 +4490,16 @@ spec:
                               containing the configuration for Azure DNS
                             type: object
                             required:
-                            - clientID
-                            - clientSecretSecretRef
                             - resourceGroupName
                             - subscriptionID
-                            - tenantID
                             properties:
                               clientID:
+                                description: if both this and ClientSecret are left
+                                  unset MSI will be used
                                 type: string
                               clientSecretSecretRef:
+                                description: if both this and ClientID are left unset
+                                  MSI will be used
                                 type: object
                                 required:
                                 - name
@@ -3743,6 +4528,8 @@ spec:
                               subscriptionID:
                                 type: string
                               tenantID:
+                                description: when specifying ClientID and ClientSecret
+                                  then this field is also needed
                                 type: string
                           clouddns:
                             description: ACMEIssuerDNS01ProviderCloudDNS is a structure
@@ -3845,9 +4632,11 @@ spec:
                             - nameserver
                             properties:
                               nameserver:
-                                description: 'The IP address of the DNS supporting
-                                  RFC2136. Required. Note: FQDN is not a valid value,
-                                  only IP.'
+                                description: The IP address or hostname of an authoritative
+                                  DNS server supporting RFC2136 in the form host:port.
+                                  If the host is an IPv6 address it must be enclosed
+                                  in square brackets (e.g [2001:db8::1]) ; port is
+                                  optional. This field is required.
                                 type: string
                               tsigAlgorithm:
                                 description: 'The TSIG Algorithm configured in the
@@ -3979,6 +4768,32 @@ spec:
                                   use this challenge solver. Only one of 'class' or
                                   'name' may be specified.
                                 type: string
+                              ingressTemplate:
+                                description: Optional ingress template used to configure
+                                  the ACME challenge solver ingress used for HTTP01
+                                  challenges
+                                type: object
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the ingress
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        description: Annotations that should be added
+                                          to the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      labels:
+                                        description: Labels that should be added to
+                                          the created ACME HTTP01 solver ingress.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
                               name:
                                 description: The name of the ingress resource that
                                   should have ACME challenge solving routes inserted
@@ -4991,12 +5806,29 @@ spec:
               required:
               - secretName
               properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
                 secretName:
                   description: SecretName is the name of the secret used to sign Certificates
                     issued by this Issuer.
                   type: string
             selfSigned:
               type: object
+              properties:
+                crlDistributionPoints:
+                  description: The CRL distribution points is an X.509 v3 certificate
+                    extension which identifies the location of the CRL from which
+                    the revocation of this certificate can be checked. If not set
+                    certificate will be issued without CDP. Values are strings.
+                  type: array
+                  items:
+                    type: string
             vault:
               type: object
               required:
@@ -5111,7 +5943,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for
@@ -5140,7 +5971,7 @@ spec:
                   - url
                   properties:
                     caBundle:
-                      description: CABundle is a PEM encoded TLS certifiate to use
+                      description: CABundle is a PEM encoded TLS certificate to use
                         to verify connections to the TPP instance. If specified, system
                         roots will not be used and the issuing CA for the TPP instance
                         must be verifiable using the provided root. If not specified,
@@ -5218,16 +6049,20 @@ spec:
                   type:
                     description: Type of the condition, currently ('Ready').
                     type: string
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
 ---
+# Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: orders.acme.cert-manager.io
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/managed-by: 'Helm'
+    helm.sh/chart: 'cert-manager-v0.15.0'
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -5250,6 +6085,15 @@ spec:
     type: date
   group: acme.cert-manager.io
   preserveUnknownFields: false
+  conversion:
+    # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.
+    strategy: Webhook
+    # webhookClientConfig is required when strategy is `Webhook` and it configures the webhook endpoint to be called by API server.
+    webhookClientConfig:
+      service:
+        namespace: 'cert-manager'
+        name: 'cert-manager-webhook'
+        path: /convert
   names:
     kind: Order
     listKind: OrderList
@@ -5258,8 +6102,15 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+  "validation":
+    "openAPIV3Schema":
       description: Order is a type to represent an Order with an ACME server
       type: object
       required:
@@ -5326,8 +6177,8 @@ spec:
           properties:
             authorizations:
               description: Authorizations contains data returned from the ACME server
-                on what authoriations must be completed in order to validate the DNS
-                names specified on the Order.
+                on what authorizations must be completed in order to validate the
+                DNS names specified on the Order.
               type: array
               items:
                 description: ACMEAuthorization contains data returned from the ACME
@@ -5371,6 +6222,24 @@ spec:
                     description: Identifier is the DNS name to be validated as part
                       of this authorization
                     type: string
+                  initialState:
+                    description: InitialState is the initial state of the ACME authorization
+                      when first fetched from the ACME server. If an Authorization
+                      is already 'valid', the Order controller will not create a Challenge
+                      resource for the authorization. This will occur when working
+                      with an ACME server that enables 'authz reuse' (such as Let's
+                      Encrypt's production endpoint). If not set and 'identifier'
+                      is set, the state is assumed to be pending and a Challenge will
+                      be created.
+                    type: string
+                    enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
                   url:
                     description: URL is the URL of the Authorization that must be
                       completed
@@ -5420,12 +6289,6 @@ spec:
                 field when the Order is first processed. This field will be immutable
                 after it is initially set.
               type: string
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
 ---
 apiVersion: v1
 kind: Namespace
@@ -5442,9 +6305,9 @@ metadata:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.0
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -5452,14 +6315,13 @@ kind: ServiceAccount
 metadata:
   name: cert-manager
   namespace: "cert-manager"
-  annotations:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -5471,8 +6333,9 @@ metadata:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -5483,8 +6346,9 @@ metadata:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -5504,218 +6368,11 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-cainjector
-  labels:
-    app: cainjector
-    app.kubernetes.io/name: cainjector
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-cainjector
-subjects:
-  - name: cert-manager-cainjector
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-# leader election rules
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  name: cert-manager-cainjector:leaderelection
-  namespace: kube-system
-  labels:
-    app: cainjector
-    app.kubernetes.io/name: cainjector
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-rules:
-  # Used for leader election by the controller
-  # TODO: refine the permission to *just* the leader election configmap
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "create", "update", "patch"]
-
----
-
-# grant cert-manager permission to manage the leaderelection configmap in the
-# leader election namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: cert-manager-cainjector:leaderelection
-  namespace: kube-system
-  labels:
-    app: cainjector
-    app.kubernetes.io/name: cainjector
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: cert-manager-cainjector:leaderelection
-subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: cert-manager-cainjector
-    namespace: cert-manager
----
-# Source: cert-manager/templates/webhook-rbac.yaml
-### Webhook ###
----
-# apiserver gets the auth-delegator role to delegate auth decisions to
-# the core apiserver
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-webhook:auth-delegator
-  labels:
-    app: webhook
-    app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-- apiGroup: ""
-  kind: ServiceAccount
-  name: cert-manager-webhook
-  namespace: cert-manager
-
----
-
-# apiserver gets the ability to read authentication. This allows it to
-# read the specific configmap that has the requestheader-* entries to
-# api agg
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: cert-manager-webhook:webhook-authentication-reader
-  namespace: kube-system
-  labels:
-    app: webhook
-    app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
-subjects:
-- apiGroup: ""
-  kind: ServiceAccount
-  name: cert-manager-webhook
-  namespace: cert-manager
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cert-manager-webhook:webhook-requester
-  labels:
-    app: webhook
-    app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-rules:
-- apiGroups:
-  - admission.cert-manager.io
-  resources:
-  - certificates
-  - certificaterequests
-  - issuers
-  - clusterissuers
-  verbs:
-  - create
+  - apiGroups: ["auditregistration.k8s.io"]
+    resources: ["auditsinks"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 # Source: cert-manager/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  name: cert-manager:leaderelection
-  namespace: kube-system
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-rules:
-  # Used for leader election by the controller
-  # TODO: refine the permission to *just* the leader election configmap
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "create", "update", "patch"]
-
----
-
-# grant cert-manager permission to manage the leaderelection configmap in the
-# leader election namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: cert-manager:leaderelection
-  namespace: kube-system
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: cert-manager:leaderelection
-subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: cert-manager
-    namespace: cert-manager
-
----
-
-# Issuer controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-issuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-rules:
-  - apiGroups: ["cert-manager.io"]
-    resources: ["issuers", "issuers/status"]
-    verbs: ["update"]
-  - apiGroups: ["cert-manager.io"]
-    resources: ["issuers"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
 # ClusterIssuer controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -5725,8 +6382,9 @@ metadata:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -5740,84 +6398,35 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-
 ---
-
-# Certificates controller role
+# Source: cert-manager/templates/rbac.yaml
+# Issuer controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: cert-manager-controller-certificates
+  name: cert-manager-controller-issuers
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 rules:
   - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    resources: ["issuers", "issuers/status"]
     verbs: ["update"]
   - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    resources: ["issuers"]
     verbs: ["get", "list", "watch"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
-    verbs: ["update"]
-  - apiGroups: ["acme.cert-manager.io"]
-    resources: ["orders"]
-    verbs: ["create", "delete", "get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-
 ---
-
-# Orders controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-orders
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-rules:
-  - apiGroups: ["acme.cert-manager.io"]
-    resources: ["orders", "orders/status"]
-    verbs: ["update"]
-  - apiGroups: ["acme.cert-manager.io"]
-    resources: ["orders", "challenges"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["cert-manager.io"]
-    resources: ["clusterissuers", "issuers"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["acme.cert-manager.io"]
-    resources: ["challenges"]
-    verbs: ["create", "delete"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["acme.cert-manager.io"]
-    resources: ["orders/finalizers"]
-    verbs: ["update"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
+# Source: cert-manager/templates/rbac.yaml
 # Challenges controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -5827,8 +6436,9 @@ metadata:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -5857,6 +6467,12 @@ rules:
   - apiGroups: ["extensions"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
+  # We require the ability to specify a custom hostname when we are creating
+  # new ingress resources.
+  # See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes/custom-host"]
+    verbs: ["create"]
   # We require these rules to support users with the OwnerReferencesPermissionEnforcement
   # admission controller enabled:
   # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
@@ -5867,9 +6483,66 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-
 ---
-
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-edit
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Orders controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+rules:
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "orders/status"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["create", "delete"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
 # ingress-shim controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -5879,8 +6552,9 @@ metadata:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -5900,135 +6574,44 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-
 ---
-
+# Source: cert-manager/templates/rbac.yaml
+# Certificates controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-issuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-issuers
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-clusterissuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-clusterissuers
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
   name: cert-manager-controller-certificates
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-certificates
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-orders
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-orders
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-challenges
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-challenges
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-ingress-shim
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-ingress-shim
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
+# Source: cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -6037,8 +6620,9 @@ metadata:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -6046,29 +6630,302 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]
     verbs: ["get", "list", "watch"]
-
 ---
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
 metadata:
-  name: cert-manager-edit
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-cainjector
+subjects:
+  - name: cert-manager-cainjector
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-ingress-shim
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-ingress-shim
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-challenges
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-issuers
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# leader election rules
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.0
 rules:
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificaterequests", "issuers"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
-
+  # Used for leader election by the controller
+  # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
+  #   see cmd/cainjector/start.go#L113
+  # cert-manager-cainjector-leader-election-core is used by the SecretBased injector controller
+  #   see cmd/cainjector/start.go#L137
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+rules:
+  # Used for leader election by the controller
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cert-manager-controller"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager-webhook:dynamic-serving
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+  - 'cert-manager-webhook-ca'
+  verbs: ["get", "list", "watch", "update"]
+# It's not possible to grant CREATE permission on a single resourceName.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-cainjector:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-cainjector
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook:dynamic-serving
+  namespace: "cert-manager"
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-webhook:dynamic-serving
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook
+  namespace: cert-manager
 ---
 # Source: cert-manager/templates/service.yaml
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -6078,8 +6935,9 @@ metadata:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 spec:
   type: ClusterIP
   ports:
@@ -6089,7 +6947,7 @@ spec:
   selector:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-
+    app.kubernetes.io/component: "controller"
 ---
 # Source: cert-manager/templates/webhook-service.yaml
 apiVersion: v1
@@ -6101,8 +6959,9 @@ metadata:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
 spec:
   type: ClusterIP
   ports:
@@ -6110,10 +6969,9 @@ spec:
     port: 443
     targetPort: 10250
   selector:
-    app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
+    app.kubernetes.io/component: "webhook"
 ---
 # Source: cert-manager/templates/cainjector-deployment.yaml
 apiVersion: apps/v1
@@ -6125,30 +6983,30 @@ metadata:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: cert-manager-v0.15.0
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: cainjector
       app.kubernetes.io/name: cainjector
       app.kubernetes.io/instance: cert-manager
-      app.kubernetes.io/managed-by: Tiller
+      app.kubernetes.io/component: "cainjector"
   template:
     metadata:
       labels:
         app: cainjector
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Tiller
-        helm.sh/chart: cert-manager-v0.12.0
-      annotations:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: "cainjector"
+        helm.sh/chart: cert-manager-v0.15.0
     spec:
       serviceAccountName: cert-manager-cainjector
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-cainjector:v0.12.0"
+          image: "quay.io/jetstack/cert-manager-cainjector:v0.15.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -6160,8 +7018,6 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-
-
 ---
 # Source: cert-manager/templates/deployment.yaml
 apiVersion: apps/v1
@@ -6173,24 +7029,25 @@ metadata:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: cert-manager-v0.15.0
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: cert-manager
       app.kubernetes.io/name: cert-manager
       app.kubernetes.io/instance: cert-manager
-      app.kubernetes.io/managed-by: Tiller
+      app.kubernetes.io/component: "controller"
   template:
     metadata:
       labels:
         app: cert-manager
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Tiller
-        helm.sh/chart: cert-manager-v0.12.0
+        app.kubernetes.io/component: "controller"
+        app.kubernetes.io/managed-by: Helm
+        helm.sh/chart: cert-manager-v0.15.0
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -6199,16 +7056,12 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.12.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.15.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --webhook-namespace=$(POD_NAMESPACE)
-          - --webhook-ca-secret=cert-manager-webhook-ca
-          - --webhook-serving-secret=cert-manager-webhook-tls
-          - --webhook-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc
           ports:
           - containerPort: 9402
             protocol: TCP
@@ -6218,11 +7071,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
-
-
+            {}
 ---
 # Source: cert-manager/templates/webhook-deployment.yaml
 apiVersion: apps/v1
@@ -6234,46 +7083,54 @@ metadata:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: webhook
       app.kubernetes.io/name: webhook
       app.kubernetes.io/instance: cert-manager
-      app.kubernetes.io/managed-by: Tiller
+      app.kubernetes.io/component: "webhook"
   template:
     metadata:
       labels:
         app: webhook
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Tiller
-        helm.sh/chart: cert-manager-v0.12.0
-      annotations:
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: "webhook"
+        helm.sh/chart: cert-manager-v0.15.0
     spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v0.12.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.15.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --secure-port=10250
-          - --tls-cert-file=/certs/tls.crt
-          - --tls-private-key-file=/certs/tls.key
+          - --dynamic-serving-ca-secret-namespace=cert-manager
+          - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
+          - --dynamic-serving-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc
+          ports:
+          - name: https
+            containerPort: 10250
           livenessProbe:
             httpGet:
               path: /livez
               port: 6080
               scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
               port: 6080
               scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -6281,14 +7138,6 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-
-          volumeMounts:
-          - name: certs
-            mountPath: /certs
-      volumes:
-      - name: certs
-        secret:
-          secretName: cert-manager-webhook-tls
 ---
 # Source: cert-manager/templates/webhook-mutating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -6299,10 +7148,11 @@ metadata:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
   annotations:
-    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-tls"
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
   - name: webhook.cert-manager.io
     rules:
@@ -6311,58 +7161,20 @@ webhooks:
           - "acme.cert-manager.io"
         apiVersions:
           - v1alpha2
+          - v1alpha3
         operations:
           - CREATE
           - UPDATE
         resources:
           - "*/*"
     failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
     clientConfig:
       service:
         name: cert-manager-webhook
         namespace: "cert-manager"
         path: /mutate
----
-# Source: cert-manager/templates/cainjector-psp-clusterrole.yaml
-
-
----
-# Source: cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
-
-
----
-# Source: cert-manager/templates/cainjector-psp.yaml
-
-
----
-# Source: cert-manager/templates/psp-clusterrole.yaml
-
-
----
-# Source: cert-manager/templates/psp-clusterrolebinding.yaml
-
-
----
-# Source: cert-manager/templates/psp.yaml
-
-
----
-# Source: cert-manager/templates/servicemonitor.yaml
-
-
----
-# Source: cert-manager/templates/webhook-psp-clusterrole.yaml
-
-
----
-# Source: cert-manager/templates/webhook-psp-clusterrolebinding.yaml
-
-
----
-# Source: cert-manager/templates/webhook-psp.yaml
-
-
 ---
 # Source: cert-manager/templates/webhook-validating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -6373,10 +7185,11 @@ metadata:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.12.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: cert-manager-v0.15.0
   annotations:
-    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-tls"
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
   - name: webhook.cert-manager.io
     namespaceSelector:
@@ -6395,15 +7208,17 @@ webhooks:
           - "acme.cert-manager.io"
         apiVersions:
           - v1alpha2
+          - v1alpha3
         operations:
           - CREATE
           - UPDATE
         resources:
           - "*/*"
     failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
     clientConfig:
       service:
         name: cert-manager-webhook
         namespace: "cert-manager"
-        path: /mutate
+        path: /validate


### PR DESCRIPTION
Signed-off-by: Prabhav Thali <Prabhav.Thali1@ibm.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Upgrade cert-manager from `v0.12.0` to `v0.15.0` as `v0.15.0` cert-manager images have multi-arch support.

### What issues does this PR fix or reference?
This PR is part of [this ](https://github.com/eclipse/che/issues/16655)initiative.
