### PR TITLE
fix: Allows to delete Eclipse Che even if server isn't available

### DIFF
--- a/src/commands/server/delete.ts
+++ b/src/commands/server/delete.ts
@@ -54,7 +54,6 @@ export default class Delete extends Command {
     )
 
     tasks.add(apiTasks.testApiTasks(flags, this))
-    tasks.add(cheTasks.checkIfCheIsInstalledTasks(flags, this))
     tasks.add(operatorTasks.deleteTasks(flags))
     tasks.add(olmTasks.deleteTasks(flags))
     tasks.add(cheTasks.deleteTasks(flags))

--- a/src/commands/server/stop.ts
+++ b/src/commands/server/stop.ts
@@ -55,16 +55,6 @@ export default class Stop extends Command {
         task: async () => {
           await this.error(`E_BAD_DEPLOY - Deployment do not exist.\nA Deployment named "${flags['deployment-name']}" exist in namespace \"${flags.chenamespace}\", Eclipse Che server cannot be stopped.\nFix with: verify the namespace where Eclipse Che is running (oc get projects)\nhttps://github.com/eclipse/che`, { code: 'E_BAD_DEPLOY' })
         }
-      },
-      {
-        title: 'Eclipse Che server was already stopped',
-        enabled: (ctx: any) => (ctx.isStopped),
-        task: async () => { }
-      },
-      {
-        title: 'Eclipse Che server pod is not ready. It may be failing to start. Skipping shutdown request',
-        enabled: (ctx: any) => (ctx.isNotReadyYet),
-        task: async () => { }
       }
     ],
       { renderer: flags['listr-renderer'] as any }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -429,7 +429,6 @@ export class CheTasks {
     return [
       {
         title: 'Wait until Eclipse Che pod is deleted',
-        enabled: (ctx: any) => !ctx.isCheStopped,
         task: async (_ctx: any, task: any) => {
           await this.kube.waitUntilPodIsDeleted(this.cheSelector, this.cheNamespace)
           task.title = `${task.title}...done.`
@@ -437,7 +436,6 @@ export class CheTasks {
       },
       {
         title: 'Wait until Keycloak pod is deleted',
-        enabled: (ctx: any) => ctx.isKeycloakDeployed && !ctx.isKeycloakStopped,
         task: async (_ctx: any, task: any) => {
           await this.kube.waitUntilPodIsDeleted(this.keycloakSelector, this.cheNamespace)
           task.title = `${task.title}...done.`
@@ -445,7 +443,6 @@ export class CheTasks {
       },
       {
         title: 'Wait until Postgres pod is deleted',
-        enabled: (ctx: any) => ctx.isPostgresDeployed && !ctx.isPostgresStopped,
         task: async (_ctx: any, task: any) => {
           await this.kube.waitUntilPodIsDeleted(this.postgresSelector, this.cheNamespace)
           task.title = `${task.title}...done.`
@@ -453,7 +450,6 @@ export class CheTasks {
       },
       {
         title: 'Wait until Devfile registry pod is deleted',
-        enabled: (ctx: any) => ctx.isDevfileRegistryDeployed && !ctx.isDevfileRegistryStopped,
         task: async (_ctx: any, task: any) => {
           await this.kube.waitUntilPodIsDeleted(this.devfileRegistrySelector, this.cheNamespace)
           task.title = `${task.title}...done.`
@@ -461,7 +457,6 @@ export class CheTasks {
       },
       {
         title: 'Wait until Plugin registry pod is deleted',
-        enabled: (ctx: any) => ctx.isPluginRegistryDeployed && !ctx.isPluginRegistryStopped,
         task: async (_ctx: any, task: any) => {
           await this.kube.waitUntilPodIsDeleted(this.pluginRegistrySelector, this.cheNamespace)
           task.title = `${task.title}...done.`


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
This PR allows to delete Eclipse Che despite the fact that it isn't available (Che API doesn't respond). 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17534
