### PR TITLE
feat: Rework server:delete to remove consoleLinks, namespace or openshift oauthAuthorizations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,7 @@
                 "server:delete",
                 "--chenamespace",
                 "che",
+                "--delete-namespace"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,24 @@
           "windows": {
               "program": "${workspaceFolder}/node_modules/jest/bin/jest",
           }
-      },
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Openshift server:delete",
+            "program": "${workspaceFolder}/bin/run",
+            "args": [
+                "server:delete",
+                "--chenamespace",
+                "che",
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+        },
         {
             "type": "node",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,24 +32,6 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Openshift server:delete",
-            "program": "${workspaceFolder}/bin/run",
-            "args": [
-                "server:delete",
-                "--chenamespace",
-                "che",
-                "--delete-namespace"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "windows": {
-                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            }
-        },
-        {
-            "type": "node",
-            "request": "launch",
             "name": "Jest All",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "args": [

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ OPTIONS
   -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Eclipse Che server is supposed to
                                            be deployed
 
-  --delete-namespace                       Set to true to delete namespace after removing Eclipse Che
+  --delete-namespace                       Indicates that a Eclipse Che namespace will be deleted as well
 
   --deployment-name=deployment-name        [default: che] Eclipse Che deployment name
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ OPTIONS
   -n, --chenamespace=chenamespace          [default: che] Kubernetes namespace where Eclipse Che server is supposed to
                                            be deployed
 
+  --delete-namespace                       Set to true to delete namespace after removing Eclipse Che
+
   --deployment-name=deployment-name        [default: che] Eclipse Che deployment name
 
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1431,15 +1431,14 @@ export class KubeHelper {
     }
   }
 
-  async deleteOAuthClientAuthorizations(oAuthClientAuthorizations: any[]): Promise<boolean> {
+  async deleteOAuthClientAuthorizations(oAuthClientAuthorizations: any[]): Promise<void> {
     const customObjectsApi = KubeHelper.KUBE_CONFIG.makeApiClient(CustomObjectsApi)
     try {
       const options = new V1DeleteOptions()
-      oAuthClientAuthorizations.filter((e => e.metadata && e.metadata.name)).forEach(async e => {
-        await customObjectsApi.deleteClusterCustomObject('oauth.openshift.io', 'v1', 'oauthclientauthorizations', e.metadata.name, options)
-      })
-      return true
-
+      const filetOauthAuthorizations = oAuthClientAuthorizations.filter((e => e.metadata && e.metadata.name))
+      for (let oauthAuthorization of filetOauthAuthorizations) {
+        await customObjectsApi.deleteClusterCustomObject('oauth.openshift.io', 'v1', 'oauthclientauthorizations', oauthAuthorization.metadata.name, options)
+      }
     } catch (e) {
       throw this.wrapK8sClientError(e)
     }
@@ -1459,7 +1458,7 @@ export class KubeHelper {
     }
   }
 
-  async deleteConsoleLink(name: string) {
+  async deleteConsoleLink(name: string): Promise<void> {
     const customObjectsApi = KubeHelper.KUBE_CONFIG.makeApiClient(CustomObjectsApi)
     try {
       const options = new V1DeleteOptions()

--- a/src/commands/server/delete.ts
+++ b/src/commands/server/delete.ts
@@ -28,6 +28,10 @@ export default class Delete extends Command {
   static flags = {
     help: flags.help({ char: 'h' }),
     chenamespace: cheNamespace,
+    'delete-namespace': boolean({
+      description: 'Set to true to delete namespace after removing Eclipse Che',
+      default: false
+    }),
     'deployment-name': cheDeployment,
     'listr-renderer': listrRenderer,
     'skip-deletion-check': boolean({
@@ -60,6 +64,9 @@ export default class Delete extends Command {
     tasks.add(helmTasks.deleteTasks(flags))
     tasks.add(minishiftAddonTasks.deleteTasks(flags))
     tasks.add(cheTasks.waitPodsDeletedTasks())
+    if (flags['delete-namespace']) {
+      tasks.add(cheTasks.deleteNamespace(flags))
+    }
 
     const cluster = KubeHelper.KUBE_CONFIG.getCurrentCluster()
     if (!cluster) {

--- a/src/commands/server/delete.ts
+++ b/src/commands/server/delete.ts
@@ -29,7 +29,7 @@ export default class Delete extends Command {
     help: flags.help({ char: 'h' }),
     chenamespace: cheNamespace,
     'delete-namespace': boolean({
-      description: 'Set to true to delete namespace after removing Eclipse Che',
+      description: 'Indicates that a Eclipse Che namespace will be deleted as well',
       default: false
     }),
     'deployment-name': cheDeployment,

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -424,7 +424,7 @@ export class CheTasks {
           const consoleLinkExists = await this.kube.consoleLinkExists(this.cheConsoleLinkName)
           const checlusters = await this.kube.getAllCheCluster()
           // Delete the consoleLink only in case if there no more checluster installed
-          if (!checlusters && consoleLinkExists) {
+          if (checlusters.length === 0 && consoleLinkExists) {
             await this.kube.deleteConsoleLink(this.cheConsoleLinkName)
           }
           task.title = `${task.title}...OK`

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -482,9 +482,8 @@ export class CheTasks {
         const namespaceExist = await this.kube.namespaceExist(flags.chenamespace)
         if (namespaceExist) {
           await this.kube.deleteNamespace(flags.chenamespace)
-          task.title = await `${task.title}...OK`
         }
-        task.title = await `${task.title}...OK`
+        task.title = `${task.title}...OK`
       }
     }]
   }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -484,6 +484,7 @@ export class CheTasks {
           await this.kube.deleteNamespace(flags.chenamespace)
           task.title = await `${task.title}...OK`
         }
+        task.title = await `${task.title}...OK`
       }
     }]
   }

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -46,6 +46,8 @@ export class CheTasks {
 
   cheOperatorSelector = 'app=che-operator'
 
+  cheConsoleLinkName = 'che'
+
   constructor(flags: any) {
     this.kube = new KubeHelper(flags)
     this.kubeTasks = new KubeTasks(flags)
@@ -415,6 +417,18 @@ export class CheTasks {
           }
           task.title = await `${task.title}...OK`
         }
+      },
+      {
+        title: `Delete console link ${this.cheConsoleLinkName}`,
+        task: async (_ctx: any, task: any) => {
+          const consoleLinkExists = await this.kube.consoleLinkExists(this.cheConsoleLinkName)
+          const checlusters = await this.kube.getAllCheCluster()
+          // Delete the consoleLink only in case if there no more checluster installed
+          if (!checlusters && consoleLinkExists) {
+            await this.kube.deleteConsoleLink(this.cheConsoleLinkName)
+          }
+          task.title = `${task.title}...OK`
+        }
       }]
   }
 
@@ -459,6 +473,19 @@ export class CheTasks {
         }
       }
     ]
+  }
+
+  deleteNamespace(flags: any): ReadonlyArray<Listr.ListrTask> {
+    return [{
+      title: `Delete namespace ${flags.chenamespace}`,
+      task: async (task: any) => {
+        const namespaceExist = await this.kube.namespaceExist(flags.chenamespace)
+        if (namespaceExist) {
+          await this.kube.deleteNamespace(flags.chenamespace)
+          task.title = await `${task.title}...OK`
+        }
+      }
+    }]
   }
 
   verifyCheNamespaceExistsTask(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -419,7 +419,7 @@ export class CheTasks {
         }
       },
       {
-        title: `Delete console link ${this.cheConsoleLinkName}`,
+        title: `Delete consoleLink ${this.cheConsoleLinkName}`,
         task: async (_ctx: any, task: any) => {
           const consoleLinkExists = await this.kube.consoleLinkExists(this.cheConsoleLinkName)
           const checlusters = await this.kube.getAllCheCluster()

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -336,8 +336,8 @@ export class OperatorTasks {
       task: async (_ctx: any, task: any) => {
         const checluster = await kh.getCheCluster(flags.chenamespace)
         if (checluster && checluster.spec.auth.oAuthClientName) {
-          const oAuthClientAuthorization = await kh.getOAuthClientAuthorizations(checluster.spec.auth.oAuthClientName)
-          await kh.deleteOAuthClientAuthorizations(oAuthClientAuthorization)
+          const oAuthClientAuthorizations = await kh.getOAuthClientAuthorizations(checluster.spec.auth.oAuthClientName)
+          await kh.deleteOAuthClientAuthorizations(oAuthClientAuthorizations)
           task.title = await `${task.title}...OK`
         } else {
           task.title = await `${task.title}...Skipped: No oauthClientAuthorizations found.`

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -332,7 +332,7 @@ export class OperatorTasks {
     const clusterRoleName = `${flags.chenamespace}-${this.operatorClusterRole}`
     const clusterRoleBindingName = `${flags.chenamespace}-${this.operatorClusterRoleBinding}`
     return [{
-      title: 'Delete the oauthClientAuthorizations',
+      title: 'Delete oauthClientAuthorizations',
       task: async (_ctx: any, task: any) => {
         const checluster = await kh.getCheCluster(flags.chenamespace)
         if (checluster && checluster.spec.auth.oAuthClientName) {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -339,7 +339,7 @@ export class OperatorTasks {
           const oAuthClientAuthorizations = await kh.getOAuthClientAuthorizations(checluster.spec.auth.oAuthClientName)
           await kh.deleteOAuthClientAuthorizations(oAuthClientAuthorizations)
         }
-        task.title = await `${task.title}...OK`
+        task.title = `${task.title}...OK`
       }
     },
     {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -335,13 +335,11 @@ export class OperatorTasks {
       title: 'Delete oauthClientAuthorizations',
       task: async (_ctx: any, task: any) => {
         const checluster = await kh.getCheCluster(flags.chenamespace)
-        if (checluster && checluster.spec.auth.oAuthClientName) {
+        if (checluster && checluster.spec && checluster.spec.auth && checluster.spec.auth.oAuthClientName) {
           const oAuthClientAuthorizations = await kh.getOAuthClientAuthorizations(checluster.spec.auth.oAuthClientName)
           await kh.deleteOAuthClientAuthorizations(oAuthClientAuthorizations)
-          task.title = await `${task.title}...OK`
-        } else {
-          task.title = await `${task.title}...Skipped: No oauthClientAuthorizations found.`
         }
+        task.title = await `${task.title}...OK`
       }
     },
     {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -358,7 +358,7 @@ export class OperatorTasks {
       title: `Delete CRD ${this.cheClusterCrd}`,
       task: async (_ctx: any, task: any) => {
         const checlusters = await kh.getAllCheCluster()
-        if (checlusters && checlusters.length > 0) {
+        if (checlusters.length > 0) {
           task.title = await `${task.title}...Skipped: another Eclipse Che deployment found.`
         } else {
           await kh.deleteCrd(this.cheClusterCrd)

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -332,6 +332,19 @@ export class OperatorTasks {
     const clusterRoleName = `${flags.chenamespace}-${this.operatorClusterRole}`
     const clusterRoleBindingName = `${flags.chenamespace}-${this.operatorClusterRoleBinding}`
     return [{
+      title: 'Delete the oauthClientAuthorizations',
+      task: async (_ctx: any, task: any) => {
+        const checluster = await kh.getCheCluster(flags.chenamespace)
+        if (checluster && checluster.spec.auth.oAuthClientName) {
+          const oAuthClientAuthorization = await kh.getOAuthClientAuthorizations(checluster.spec.auth.oAuthClientName)
+          await kh.deleteOAuthClientAuthorizations(oAuthClientAuthorization)
+          task.title = await `${task.title}...OK`
+        } else {
+          task.title = await `${task.title}...Skipped: No oauthClientAuthorizations found.`
+        }
+      }
+    },
+    {
       title: `Delete the Custom Resource of type ${CHE_CLUSTER_CRD}`,
       task: async (_ctx: any, task: any) => {
         await kh.deleteCheCluster(flags.chenamespace)
@@ -345,7 +358,7 @@ export class OperatorTasks {
       title: `Delete CRD ${this.cheClusterCrd}`,
       task: async (_ctx: any, task: any) => {
         const checlusters = await kh.getAllCheCluster()
-        if (checlusters.length > 0) {
+        if (checlusters && checlusters.length > 0) {
           task.title = await `${task.title}...Skipped: another Eclipse Che deployment found.`
         } else {
           await kh.deleteCrd(this.cheClusterCrd)

--- a/test/e2e/minikube.test.ts
+++ b/test/e2e/minikube.test.ts
@@ -157,7 +157,7 @@ describe('Workspace creation, list, start, inject, delete. Support stop and dele
     test
       .stdout()
       .stderr({ print: true })
-      .command(['server:delete', '--skip-deletion-check'])
+      .command(['server:delete', '--skip-deletion-check', '--delete-namespace'])
       .exit(0)
       .it('deletes Eclipse Che resources on minikube successfully')
   })

--- a/test/e2e/minishift.test.ts
+++ b/test/e2e/minishift.test.ts
@@ -160,7 +160,7 @@ describe('Workspace creation, list, start, inject, delete. Support stop and dele
     test
       .stdout()
       .stderr({ print: true })
-      .command(['server:delete', '--skip-deletion-check'])
+      .command(['server:delete', '--skip-deletion-check', '--delete-namespace'])
       .exit(0)
       .it('deletes Eclipse Che resources on minishift successfully')
   })

--- a/test/e2e/openshift.test.ts
+++ b/test/e2e/openshift.test.ts
@@ -165,7 +165,7 @@ describe('Workspace creation, list, start, inject, delete. Support stop and dele
     test
       .stdout()
       .stderr({ print: true })
-      .command(['server:delete', '--skip-deletion-check'])
+      .command(['server:delete', '--skip-deletion-check', '--delete-namespace'])
       .exit(0)
       .it('deletes Eclipse Che resources on minishift successfully')
   })


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
This PR have:
 
- New flag(--delete-namespace) for server:delete which allows users to delete the namespace after remove Che resources from cluster
- Remove ConsoleLinks from cluster 
- Remove all oauthClientAuthorizations linked to che instance

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-714
https://github.com/eclipse/che/issues/17784