### PR TITLE
fix: (helm) Fix selfSignedCert detection for helm installer

### DIFF
--- a/src/tasks/installers/helm.ts
+++ b/src/tasks/installers/helm.ts
@@ -315,7 +315,7 @@ error: E_COMMAND_FAILED`)
       tlsFlag = `-f ${destDir}values/tls.yaml`
     }
 
-    const selfSignedCertSecretExists = !! await this.kubeHelper.getSecret(CHE_TLS_SECRET_NAME, flags.chenamespace)
+    const selfSignedCertSecretExists = !! await this.kubeHelper.getSecret(CHE_ROOT_CA_SECRET_NAME, flags.chenamespace)
     setOptions.push(`--set global.tls.useSelfSignedCerts=${selfSignedCertSecretExists}`)
 
     if (flags['plugin-registry-url']) {


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Sets `global.tls.useSelfSignedCerts` flag only if `self-signed-certificate` secret exists

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17333
