### PR TITLE
fix(olm): Allow to use os-oauth with olm installer

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -284,8 +284,8 @@ export default class Start extends Command {
         if (flags.platform !== 'openshift' && flags.platform !== 'minishift' && flags.platform !== 'crc') {
           this.error(`You requested to enable OpenShift OAuth but the platform doesn\'t seem to be OpenShift. Platform is ${flags.platform}.`)
         }
-        if (flags.installer !== 'operator') {
-          this.error(`You requested to enable OpenShift OAuth but that's only possible when using the operator as installer. The current installer is ${flags.installer}. To use the operator add parameter "--installer operator".`)
+        if (flags.installer !== 'operator' && flags.installer !== 'olm') {
+          this.error(`You requested to enable OpenShift OAuth but that's only possible when using the 'operator' or 'olm' as installer. The current installer is ${flags.installer}.`)
         }
       }
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Allow to use os-oauth with olm installer

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16969
