### PR TITLE
feat: Add catalog source name and namespace to use external catalog source to install Eclipse Che.

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,14 @@ OPTIONS
       command.
                            This parameter is used only when the installer is 'olm'.
 
+  --catalog-source-name=catalog-source-name
+      OLM catalog source to install Eclipse Che operator.
+                           This parameter is used only when the installer is the 'olm'.
+
+  --catalog-source-namespace=catalog-source-namespace
+      Namespace for OLM catalog source to install Eclipse Che operator.
+                           This parameter is used only when the installer is the 'olm'.
+
   --catalog-source-yaml=catalog-source-yaml
       Path to a yaml file that describes custom catalog source for installation Eclipse Che operator.
                            Catalog source will be applied to the namespace with Che operator.

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -52,7 +52,7 @@ export class OLMTasks {
 
           ctx.approvalStarategy = flags['auto-update'] ? 'Automatic' : 'Manual'
 
-          ctx.sourceName = CUSTOM_CATALOG_SOURCE_NAME
+          ctx.sourceName = flags['catalog-source-name'] || CUSTOM_CATALOG_SOURCE_NAME
 
           task.title = `${task.title}...done.`
         }
@@ -80,10 +80,11 @@ export class OLMTasks {
             task.title = `${task.title}...It already exists.`
           } else {
             let subscription: Subscription
-            if (!flags['catalog-source-yaml']) {
+            if (!flags['catalog-source-yaml'] && !flags['catalog-source-name']) {
               subscription = this.createSubscription(SUBSCRIPTION_NAME, DEFAULT_CHE_OLM_PACKAGE_NAME, flags.chenamespace, ctx.defaultCatalogSourceNamespace, OLM_STABLE_CHANNEL_NAME, ctx.catalogSourceNameStable, ctx.approvalStarategy, flags['starting-csv'])
             } else {
-              subscription = this.createSubscription(SUBSCRIPTION_NAME, flags['package-manifest-name'], flags.chenamespace, flags.chenamespace, flags['olm-channel'], ctx.sourceName, ctx.approvalStarategy, flags['starting-csv'])
+              const catalogSourceNamespace = flags['catalog-source-namespace'] || flags.chenamespace
+              subscription = this.createSubscription(SUBSCRIPTION_NAME, flags['package-manifest-name'], flags.chenamespace, catalogSourceNamespace, flags['olm-channel'], ctx.sourceName, ctx.approvalStarategy, flags['starting-csv'])
             }
             await kube.createOperatorSubscription(subscription)
             task.title = `${task.title}...created new one.`


### PR DESCRIPTION
### What does this PR do?
Add catalog source name and namespace to use external catalog source to install Eclipse Che. It is possible way how test nightly or release candidates.

For example nightly preview operatorSource:

```yaml
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: eclipse-che-preview-openshift
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  endpoint: 'https://quay.io/cnr'
  registryNamespace: eclipse-che-operator-openshift
  type: appregistry
```
Apply it:

```
$ kubectl apply -f operatorSource.yaml -n openshift-marketplace
```

And install nightly Che:

```
chectl server:start -p openshift -n moon44 --catalog-source-name=eclipse-che-preview-openshift --catalog-source-namespace=openshift-marketplace --olm-channel=nightly --package-manifest-name=eclipse-che-preview-openshift
```


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-976

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>