### PR TITLE
fix: Fix minishift server:start test case

### DIFF
--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -13,6 +13,7 @@ import * as execa from 'execa'
 import { E2eHelper } from './util/e2e'
 
 const helper = new E2eHelper()
+jest.setTimeout(600000)
 
 const PLATFORM = 'openshift'
 const binChectl = `${process.cwd()}/bin/run`
@@ -25,16 +26,18 @@ describe('Eclipse Che deploy test suite', () => {
       .command(['server:start', '--platform=minishift', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--installer=operator'])
       .exit(0)
       .it('uses minishift as platform, operator as installer and auth is enabled')
-    test
-      .it('Obtain access_token from keycloak and set it like environment variable.', async () => {
-        try {
-          const token = await helper.getAccessToken(PLATFORM)
-          process.env.CHE_ACCESS_TOKEN = token
-          console.log(token)
-        } catch (error) {
-          console.log(error)
-        }
-      })
+    describe('Obtain access_token from keycloak and set it like environment variable', () => {
+      test
+        .it('Obtain access_token from keycloak and set it like environment variable.', async () => {
+          try {
+            const token = await helper.getAccessToken(PLATFORM)
+            process.env.CHE_ACCESS_TOKEN = token
+            console.log(token)
+          } catch (error) {
+            console.log(error)
+          }
+        })
+    })
   })
 })
 

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -20,25 +20,28 @@ const binChectl = `${process.cwd()}/bin/run`
 
 describe('Eclipse Che deploy test suite', () => {
   describe('server:start using operator and self signed certificates', () => {
-    test
-      .stdout({ print: true })
-      .stderr({ print: true })
-      .command(['server:start', '--platform=minishift', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--installer=operator'])
-      .exit(0)
-      .it('uses minishift as platform, operator as installer and auth is enabled')
+    it('server:start using operator and self signed certificates', async () => {
+      const command = `${binChectl} server:start --platform=minishift --che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml --tls --installer=operator`
+      const { exitCode, stdout, stderr } = await execa(command, { shell: true })
+
+      expect(exitCode).equal(0)
+      console.log(stdout)
+
+      if (exitCode !== 0) {
+        console.log(stderr)
+      }
+    })
   })
-  describe('Obtain access_token from keycloak and set it like environment variable', () => {
-    test
-      .it('Obtain access_token from keycloak and set it like environment variable.', async () => {
-        try {
-          const token = await helper.getAccessToken(PLATFORM)
-          process.env.CHE_ACCESS_TOKEN = token
-          console.log(token)
-        } catch (error) {
-          console.log(error)
-        }
-      })
-  })
+  test
+    .it('Obtain access_token from keycloak and set it like environment variable.', async () => {
+      try {
+        const token = await helper.getAccessToken(PLATFORM)
+        process.env.CHE_ACCESS_TOKEN = token
+        console.log(token)
+      } catch (error) {
+        console.log(error)
+      }
+    })
 })
 
 describe('Export CA certificate', () => {

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -13,7 +13,6 @@ import * as execa from 'execa'
 import { E2eHelper } from './util/e2e'
 
 const helper = new E2eHelper()
-jest.setTimeout(600000)
 
 const PLATFORM = 'openshift'
 const binChectl = `${process.cwd()}/bin/run`

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -13,7 +13,7 @@ import * as execa from 'execa'
 import { E2eHelper } from './util/e2e'
 
 const helper = new E2eHelper()
-jest.setTimeout(600000)
+jest.setTimeout(1000000)
 
 const PLATFORM = 'openshift'
 const binChectl = `${process.cwd()}/bin/run`

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -26,18 +26,18 @@ describe('Eclipse Che deploy test suite', () => {
       .command(['server:start', '--platform=minishift', '--che-operator-cr-patch-yaml=test/e2e/util/cr-test.yaml', '--tls', '--installer=operator'])
       .exit(0)
       .it('uses minishift as platform, operator as installer and auth is enabled')
-    describe('Obtain access_token from keycloak and set it like environment variable', () => {
-      test
-        .it('Obtain access_token from keycloak and set it like environment variable.', async () => {
-          try {
-            const token = await helper.getAccessToken(PLATFORM)
-            process.env.CHE_ACCESS_TOKEN = token
-            console.log(token)
-          } catch (error) {
-            console.log(error)
-          }
-        })
-    })
+  })
+  describe('Obtain access_token from keycloak and set it like environment variable', () => {
+    test
+      .it('Obtain access_token from keycloak and set it like environment variable.', async () => {
+        try {
+          const token = await helper.getAccessToken(PLATFORM)
+          process.env.CHE_ACCESS_TOKEN = token
+          console.log(token)
+        } catch (error) {
+          console.log(error)
+        }
+      })
   })
 })
 


### PR DESCRIPTION
Signed-off-by: flacatus <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Sometimes the jobs crash with the next error:
`Timeout - Async callback was not invoked within the 600000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 600000ms timeout specified by jest.setTimeout.Error: `

### What issues does this PR fix or reference?
Execute `server:start` test case using execa library.
