### PR TITLE
fix: Check for oAuth platform configuration only on server start and update

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -23,6 +23,7 @@ import { CheTasks } from '../../tasks/che'
 import { getRetrieveKeycloakCredentialsTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
+import { CommonPlatformTasks } from '../../tasks/platforms/common-platform-tasks'
 import { PlatformTasks } from '../../tasks/platforms/platform'
 import { isOpenshiftPlatformFamily, setDefaultInstaller } from '../../util'
 
@@ -331,6 +332,7 @@ export default class Start extends Command {
 
     // Platform Checks
     let platformCheckTasks = new Listr(platformTasks.preflightCheckTasks(flags, this), listrOptions)
+    platformCheckTasks.add(CommonPlatformTasks.oAuthProvidersExists(flags))
 
     // Checks if Eclipse Che is already deployed
     let preInstallTasks = new Listr(undefined, listrOptions)

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -12,7 +12,7 @@ import ansi = require('ansi-colors')
 import { cli } from 'cli-ux'
 import * as execa from 'execa'
 import { copy, mkdirp, remove } from 'fs-extra'
-import { ListrTask } from 'listr'
+import * as Listr from 'listr'
 import * as path from 'path'
 
 import { CheHelper } from '../../api/che'
@@ -20,7 +20,7 @@ import { KubeHelper } from '../../api/kube'
 import { CHE_CLUSTER_CR_NAME, DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER } from '../../constants'
 import { isKubernetesPlatformFamily, isOpenshiftPlatformFamily } from '../../util'
 
-export function createNamespaceTask(flags: any): ListrTask {
+export function createNamespaceTask(flags: any): Listr.ListrTask {
   return {
     title: `Create Namespace (${flags.chenamespace})`,
     task: async (_ctx: any, task: any) => {
@@ -39,7 +39,7 @@ export function createNamespaceTask(flags: any): ListrTask {
   }
 }
 
-export function copyOperatorResources(flags: any, cacheDir: string): ListrTask {
+export function copyOperatorResources(flags: any, cacheDir: string): Listr.ListrTask {
   return {
     title: 'Copying operator resources',
     task: async (ctx: any, task: any) => {
@@ -60,7 +60,7 @@ async function copyCheOperatorResources(templatesDir: string, cacheDir: string):
   return destDir
 }
 
-export function createEclipseCheCluster(flags: any, kube: KubeHelper): ListrTask {
+export function createEclipseCheCluster(flags: any, kube: KubeHelper): Listr.ListrTask {
   return {
     title: `Create Eclipse Che cluster ${CHE_CLUSTER_CR_NAME} in namespace ${flags.chenamespace}`,
     task: async (ctx: any, task: any) => {
@@ -99,7 +99,7 @@ export function createEclipseCheCluster(flags: any, kube: KubeHelper): ListrTask
   }
 }
 
-export function checkTlsCertificate(flags: any): ListrTask {
+export function checkTlsCertificate(flags: any): Listr.ListrTask {
   return {
     title: 'Checking certificate',
     // It makes sense to check whether self-signed certificate is used only if TLS mode is on
@@ -133,7 +133,7 @@ export function checkTlsCertificate(flags: any): ListrTask {
   }
 }
 
-export function retrieveCheCaCertificateTask(flags: any): ListrTask {
+export function retrieveCheCaCertificateTask(flags: any): Listr.ListrTask {
   return {
     title: 'Retrieving Che self-signed CA certificate',
     // It makes sense to retrieve CA certificate only if self-signed certificate is used.
@@ -155,7 +155,7 @@ export function getMessageImportCaCertIntoBrowser(caCertFileLocation: string): s
   return message
 }
 
-export function getRetrieveKeycloakCredentialsTask(flags: any): ListrTask {
+export function getRetrieveKeycloakCredentialsTask(flags: any): Listr.ListrTask {
   return {
     title: 'Retrieving Keycloak admin credentials',
     enabled: (ctx: any) => ctx.cr && !ctx.cr.spec.auth.externalIdentityProvider && flags.multiuser && (flags.installer !== 'operator' || flags.installer !== 'olm'),
@@ -169,6 +169,27 @@ export function getRetrieveKeycloakCredentialsTask(flags: any): ListrTask {
       } else {
         task.title = `${task.title }... Failed.`
       }
+    }
+  }
+}
+
+/**
+ * Prints important to user messages which are stored in ctx.highlightedMessages
+ * Typically this task is the last task of a command.
+ */
+export function getPrintHighlightedMessagesTask(): Listr.ListrTask {
+  return {
+    title: 'Show important messages',
+    enabled: ctx => ctx.highlightedMessages && ctx.highlightedMessages.length > 0,
+    task: (ctx: any) => {
+      const printMessageTasks = new Listr([], ctx.listrOptions)
+      for (const message of ctx.highlightedMessages) {
+        printMessageTasks.add({
+          title: message,
+          task: () => { }
+        })
+      }
+      return printMessageTasks
     }
   }
 }

--- a/src/tasks/platforms/common-platform-tasks.ts
+++ b/src/tasks/platforms/common-platform-tasks.ts
@@ -103,26 +103,26 @@ export namespace CommonPlatformTasks {
   }
 
   /**
-   * Checks if Openshift oAuth is disabled via operator custom resource.
+   * Checks if Openshift oAuth enabled in Che configuration.
    * Returns true if Openshift oAuth is enabled (or omitted) and false if it is explicitly disabled.
    */
   async function isOAuthEnabled(flags: any): Promise<boolean> {
-    if (flags['che-operator-cr-yaml']) {
-      const cheOperatorCrYamlPath = flags['che-operator-cr-yaml']
-      if (fs.existsSync(cheOperatorCrYamlPath)) {
-        const cr = yaml.safeLoad(fs.readFileSync(cheOperatorCrYamlPath).toString())
-        if (cr && cr.spec && cr.spec.auth && typeof cr.spec.auth.openShiftoAuth === 'boolean') {
-          return cr.spec.auth.openShiftoAuth
-        }
-      }
-    }
-
     if (flags['che-operator-cr-patch-yaml']) {
       const cheOperatorCrPatchYamlPath = flags['che-operator-cr-patch-yaml']
       if (fs.existsSync(cheOperatorCrPatchYamlPath)) {
         const crPatch = yaml.safeLoad(fs.readFileSync(cheOperatorCrPatchYamlPath).toString())
         if (crPatch && crPatch.spec && crPatch.spec.auth && typeof crPatch.spec.auth.openShiftoAuth === 'boolean') {
           return crPatch.spec.auth.openShiftoAuth
+        }
+      }
+    }
+
+    if (flags['che-operator-cr-yaml']) {
+      const cheOperatorCrYamlPath = flags['che-operator-cr-yaml']
+      if (fs.existsSync(cheOperatorCrYamlPath)) {
+        const cr = yaml.safeLoad(fs.readFileSync(cheOperatorCrYamlPath).toString())
+        if (cr && cr.spec && cr.spec.auth && typeof cr.spec.auth.openShiftoAuth === 'boolean') {
+          return cr.spec.auth.openShiftoAuth
         }
       }
     }

--- a/src/tasks/platforms/common-platform-tasks.ts
+++ b/src/tasks/platforms/common-platform-tasks.ts
@@ -106,7 +106,7 @@ export namespace CommonPlatformTasks {
    * Checks if Openshift oAuth enabled in Che configuration.
    * Returns true if Openshift oAuth is enabled (or omitted) and false if it is explicitly disabled.
    */
-  async function isOAuthEnabled(flags: any): Promise<boolean> {
+  function isOAuthEnabled(flags: any): boolean {
     if (flags['che-operator-cr-patch-yaml']) {
       const cheOperatorCrPatchYamlPath = flags['che-operator-cr-patch-yaml']
       if (fs.existsSync(cheOperatorCrPatchYamlPath)) {

--- a/src/tasks/platforms/crc.ts
+++ b/src/tasks/platforms/crc.ts
@@ -15,8 +15,6 @@ import * as Listr from 'listr'
 
 import { VersionHelper } from '../../api/version'
 
-import { CommonPlatformTasks } from './common-platform-tasks'
-
 /**
  * Helper for Code Ready Container
  */
@@ -65,7 +63,6 @@ export class CRCHelper {
           task.title = `${task.title}...${flags.domain}.`
         }
       },
-      CommonPlatformTasks.oAuthProvidersExists(flags)
     ], { renderer: flags['listr-renderer'] as any })
   }
 

--- a/src/tasks/platforms/minishift.ts
+++ b/src/tasks/platforms/minishift.ts
@@ -15,8 +15,6 @@ import * as Listr from 'listr'
 
 import { VersionHelper } from '../../api/version'
 
-import { CommonPlatformTasks } from './common-platform-tasks'
-
 export class MinishiftTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
@@ -56,7 +54,6 @@ export class MinishiftTasks {
       },
       VersionHelper.getOpenShiftCheckVersionTask(flags),
       VersionHelper.getK8sCheckVersionTask(flags),
-      CommonPlatformTasks.oAuthProvidersExists(flags)
     ], { renderer: flags['listr-renderer'] as any })
   }
 

--- a/src/tasks/platforms/openshift.ts
+++ b/src/tasks/platforms/openshift.ts
@@ -15,8 +15,6 @@ import * as Listr from 'listr'
 
 import { VersionHelper } from '../../api/version'
 
-import { CommonPlatformTasks } from './common-platform-tasks'
-
 export class OpenshiftTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
@@ -46,7 +44,6 @@ export class OpenshiftTasks {
       },
       VersionHelper.getOpenShiftCheckVersionTask(flags),
       VersionHelper.getK8sCheckVersionTask(flags),
-      CommonPlatformTasks.oAuthProvidersExists(flags)
     ], { renderer: flags['listr-renderer'] as any })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,11 +1525,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#87742c56ba2c3b12cf81c174716504b84f62c846"
+  resolved "git://github.com/eclipse/che-operator#03978b3724a455df8a48d72c8bfbab8556f270d4"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#d32dd563eb193d4c516be5b64a2e07638a8037b5"
+  resolved "git://github.com/eclipse/che#626b945cd9749391627226ad100b6ea278f2156a"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes oAuth configuration checker run only if `server:start` or `server:update` command is used.
