### PR TITLE
fix: Check if Olm is preinstalled on the Openshift 4.

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -415,7 +415,7 @@ export default class Start extends Command {
    */
   async setDefaultInstaller(flags: any): Promise<void> {
     const kubeHelper = new KubeHelper(flags)
-    if (flags.platform === 'openshift' && await kubeHelper.isOpenShift4() && isStableVersion(flags)) {
+    if (flags.platform === 'openshift' && await kubeHelper.isOpenShift4() && isStableVersion(flags) && kubeHelper.isPreInstalledOLM()) {
       flags.installer = 'olm'
     } else {
       flags.installer = 'operator'


### PR DESCRIPTION
### What does this PR do?
Openshift 4.1 doesn't have OLM from the box. So let's check if OLM is preinstalled.

### What issues does this PR fix or reference?
Part of the https://issues.redhat.com/browse/CRW-967

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>