### PR TITLE
fix: Increase Minikube ingress addon enabling timeout

### DIFF
--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -154,7 +154,7 @@ export class MinikubeTasks {
   }
 
   async enableIngressAddon() {
-    await execa('minikube', ['addons', 'enable', 'ingress'], { timeout: 18000 })
+    await execa('minikube', ['addons', 'enable', 'ingress'], { timeout: 60000 })
   }
 
   async getMinikubeIP(): Promise<string> {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
In the latest versions of Minikube enabling of ingress addon takes more time than in previous versions. Because of that, chectl fails on the addon enabling step. Thsi PR increases the timeout to avoid such installation failure.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17952
