### PR TITLE
fix: Improve getPodReadyConditionStatus

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -571,8 +571,8 @@ export class KubeHelper {
       throw new Error(`Get pods by selector "${selector}" returned an invalid response.`)
     }
 
-    // No pods found by the specified selector. So, it's not ready.
     if (res.body.items.length < 1) {
+      // No pods found by the specified selector. So, it's not ready.
       return 'False'
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,11 +1525,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#e7ed1e5fa647f173f39e49332610bb41836e6056"
+  resolved "git://github.com/eclipse/che-operator#e0663e1f6b5c84fb84043191d32b0a9da9c0b9fe"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#7bcf1d3e930ea4b993a09b3eae12a1bd22cdc351"
+  resolved "git://github.com/eclipse/che#0043e9dd7ce3a058ba046eb7f5dc8a4a9aa3ae9b"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Sometimes pod `status` might not contain `condition` of type `Ready`.
It is better to return `underfine` for getPodReadyConditionStatus and allows other function to wait and get `condition` in the next request.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17001
