### PR TITLE
fix: Explictly specify microk8s.status output format

### DIFF
--- a/src/tasks/platforms/microk8s.ts
+++ b/src/tasks/platforms/microk8s.ts
@@ -110,7 +110,7 @@ export class MicroK8sTasks {
   }
 
   async enabledAddons(): Promise<object> {
-    const { stdout } = await execa('microk8s.status', [], { timeout: 10000 })
+    const { stdout } = await execa('microk8s.status', ['--format', 'short'], { timeout: 10000 })
     return {
       ingress: stdout.includes('ingress: enabled'),
       storage: stdout.includes('storage: enabled')


### PR DESCRIPTION
### What does this PR do?
Explicitly specify microk8s.status output format (--format short) since microk8s recently changed the default format (with v 1.19.0), breaking the addons enabled preflight checks.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16408


### How to test this PR?
Using chectl with microk8s platform, where microk8s version is 1.19.0 or later, prior to fix, it will incorrectly fail on the MicroK8s preflight checklist, with the Error "The storage addon hasn't been enabled in microk8s". 

After the fix, the preflight checks for storage and ingress addons enabled will succeed.
