### PR TITLE
fix: Fix chectl logs before che pods start

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -395,7 +395,6 @@ export default class Start extends Command {
       if (!ctx.isCheDeployed) {
         this.checkPlatformCompatibility(flags)
         await platformCheckTasks.run(ctx)
-        this.log(`Eclipse Che logs will be available in '${ctx.directory}'`)
         await logsTasks.run(ctx)
         await eventTasks.run(ctx)
         await installTasks.run(ctx)
@@ -414,9 +413,9 @@ export default class Start extends Command {
       await postInstallTasks.run(ctx)
       this.log('Command server:start has completed successfully.')
     } catch (err) {
-      const isEmptyDir = await this.isDirEmpty(ctx.directory)
-      if (isEmptyDir) {
-        this.error('There are no any logs available for the current installation')
+      const isDirEmpty = await this.isDirEmpty(ctx.directory)
+      if (isDirEmpty) {
+        this.error(`${err}\nInstallation failed. There are no available logs.`)
       }
       this.error(`${err}\nInstallation failed, check logs in '${ctx.directory}'`)
     }

--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -220,6 +220,18 @@ export default class Start extends Command {
   }
 
   /**
+   * Determine if a directory is empty.
+   */
+  async isDirEmpty(dirname: string): Promise<boolean> {
+    try {
+      return fs.readdirSync(dirname).length === 0
+      // Fails in case if directory doesn't exist
+    } catch {
+      return true
+    }
+  }
+
+  /**
    * Checks if TLS is disabled via operator custom resource.
    * Returns true if TLS is enabled (or omitted) and false if it is explicitly disabled.
    */
@@ -402,6 +414,10 @@ export default class Start extends Command {
       await postInstallTasks.run(ctx)
       this.log('Command server:start has completed successfully.')
     } catch (err) {
+      const isEmptyDir = await this.isDirEmpty(ctx.directory)
+      if (isEmptyDir) {
+        this.error('There are no any logs available for the current installation')
+      }
       this.error(`${err}\nInstallation failed, check logs in '${ctx.directory}'`)
     }
 


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Sometimes chectl fails before Che pods start and that means there are not any logs. 
This PR check if directory logs are empty and print a message.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-859
