### PR TITLE
fix: Detect olm installer type for server:update command

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -10,6 +10,7 @@
 
 import { Command, flags } from '@oclif/command'
 import { boolean, string } from '@oclif/parser/lib/flags'
+import { cli } from 'cli-ux'
 import * as fs from 'fs-extra'
 import * as yaml from 'js-yaml'
 import * as Listr from 'listr'
@@ -17,6 +18,7 @@ import * as notifier from 'node-notifier'
 import * as os from 'os'
 import * as path from 'path'
 
+import { KubeHelper } from '../../api/kube'
 import { cheDeployment, cheNamespace, listrRenderer, skipKubeHealthzCheck as skipK8sHealthCheck } from '../../common-flags'
 import { DEFAULT_CHE_IMAGE, DEFAULT_CHE_OPERATOR_IMAGE, DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT } from '../../constants'
 import { CheTasks } from '../../tasks/che'
@@ -24,7 +26,7 @@ import { getRetrieveKeycloakCredentialsTask, retrieveCheCaCertificateTask } from
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
-import { isOpenshiftPlatformFamily, setDefaultInstaller } from '../../util'
+import { isOpenshiftPlatformFamily } from '../../util'
 
 export default class Start extends Command {
   static description = 'start Eclipse Che server'
@@ -192,7 +194,7 @@ export default class Start extends Command {
     flags.tls = await this.checkTlsMode(flags)
 
     if (!flags.installer) {
-      await setDefaultInstaller(flags)
+      await this.setDefaultInstaller(flags)
     }
 
     if (!flags.templates) {
@@ -416,5 +418,20 @@ export default class Start extends Command {
     })
 
     this.exit(0)
+  }
+
+  /**
+   * Sets default installer which is `olm` for OpenShift 4 with stable version of chectl
+   * and `operator` for other cases.
+   */
+  async setDefaultInstaller(flags: any): Promise<void> {
+    const cheVersion = DEFAULT_CHE_OPERATOR_IMAGE.split(':')[1]
+    const kubeHelper = new KubeHelper(flags)
+    if (flags.platform === 'openshift' && await kubeHelper.isOpenShift4() && cheVersion !== 'nightly' && cheVersion !== 'latest') {
+      flags.installer = 'olm'
+    } else {
+      flags.installer = 'operator'
+      cli.info(`› Installer type is set to: '${flags.installer}'`)
+    }
   }
 }

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -21,9 +21,10 @@ import { cheDeployment, cheNamespace, listrRenderer, skipKubeHealthzCheck } from
 import { CHE_CLUSTER_CR_NAME, DEFAULT_CHE_OPERATOR_IMAGE } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { InstallerTasks } from '../../tasks/installers/installer'
+import { OLMTasks } from '../../tasks/installers/olm'
 import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
-import { isKubernetesPlatformFamily, setDefaultInstaller } from '../../util'
+import { isKubernetesPlatformFamily } from '../../util'
 
 export default class Update extends Command {
   static description = 'update Eclipse Che server'
@@ -75,7 +76,7 @@ export default class Update extends Command {
   async checkIfInstallerSupportUpdating(flags: any) {
     // matrix checks
     if (!flags.installer) {
-      await setDefaultInstaller(flags)
+      await this.setDefaultInstaller(flags)
     }
 
     if (flags.installer === 'operator' || flags.installer === 'olm') {
@@ -166,5 +167,16 @@ export default class Update extends Command {
     if (cheCluster && cheCluster.spec.k8s && cheCluster.spec.k8s.ingressDomain) {
       flags.domain = cheCluster.spec.k8s.ingressDomain
     }
+  }
+
+  async setDefaultInstaller(flags: any): Promise<void> {
+    const kubeHelper = new KubeHelper(flags)
+    try {
+      await kubeHelper.getOperatorSubscription(OLMTasks.SUBSCRIPTION_NAME, flags.chenamespace)
+      flags.installer = 'olm'
+    } catch {
+      flags.installer = 'operator'
+    }
+    cli.info(`› Installer type is set to: '${flags.installer}'`)
   }
 }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -492,7 +492,7 @@ export class CheTasks {
     return [
       {
         title: `${follow ? 'Start following' : 'Read'} Operator logs`,
-        skip: () => flags.installer && flags.installer !== 'operator',
+        skip: () => flags.installer !== 'operator' && flags.installer !== 'olm',
         task: async (ctx: any, task: any) => {
           await this.che.readPodLog(flags.chenamespace, this.cheOperatorSelector, ctx.directory, follow)
           task.title = `${task.title}...done`

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,11 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { cli } from 'cli-ux'
 import * as commandExists from 'command-exists'
-
-import { KubeHelper } from './api/kube'
-import { DEFAULT_CHE_OPERATOR_IMAGE } from './constants'
 
 export const KUBERNETES_CLI = 'kubectl'
 export const OPENSHIFT_CLI = 'oc'
@@ -67,20 +63,4 @@ export function generatePassword(passwodLength: number, charactersSet = '') {
 
 export function base64Decode(arg: string): string {
   return Buffer.from(arg, 'base64').toString('ascii')
-}
-
-/**
- * Sets default installer which is `olm` for OpenShift 4 with stable version of chectl
- * and `operator` for other cases.
- */
-export async function setDefaultInstaller(flags: any): Promise<void> {
-  const cheVersion = DEFAULT_CHE_OPERATOR_IMAGE.split(':')[1]
-  const kubeHelper = new KubeHelper(flags)
-  if (flags.platform === 'openshift' && await kubeHelper.isOpenShift4() && cheVersion !== 'nightly' && cheVersion !== 'latest') {
-    flags.installer = 'olm'
-    cli.info('OLM installer is used for OpenShift v4.x')
-  } else {
-    flags.installer = 'operator'
-    cli.info('Operator installer is used by default')
-  }
 }


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Check if subscription exists and automatically set installer type to `olm` if it wasn't specified.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16861
