### PR TITLE
fix: Don't throw an error when there is no checlusters crd

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1292,6 +1292,10 @@ export class KubeHelper {
         await customObjectsApi.deleteNamespacedCustomObject('org.eclipse.che', 'v1', namespace, 'checlusters', cr.metadata.name, options)
       }
     } catch (e) {
+      if (e.response.statusCode === 404) {
+        // There is no CRD 'checlusters`
+        return
+      }
       throw this.wrapK8sClientError(e)
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,11 +1544,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#110149a5c7b158ec14659ca61f5c3153a9e8b80a"
+  resolved "git://github.com/eclipse/che-operator#fdb32622d63fba3895e173d1624dc66512375d57"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#3ceb16245fa72722ddf9004747c092c693ee4b28"
+  resolved "git://github.com/eclipse/che#7cf97838a4492f4b20327adf0cba5f4c8033fbd7"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
`server:delete` command should not throw an error trying to remove `checlusters` CR when Eclipse Che has been deploying using helm.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17375
