### PR TITLE
fix: Fix appearing server start deprectation note

### DIFF
--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -334,7 +334,7 @@ export default class Deploy extends Command {
   }
 
   async run() {
-    if (process.argv.indexOf('server:start')) {
+    if (process.argv.indexOf('server:start') > -1) {
       this.warn('\'server:start\' command is deprecated. Use \'server:deploy\' instead.')
     }
 


### PR DESCRIPTION
### What does this PR do?
Fix appearing `serverstart` command deprectation note

### What issues does this PR fix or reference?
Little quick fix

### How to test this PR?
Run:

```
./bin/run server:deploy -n che -p openshift -m
```
Message:

`Warning: 'server:start' command is deprecated. Use 'server:deploy' `

should not appear.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
