### PR TITLE
feat: Deprecate 'self-signed-cert' flag and implement autodetection for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,12 +338,11 @@ OPTIONS
   -s, --tls
       Enable TLS encryption.
                            Note, this option is turned on by default.
-                           For Kubernetes infrastructure, it is required to provide own certificate: 'che-tls' secret with 
-      TLS certificate must be pre-created in the configured namespace.
-                           The only exception is Helm installer. In that case the secret will be generated automatically.
+                           To provide own certificate for Kubernetes infrastructure, 'che-tls' secret with TLS certificate 
+      must be pre-created in the configured namespace.
+                           In case of providing own self-signed certificate 'self-signed-certificate' secret should be 
+      also created.
                            For OpenShift, router will use default cluster certificates.
-                           If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise 
-      Che won't be able to start.
                            Please see docs for more details: 
       https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/
 
@@ -414,10 +413,7 @@ OPTIONS
       persistent volume storage class name to use to store Eclipse Che postgres database
 
   --self-signed-cert
-      Authorize usage of self signed certificates for encryption.
-                           This is the flag for Eclipse Che to propagate the certificate to components, so they will trust 
-      it.
-                           Note that `che-tls` secret with CA certificate must be created in the configured namespace.
+      Deprecated. The flag is ignored. Self signed certificates usage is autodetected now.
 
   --skip-cluster-availability-check
       Skip cluster availability check. The check is a simple request to ensure the cluster is reachable.

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -110,13 +110,19 @@ export class CheHelper {
     }
   }
 
+  async isSelfSignedCertificateSecretExist(namespace: string): Promise<boolean> {
+    const selfSignedCertSecret = await this.kube.getSecret(CHE_ROOT_CA_SECRET_NAME, namespace)
+    return !!selfSignedCertSecret
+  }
+
   /**
-   * Gets self-signed Che CA certificate from 'self-signed-certificate' secret. The secret should exist.
+   * Gets self-signed Che CA certificate from 'self-signed-certificate' secret.
+   * If secret doesn't exist, undefined is returned.
    */
-  async retrieveCheCaCert(cheNamespace: string): Promise<string> {
+  async retrieveCheCaCert(cheNamespace: string): Promise<string | undefined> {
     const cheCaSecret = await this.kube.getSecret(CHE_ROOT_CA_SECRET_NAME, cheNamespace)
     if (!cheCaSecret) {
-      throw new Error('Che CA self-signed certificate not found. Are you using self-signed certificate?')
+      return
     }
 
     if (cheCaSecret.data && cheCaSecret.data['ca.crt']) {

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -20,7 +20,7 @@ import { merge } from 'lodash'
 import * as net from 'net'
 import { Writable } from 'stream'
 
-import { CHE_CLUSTER_CRD, CHE_ROOT_CA_SECRET_NAME, DEFAULT_CHE_IMAGE, OLM_STABLE_CHANNEL_NAME } from '../constants'
+import { CHE_CLUSTER_CRD, DEFAULT_CHE_IMAGE, OLM_STABLE_CHANNEL_NAME } from '../constants'
 import { getClusterClientCommand } from '../util'
 
 import { V1alpha2Certificate } from './typings/cert-manager'

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -20,7 +20,7 @@ import { merge } from 'lodash'
 import * as net from 'net'
 import { Writable } from 'stream'
 
-import { CHE_CLUSTER_CRD, DEFAULT_CHE_IMAGE, OLM_STABLE_CHANNEL_NAME } from '../constants'
+import { CHE_CLUSTER_CRD, CHE_ROOT_CA_SECRET_NAME, DEFAULT_CHE_IMAGE, OLM_STABLE_CHANNEL_NAME } from '../constants'
 import { getClusterClientCommand } from '../util'
 
 import { V1alpha2Certificate } from './typings/cert-manager'
@@ -1146,7 +1146,6 @@ export class KubeHelper {
           yamlCr.spec.k8s.tlsSecretName = 'che-tls'
         }
       }
-      yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
       if (flags.domain) {
         yamlCr.spec.k8s.ingressDomain = flags.domain
       }
@@ -1789,6 +1788,26 @@ export class KubeHelper {
       } else {
         return
       }
+    } catch {
+      return
+    }
+  }
+
+  /**
+   * Creates a secret with given name and data.
+   * Data should not be base64 encoded.
+   */
+  async createSecret(name: string, data: {[key: string]: string}, namespace: string): Promise<V1Secret | undefined> {
+    const k8sCoreApi = KubeHelper.KUBE_CONFIG.makeApiClient(CoreV1Api)
+
+    const secret = new V1Secret()
+    secret.metadata = new V1ObjectMeta()
+    secret.metadata.name = name
+    secret.metadata.namespace = namespace
+    secret.stringData = data
+
+    try {
+      return (await k8sCoreApi.createNamespacedSecret(namespace, secret)).body
     } catch {
       return
     }

--- a/src/commands/cacert/export.ts
+++ b/src/commands/cacert/export.ts
@@ -53,8 +53,12 @@ export default class Export extends Command {
     try {
       await tasks.run(ctx)
       const cheCaCert = await cheHelper.retrieveCheCaCert(flags.chenamespace)
-      const targetFile = await cheHelper.saveCheCaCert(cheCaCert, this.getTargetFile(flags.destination))
-      this.log(`Eclipse Che self-signed CA certificate is exported to ${targetFile}`)
+      if (cheCaCert) {
+        const targetFile = await cheHelper.saveCheCaCert(cheCaCert, this.getTargetFile(flags.destination))
+        this.log(`Eclipse Che self-signed CA certificate is exported to ${targetFile}`)
+      } else {
+        this.error('Self-signed CA certificate not found')
+      }
     } catch (error) {
       this.error(error)
     }

--- a/src/commands/cacert/export.ts
+++ b/src/commands/cacert/export.ts
@@ -57,7 +57,7 @@ export default class Export extends Command {
         const targetFile = await cheHelper.saveCheCaCert(cheCaCert, this.getTargetFile(flags.destination))
         this.log(`Eclipse Che self-signed CA certificate is exported to ${targetFile}`)
       } else {
-        this.error('Self-signed CA certificate not found')
+        this.log('Seems commonly trusted certificate is used.')
       }
     } catch (error) {
       this.error(error)

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -86,7 +86,7 @@ export default class Start extends Command {
                     Please see docs for more details: ${DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT}`
     }),
     'self-signed-cert': flags.boolean({
-      description: 'Deprecated. The flag is ignored. Usage of self signed certificates is autodetected now.',
+      description: 'Deprecated. The flag is ignored. Self signed certificates usage is autodetected now.',
       default: false
     }),
     platform: string({

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -80,16 +80,13 @@ export default class Start extends Command {
       char: 's',
       description: `Enable TLS encryption.
                     Note, this option is turned on by default.
-                    For Kubernetes infrastructure, it is required to provide own certificate: 'che-tls' secret with TLS certificate must be pre-created in the configured namespace.
-                    The only exception is Helm installer. In that case the secret will be generated automatically.
+                    To provide own certificate for Kubernetes infrastructure, 'che-tls' secret with TLS certificate must be pre-created in the configured namespace.
+                    In case of providing own self-signed certificate 'self-signed-certificate' secret should be also created.
                     For OpenShift, router will use default cluster certificates.
-                    If the certificate is self-signed, '--self-signed-cert' option should be provided, otherwise Che won't be able to start.
                     Please see docs for more details: ${DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT}`
     }),
     'self-signed-cert': flags.boolean({
-      description: `Authorize usage of self signed certificates for encryption.
-                    This is the flag for Eclipse Che to propagate the certificate to components, so they will trust it.
-                    Note that \`che-tls\` secret with CA certificate must be created in the configured namespace.`,
+      description: 'Deprecated. The flag is ignored. Usage of self signed certificates is autodetected now.',
       default: false
     }),
     platform: string({
@@ -253,7 +250,6 @@ export default class Start extends Command {
       flags['devfile-registry-url'] && ignoredFlags.push('--devfile-registry-url')
       flags['postgres-pvc-storage-class-name'] && ignoredFlags.push('--postgres-pvc-storage-class-name')
       flags['workspace-pvc-storage-class-name'] && ignoredFlags.push('--workspace-pvc-storage-class-name')
-      flags['self-signed-cert'] && ignoredFlags.push('--self-signed-cert')
       flags['os-oauth'] && ignoredFlags.push('--os-oauth')
       flags.tls && ignoredFlags.push('--tls')
       flags.cheimage && ignoredFlags.push('--cheimage')
@@ -326,6 +322,10 @@ export default class Start extends Command {
     ctx.listrOptions = listrOptions
     // Holds messages which should be printed at the end of chectl log
     ctx.highlightedMessages = [] as string[]
+
+    if (flags['self-signed-cert']) {
+      this.warn('"self-signed-cert" flag is deprecated and has no effect. Autodetection is used instead.')
+    }
 
     const cheTasks = new CheTasks(flags)
     const platformTasks = new PlatformTasks()

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -9,7 +9,6 @@
  **********************************************************************/
 
 import ansi = require('ansi-colors')
-import { cli } from 'cli-ux'
 import * as execa from 'execa'
 import { copy, mkdirp, remove } from 'fs-extra'
 import * as Listr from 'listr'

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -112,7 +112,7 @@ export function retrieveCheCaCertificateTask(flags: any): Listr.ListrTask {
         task.title = `${task.title }... is exported to ${targetFile}`
         ctx.highlightedMessages.push(getMessageImportCaCertIntoBrowser(targetFile))
       } else {
-        task.title = `${task.title }... not found.`
+        task.title = `${task.title }... commonly trusted certificate is used.`
       }
 
     }

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -17,7 +17,7 @@ import { CatalogSource, Subscription } from '../../api/typings/olm'
 import { CUSTOM_CATALOG_SOURCE_NAME, CVS_PREFIX, DEFAULT_CHE_IMAGE, DEFAULT_CHE_OLM_PACKAGE_NAME, DEFAULT_OLM_KUBERNETES_NAMESPACE, DEFAULT_OPENSHIFT_MARKET_PLACE_NAMESPACE, KUBERNETES_OLM_CATALOG, OLM_STABLE_CHANNEL_NAME, OPENSHIFT_OLM_CATALOG, OPERATOR_GROUP_NAME, SUBSCRIPTION_NAME } from '../../constants'
 import { isKubernetesPlatformFamily } from '../../util'
 
-import { checkTlsCertificate, copyOperatorResources, createEclipseCheCluster, createNamespaceTask } from './common-tasks'
+import { copyOperatorResources, createEclipseCheCluster, createNamespaceTask } from './common-tasks'
 
 export class OLMTasks {
   /**
@@ -32,7 +32,6 @@ export class OLMTasks {
       this.isOlmPreInstalledTask(command, kube),
       copyOperatorResources(flags, command.config.cacheDir),
       createNamespaceTask(flags),
-      checkTlsCertificate(flags),
       {
         title: 'Create operator group',
         task: async (_ctx: any, task: any) => {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -18,7 +18,7 @@ import { KubeHelper } from '../../api/kube'
 import { CHE_CLUSTER_CRD } from '../../constants'
 import { isStableVersion } from '../../util'
 
-import { checkTlsCertificate, copyOperatorResources, createEclipseCheCluster, createNamespaceTask } from './common-tasks'
+import { copyOperatorResources, createEclipseCheCluster, createNamespaceTask } from './common-tasks'
 
 export class OperatorTasks {
   operatorServiceAccount = 'che-operator'
@@ -40,7 +40,6 @@ export class OperatorTasks {
     return new Listr([
       copyOperatorResources(flags, command.config.cacheDir),
       createNamespaceTask(flags),
-      checkTlsCertificate(flags),
       {
         title: `Create ServiceAccount ${this.operatorServiceAccount} in namespace ${flags.chenamespace}`,
         task: async (ctx: any, task: any) => {

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -22,7 +22,7 @@ describe('Eclipse Che deploy test suite', () => {
     test
       .stdout({ print: true })
       .stderr({ print: true })
-      .command(['server:start', '--platform=minikube', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--self-signed-cert', '--installer=operator', '--skip-cluster-availability-check'])
+      .command(['server:start', '--platform=minikube', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--installer=operator', '--skip-cluster-availability-check'])
       .exit(0)
       .it('uses minikube as platform, operator as installer and auth is enabled')
     test

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -23,7 +23,7 @@ describe('Eclipse Che deploy test suite', () => {
     test
       .stdout({ print: true })
       .stderr({ print: true })
-      .command(['server:start', '--platform=minishift', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--self-signed-cert', '--installer=operator'])
+      .command(['server:start', '--platform=minishift', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--installer=operator'])
       .exit(0)
       .it('uses minishift as platform, operator as installer and auth is enabled')
     test

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,11 +1525,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#e0663e1f6b5c84fb84043191d32b0a9da9c0b9fe"
+  resolved "git://github.com/eclipse/che-operator#912fd52fc438a1917130e1f1d7c74e64c232762a"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#a46766cec2c7365d03d499d6bdbc7a663658bbe3"
+  resolved "git://github.com/eclipse/che#307a780c64745627d046068fb57fbaab980ed468"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Deprecates `self-signed-cert` option of `server:start` command.
In case of Operator installer this is handled on operator side, see https://github.com/eclipse/che-operator/pull/285
In case of Helm installer, chectl checks whether `self-signed-certificate` secret exists and based on that makes conclusion if self-signed certificate is used and put the value into Helm chart.

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/16764
Depends on: https://github.com/eclipse/che/pull/17044 and https://github.com/eclipse/che-operator/pull/285

### Tests
Tested on:
 - Minikube (Operator and Helm installers)
 - CRC (Operator installer)
 - Openshift (Operator installer with oAuth)
 - Openshift (OLM installer)