### PR TITLE
fix(yarn.lock): Update the operator to latest upstream commit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,7 +1529,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#626b945cd9749391627226ad100b6ea278f2156a"
+  resolved "git://github.com/eclipse/che#998c413ab70d20d67b5f0a4462d25b97e6812d7f"
 
 editorconfig@^0.15.0:
   version "0.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,7 +1525,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#03978b3724a455df8a48d72c8bfbab8556f270d4"
+  resolved "git://github.com/eclipse/che-operator#8a4e1d5edfd26f74418c1fca03a590321418d429"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"


### PR DESCRIPTION
### What does this PR do?

Update yarn.lock to the latest che-operator commit

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/16959