### PR TITLE
fix: Fix link to doc about importing CA into browser

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const CVS_PREFIX = 'eclipse-che'
 
 // Documentation links
 export const DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT = 'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/'
-export const DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER = 'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates'
+export const DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER = 'https://www.eclipse.org/che/docs/che-7/importing-certificates-to-browsers/'
 export const DOCS_LINK_HOW_TO_ADD_IDENTITY_PROVIDER_OS4 = 'https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html#identity-provider-overview_understanding-identity-provider'
 export const DOCS_LINK_HOW_TO_CREATE_USER_OS3 = 'https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html'
 export const DOC_LINK_OBTAIN_ACCESS_TOKEN = 'https://www.eclipse.org/che/docs/che-7/authenticating-users/#obtaining-the-token-from-keycloak_authenticating-to-the-che-server'


### PR DESCRIPTION
### What does this PR do?
Fixes link to doc about importing CA into browser, which was broken by https://github.com/eclipse/che-docs/pull/1451

### What issues does this PR fix or reference?

