### PR TITLE
fix: Fix server:delete when installer was helm

### DIFF
--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -355,11 +355,15 @@ export class OperatorTasks {
     {
       title: `Delete CRD ${this.cheClusterCrd}`,
       task: async (_ctx: any, task: any) => {
+        const crdExists = await kh.crdExist(this.cheClusterCrd)
         const checlusters = await kh.getAllCheCluster()
         if (checlusters.length > 0) {
           task.title = await `${task.title}...Skipped: another Eclipse Che deployment found.`
         } else {
-          await kh.deleteCrd(this.cheClusterCrd)
+          // Check if CRD exist. When installer is helm the CRD are not created
+          if (crdExists) {
+            await kh.deleteCrd(this.cheClusterCrd)
+          }
           task.title = await `${task.title}...OK`
         }
       }


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
After installing Eclipse Che using `helm`, server:delete is not working properly because no CRD are created.
Log issue:
[flacatus@chehost-local chectl]$ ./bin/run server:delete
› Current Kubernetes context: 'minikube'
You're going to remove Eclipse Che server in namespace 'che' on server 'https://172.17.0.10:8443'. If you want to continue - press Y: y
  ✔ Verify Kubernetes API...OK
  ✔ Delete oauthClientAuthorizations...OK
  ✔ Delete the Custom Resource of type checlusters.org.eclipse.che...OK
  ✖ Delete CRD checlusters.org.eclipse.che
    → customresourcedefinitions.apiextensions.k8s.io "checlusters.org.eclipse.che" not found
    Delete role binding che-operator
    Delete role che-operator
    Delete cluster role binding che-che-operator
    Delete cluster role che-che-operator
    Delete server and workspace rolebindings
    Delete service accounts che-operator
    Delete PVC che-operator
    Check if OLM is pre-installed on the platform
    Delete(OLM) custom catalog source eclipse-che-custom-catalog-source
    Delete all deployments
    Delete all services
    Delete all ingresses
    Delete configmaps for Eclipse Che server and operator
    Delete rolebindings che, che-workspace-exec and che-workspace-view
    Delete service accounts che, che-workspace
    Delete PVC postgres-data and che-data-volume
    Delete consoleLink che
    Purge Eclipse Che Helm chart
    Wait until Eclipse Che pod is deleted
    Wait until Keycloak pod is deleted
    Wait until Postgres pod is deleted
    Wait until Devfile registry pod is deleted
    Wait until Plugin registry pod is deleted
    Error: customresourcedefinitions.apiextensions.k8s.io "checlusters.org.eclipse.che" not found


### What issues does this PR fix or reference?

