### PR TITLE
feat: Use automatic update for nightly olm installer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "test-watch": "jest --watchAll",
     "e2e-minikube": "jest ./test/e2e/minikube.test.ts --testRegex='/test/(e2e)/.*.test.ts'",
     "e2e-minishift": "jest ./test/e2e/minishift.test.ts --testRegex='/test/(e2e)/.*.test.ts'",
+    "e2e-openshift": "jest ./test/e2e/openshift.test.ts --testRegex='/test/(e2e)/.*.test.ts'",
     "prepack": "rm -rf lib && rm -rf tsconfig.tsbuildinfo && tsc -b && oclif-dev manifest && oclif-dev readme",
     "pack-binaries": "oclif-dev pack",
     "postpack": "rm -f oclif.manifest.json",

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -47,7 +47,11 @@ export class OLMTasks {
           // catalog source name for stable Che version
           ctx.catalogSourceNameStable = isKubernetesPlatformFamily(flags.platform) ? KUBERNETES_OLM_CATALOG : OPENSHIFT_OLM_CATALOG
 
-          ctx.approvalStarategy = flags['auto-update'] ? 'Automatic' : 'Manual'
+          if (!flags['auto-update'] && !isStableVersion(flags)) {
+            ctx.approvalStarategy = 'Automatic'
+          } else {
+            ctx.approvalStarategy = flags['auto-update'] ? 'Automatic' : 'Manual'
+          }
 
           ctx.sourceName = flags['catalog-source-name'] || CUSTOM_CATALOG_SOURCE_NAME
           ctx.generalPlatformName = isKubernetesPlatformFamily(flags.platform) ? 'kubernetes' : 'openshift'


### PR DESCRIPTION
### What does this PR do?
nightly has strong tendentious to breaking changes. It would be nice to enable auto-update for nightly channel to sync images changes with deployment and permission changes in the csv file.

### What issues does this PR fix or reference?
none. Enhancement.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>