### PR TITLE
chore(cacert:export): Remove platform flag from cacert:export command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,7 @@
             "windows": {
                 "program": "${workspaceFolder}/node_modules/jest/bin/jest",
             }
-        }
+        },
+        
     ]
 }

--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ OPTIONS
   -n, --chenamespace=chenamespace
       [default: che] Kubernetes namespace where Eclipse Che server is supposed to be deployed
 
-  -p, --platform=minikube|minishift|k8s|openshift|microk8s|docker-desktop|crc
-      Type of Kubernetes platform. Valid values are "minikube", "minishift", "k8s (for kubernetes)", "openshift", "crc 
-      (for CodeReady Containers)", "microk8s".
-
   --skip-kubernetes-health-check
       Skip Kubernetes health check
 ```

--- a/src/commands/cacert/export.ts
+++ b/src/commands/cacert/export.ts
@@ -20,7 +20,6 @@ import { cheNamespace, skipKubeHealthzCheck } from '../../common-flags'
 import { DEFAULT_CA_CERT_FILE_NAME } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { ApiTasks } from '../../tasks/platforms/api'
-import { PlatformTasks } from '../../tasks/platforms/platform'
 
 export default class Export extends Command {
   static description = 'Retrieves Eclipse Che self-signed certificate'
@@ -28,11 +27,6 @@ export default class Export extends Command {
   static flags = {
     help: flags.help({ char: 'h' }),
     chenamespace: cheNamespace,
-    platform: string({
-      char: 'p',
-      description: 'Type of Kubernetes platform. Valid values are \"minikube\", \"minishift\", \"k8s (for kubernetes)\", \"openshift\", \"crc (for CodeReady Containers)\", \"microk8s\".',
-      options: ['minikube', 'minishift', 'k8s', 'openshift', 'microk8s', 'docker-desktop', 'crc'],
-    }),
     destination: string({
       char: 'd',
       description: `Destination where to store Che self-signed CA certificate.
@@ -49,12 +43,10 @@ export default class Export extends Command {
     const { flags } = this.parse(Export)
     const ctx: any = {}
     const cheHelper = new CheHelper(flags)
-    const platformTasks = new PlatformTasks()
     const cheTasks = new CheTasks(flags)
     const apiTasks = new ApiTasks()
     const tasks = new Listr([], { renderer: 'silent' })
 
-    tasks.add(platformTasks.preflightCheckTasks(flags, this))
     tasks.add(apiTasks.testApiTasks(flags, this))
     tasks.add(cheTasks.verifyCheNamespaceExistsTask(flags, this))
 

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -15,6 +15,7 @@ const helper = new E2eHelper()
 jest.setTimeout(600000)
 
 const PLATFORM = 'kubernetes'
+const binChectl = `${process.cwd()}/bin/run`
 
 describe('Eclipse Che deploy test suite', () => {
   describe('server:start using operator and self signed certificates', () => {
@@ -38,19 +39,21 @@ describe('Eclipse Che deploy test suite', () => {
 })
 
 describe('Export CA certificate', () => {
-  describe('Export CA certificate', () => {
-    test
-      .stdout({ print: true })
-      .stderr({ print: true })
-      .command(['cacert:export'])
-      .exit(0)
-      .it('Eclipse Che self-signed CA certificate is exported')
+  it('Export CA certificate', async () => {
+    const command = `${binChectl} cacert:export`
+
+    const { exitCode, stdout, stderr } = await execa(command, { timeout: 30000, shell: true })
+
+    expect(exitCode).equal(0)
+    console.log(stdout)
+
+    if (exitCode !== 0) {
+      console.log(stderr)
+    }
   })
 })
 
 describe('Workspace creation, list, start, inject, delete. Support stop and delete commands for Eclipse Che server', () => {
-  const binChectl = `${process.cwd()}/bin/run`
-
   describe('Create Workspace', () => {
     test
       .stdout({ print: true })

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -37,6 +37,17 @@ describe('Eclipse Che deploy test suite', () => {
   })
 })
 
+describe('Export CA certificate', () => {
+  describe('Export CA certificate', () => {
+    test
+      .stdout({ print: true })
+      .stderr({ print: true })
+      .command(['cacert:export'])
+      .exit(0)
+      .it('Eclipse Che self-signed CA certificate is exported')
+  })
+})
+
 describe('Workspace creation, list, start, inject, delete. Support stop and delete commands for Eclipse Che server', () => {
   const binChectl = `${process.cwd()}/bin/run`
 

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -16,6 +16,7 @@ const helper = new E2eHelper()
 jest.setTimeout(600000)
 
 const PLATFORM = 'openshift'
+const binChectl = `${process.cwd()}/bin/run`
 
 describe('Eclipse Che deploy test suite', () => {
   describe('server:start using operator and self signed certificates', () => {
@@ -39,19 +40,21 @@ describe('Eclipse Che deploy test suite', () => {
 })
 
 describe('Export CA certificate', () => {
-  describe('Export CA certificate', () => {
-    test
-      .stdout({ print: true })
-      .stderr({ print: true })
-      .command(['cacert:export'])
-      .exit(0)
-      .it('Eclipse Che self-signed CA certificate is exported')
+  it('Export CA certificate', async () => {
+    const command = `${binChectl} cacert:export`
+
+    const { exitCode, stdout, stderr } = await execa(command, { timeout: 30000, shell: true })
+
+    expect(exitCode).equal(0)
+    console.log(stdout)
+
+    if (exitCode !== 0) {
+      console.log(stderr)
+    }
   })
 })
 
 describe('Workspace creation, list, start, inject, delete. Support stop and delete commands for Eclipse Che server', () => {
-  const binChectl = `${process.cwd()}/bin/run`
-
   describe('Create Workspace', () => {
     test
       .stdout({ print: true })
@@ -145,7 +148,7 @@ describe('Workspace creation, list, start, inject, delete. Support stop and dele
       .do(async () => helper.SleepTests(30000))
       .command(['server:stop', '--listr-renderer=silent'])
       .exit(0)
-      .it('Stop Eclipse Che Server on minikube platform')
+      .it('Stop Eclipse Che Server on minishift platform')
   })
 
   describe('Delete Eclipse Che Server', () => {
@@ -154,6 +157,6 @@ describe('Workspace creation, list, start, inject, delete. Support stop and dele
       .stderr({ print: true })
       .command(['server:delete', '--skip-deletion-check'])
       .exit(0)
-      .it('deletes Eclipse Che resources on minikube successfully')
+      .it('deletes Eclipse Che resources on minishift successfully')
   })
 })

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -38,6 +38,17 @@ describe('Eclipse Che deploy test suite', () => {
   })
 })
 
+describe('Export CA certificate', () => {
+  describe('Export CA certificate', () => {
+    test
+      .stdout({ print: true })
+      .stderr({ print: true })
+      .command(['cacert:export'])
+      .exit(0)
+      .it('Eclipse Che self-signed CA certificate is exported')
+  })
+})
+
 describe('Workspace creation, list, start, inject, delete. Support stop and delete commands for Eclipse Che server', () => {
   const binChectl = `${process.cwd()}/bin/run`
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Removes platform flag from `cacert:export` command


