### PR TITLE
fix: Don't remove CRD if another deployments found

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1193,11 +1193,10 @@ export class KubeHelper {
     }
   }
 
-  async deleteCrd(name = '') {
+  async deleteCrd(name: string): Promise<void> {
     const k8sApiextensionsApi = KubeHelper.KUBE_CONFIG.makeApiClient(ApiextensionsV1beta1Api)
     try {
-      const options = new V1DeleteOptions()
-      await k8sApiextensionsApi.deleteCustomResourceDefinition(name, undefined, options)
+      await k8sApiextensionsApi.deleteCustomResourceDefinition(name)
     } catch (e) {
       throw this.wrapK8sClientError(e)
     }
@@ -1291,7 +1290,7 @@ export class KubeHelper {
   async getCheCluster(namespace: string): Promise<any | undefined> {
     const customObjectsApi = KubeHelper.KUBE_CONFIG.makeApiClient(CustomObjectsApi)
     try {
-      const { body } = await customObjectsApi.listNamespacedCustomObject('org.eclipse.che', 'v1', namespace, 'checlusters')
+      const { body } = await customObjectsApi.listNamespacedCustomObject('org.eclipse.che', 'v1', '*', 'checlusters')
       if (!body.items) {
         return
       }
@@ -1304,6 +1303,19 @@ export class KubeHelper {
       }
 
       return crs[0]
+    } catch (e) {
+      throw this.wrapK8sClientError(e)
+    }
+  }
+
+  /**
+   * Returns all `checlusters.org.eclipse.che' resources
+   */
+  async getAllCheCluster(): Promise<any[]> {
+    const customObjectsApi = KubeHelper.KUBE_CONFIG.makeApiClient(CustomObjectsApi)
+    try {
+      const { body } = await customObjectsApi.listClusterCustomObject('org.eclipse.che', 'v1', 'checlusters')
+      return body.items ? body.items : []
     } catch (e) {
       throw this.wrapK8sClientError(e)
     }

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1290,7 +1290,7 @@ export class KubeHelper {
   async getCheCluster(namespace: string): Promise<any | undefined> {
     const customObjectsApi = KubeHelper.KUBE_CONFIG.makeApiClient(CustomObjectsApi)
     try {
-      const { body } = await customObjectsApi.listNamespacedCustomObject('org.eclipse.che', 'v1', '*', 'checlusters')
+      const { body } = await customObjectsApi.listNamespacedCustomObject('org.eclipse.che', 'v1', namespace, 'checlusters')
       if (!body.items) {
         return
       }

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -346,7 +346,7 @@ export class OperatorTasks {
       task: async (_ctx: any, task: any) => {
         const checlusters = await kh.getAllCheCluster()
         if (checlusters.length > 0) {
-          task.title = await `${task.title}...Another Eclipse Che deployment found.`
+          task.title = await `${task.title}...Skipped: another Eclipse Che deployment found.`
         } else {
           await kh.deleteCrd(this.cheClusterCrd)
           task.title = await `${task.title}...OK`

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -346,7 +346,7 @@ export class OperatorTasks {
       task: async (_ctx: any, task: any) => {
         const checlusters = await kh.getAllCheCluster()
         if (checlusters.length > 0) {
-          task.title = await `${task.title}...Another Eclipse Che deployments found.`
+          task.title = await `${task.title}...Another Eclipse Che deployment found.`
         } else {
           await kh.deleteCrd(this.cheClusterCrd)
           task.title = await `${task.title}...OK`


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Deletes CRD only if there no another checluster CR

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16000

```
Existed Eclipse Che operator: quay.io/eclipse/che-operator:7.18.0.
New Eclipse Che operator    : che-operator:latest.
 ›   Warning: This command updates Eclipse Che to 7.18.0 version, but custom operator image is specified.
 ›   Warning: Make sure that the new version of the Eclipse Che is corresponding to the version of the tool you use.
 ›   Warning: Consider using 'chectl update [stable|next]' to update to the latest version of chectl.
If you want to continue - press Y:
```