### PR TITLE
fix: Wait until pod is actual deleted for server:delete and server:stop commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ OPTIONS
   -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Eclipse Che server is supposed to
                                            be deployed
 
+  --deployment-name=deployment-name        [default: che] Eclipse Che deployment name
+
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 
   --skip-deletion-check                    Skip user confirmation on deletion check

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -638,13 +638,13 @@ export class KubeHelper {
   async waitUntilPodIsDeleted(selector: string, namespace = '', intervalMs = 500, timeoutMs = this.podReadyTimeout) {
     const iterations = timeoutMs / intervalMs
     for (let index = 0; index < iterations; index++) {
-      let readyStatus = await this.getPodReadyConditionStatus(selector, namespace)
-      if (readyStatus === 'False') {
+      const pods = await this.listNamespacedPod(namespace, undefined, selector)
+      if (!pods.items.length) {
         return
       }
       await cli.wait(intervalMs)
     }
-    throw new Error(`ERR_TIMEOUT: Timeout set to pod ready timeout ${this.podReadyTimeout}`)
+    throw new Error('ERR_TIMEOUT: Waiting until pod is deleted took too long.')
   }
 
   async deletePod(name: string, namespace = '') {

--- a/src/commands/server/stop.ts
+++ b/src/commands/server/stop.ts
@@ -70,6 +70,7 @@ export default class Stop extends Command {
       { renderer: flags['listr-renderer'] as any }
     )
     tasks.add(cheTasks.scaleCheDownTasks(this))
+    tasks.add(cheTasks.waitPodsDeletedTasks())
 
     try {
       await tasks.run()

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -257,7 +257,7 @@ export class CheTasks {
       task: async (ctx: any, task: any) => {
         if (ctx.isAuthEnabled && !this.cheAccessToken) {
           command.error('E_AUTH_REQUIRED - Eclipse Che authentication is enabled and an access token need to be provided (flag --access-token). ' +
-                        `For instructions to retrieve a valid access token refer to ${DOCS_LINK_AUTH_TO_CHE_SERVER_VIA_OPENID}`)
+            `For instructions to retrieve a valid access token refer to ${DOCS_LINK_AUTH_TO_CHE_SERVER_VIA_OPENID}`)
         }
         try {
           const cheURL = await this.che.cheURL(this.cheNamespace)
@@ -282,14 +282,6 @@ export class CheTasks {
       }
     },
     {
-      title: 'Wait until Eclipse Che pod is deleted',
-      enabled: (ctx: any) => !ctx.isCheStopped,
-      task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted(this.cheSelector, this.cheNamespace)
-        task.title = `${task.title}...done.`
-      }
-    },
-    {
       title: 'Scale \"keycloak\" deployment to zero',
       enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
       task: async (_ctx: any, task: any) => {
@@ -299,14 +291,6 @@ export class CheTasks {
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale keycloak deployment. ${error.message}`)
         }
-      }
-    },
-    {
-      title: 'Wait until Keycloak pod is deleted',
-      enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
-      task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted(this.keycloakSelector, this.cheNamespace)
-        task.title = `${task.title}...done.`
       }
     },
     {
@@ -322,14 +306,6 @@ export class CheTasks {
       }
     },
     {
-      title: 'Wait until Postgres pod is deleted',
-      enabled: (ctx: any) => ctx.isPostgresDeployed && !ctx.isPostgresStopped,
-      task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted(this.postgresSelector, this.cheNamespace)
-        task.title = `${task.title}...done.`
-      }
-    },
-    {
       title: 'Scale \"devfile registry\" deployment to zero',
       enabled: (ctx: any) => ctx.isDevfileRegistryDeployed && !ctx.isDevfileRegistryStopped,
       task: async (_ctx: any, task: any) => {
@@ -342,14 +318,6 @@ export class CheTasks {
       }
     },
     {
-      title: 'Wait until Devfile registry pod is deleted',
-      enabled: (ctx: any) => ctx.isDevfileRegistryDeployed && !ctx.isDevfileRegistryStopped,
-      task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted(this.devfileRegistrySelector, this.cheNamespace)
-        task.title = `${task.title}...done.`
-      }
-    },
-    {
       title: 'Scale \"plugin registry\" deployment to zero',
       enabled: (ctx: any) => ctx.isPluginRegistryDeployed && !ctx.isPluginRegistryStopped,
       task: async (_ctx: any, task: any) => {
@@ -359,14 +327,6 @@ export class CheTasks {
         } catch (error) {
           command.error(`E_SCALE_DEPLOY_FAIL - Failed to scale plugin-registry deployment. ${error.message}`)
         }
-      }
-    },
-    {
-      title: 'Wait until Plugin registry pod is deleted',
-      enabled: (ctx: any) => ctx.isPluginRegistryDeployed && !ctx.isPluginRegistryStopped,
-      task: async (_ctx: any, task: any) => {
-        await this.kube.waitUntilPodIsDeleted(this.pluginRegistrySelector, this.cheNamespace)
-        task.title = `${task.title}...done.`
       }
     }]
   }
@@ -460,6 +420,54 @@ export class CheTasks {
           task.title = await `${task.title}...OK`
         }
       }]
+  }
+
+  /**
+   * Returns tasks which wait until pods are deleted.
+   */
+  waitPodsDeletedTasks(): ReadonlyArray<Listr.ListrTask> {
+    return [
+      {
+        title: 'Wait until Eclipse Che pod is deleted',
+        enabled: (ctx: any) => !ctx.isCheStopped,
+        task: async (_ctx: any, task: any) => {
+          await this.kube.waitUntilPodIsDeleted(this.cheSelector, this.cheNamespace)
+          task.title = `${task.title}...done.`
+        }
+      },
+      {
+        title: 'Wait until Keycloak pod is deleted',
+        enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
+        task: async (_ctx: any, task: any) => {
+          await this.kube.waitUntilPodIsDeleted(this.keycloakSelector, this.cheNamespace)
+          task.title = `${task.title}...done.`
+        }
+      },
+      {
+        title: 'Wait until Postgres pod is deleted',
+        enabled: (ctx: any) => ctx.isPostgresDeployed && !ctx.isPostgresStopped,
+        task: async (_ctx: any, task: any) => {
+          await this.kube.waitUntilPodIsDeleted(this.postgresSelector, this.cheNamespace)
+          task.title = `${task.title}...done.`
+        }
+      },
+      {
+        title: 'Wait until Devfile registry pod is deleted',
+        enabled: (ctx: any) => ctx.isDevfileRegistryDeployed && !ctx.isDevfileRegistryStopped,
+        task: async (_ctx: any, task: any) => {
+          await this.kube.waitUntilPodIsDeleted(this.devfileRegistrySelector, this.cheNamespace)
+          task.title = `${task.title}...done.`
+        }
+      },
+      {
+        title: 'Wait until Plugin registry pod is deleted',
+        enabled: (ctx: any) => ctx.isPluginRegistryDeployed && !ctx.isPluginRegistryStopped,
+        task: async (_ctx: any, task: any) => {
+          await this.kube.waitUntilPodIsDeleted(this.pluginRegistrySelector, this.cheNamespace)
+          task.title = `${task.title}...done.`
+        }
+      }
+    ]
   }
 
   verifyCheNamespaceExistsTask(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,7 +1529,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#0043e9dd7ce3a058ba046eb7f5dc8a4a9aa3ae9b"
+  resolved "git://github.com/eclipse/che#a46766cec2c7365d03d499d6bdbc7a663658bbe3"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Wait until pods are actual deleted for server:delete and server:stop commands

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14595
