### PR TITLE
fix: Do not throw error if several pods are found

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,11 +2102,11 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse/che-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#66d2f95e9fb6690b07b00a6d76ceb155ebb4b810"
+  resolved "git://github.com/eclipse/che-operator#2ba993381c5796cc3cc49456123da5e2250604f9"
 
 "eclipse-che@git://github.com/eclipse/che#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che#b2e83ac1a411a15e45ea90f0aebf6072c0723b35"
+  resolved "git://github.com/eclipse/che#d4ff87e492c3c394272120ec69aed7a309b16ecc"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Sometimes chectl fails to deploy Eclipse Che because several keycloak pods are present.
This PR should solve this problem.

