### PR TITLE
fix: Handle case when '~/.config' dir is missing

### DIFF
--- a/src/api/che-login-manager.ts
+++ b/src/api/che-login-manager.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import axios, { AxiosInstance } from 'axios'
-import * as fs from 'fs'
+import * as fs from 'fs-extra'
 import * as https from 'https'
 import * as path from 'path'
 import * as querystring from 'querystring'
@@ -141,7 +141,7 @@ export class CheServerLoginManager {
    */
   static async getInstance(configDirPath: string): Promise<CheServerLoginManager> {
     if (!fs.existsSync(configDirPath)) {
-      fs.mkdirSync(configDirPath)
+      fs.mkdirsSync(configDirPath)
     }
     const dataFilePath = path.join(configDirPath, LOGIN_DATA_FILE_NAME)
     if (loginContext && loginContext.dataFilePath === dataFilePath) {


### PR DESCRIPTION
### What does this PR do?
Fixes case when user home on *nix systems doesn't have `.config` directory created.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18169

### How to test this PR?
Run `chectl auth:login <args>` command 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
