### PR TITLE
fix: Patch minikube storage only for 1.9.1...1.12.1 versions

### DIFF
--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -98,8 +98,8 @@ export class MinikubeTasks {
         // For more details see https://github.com/kubernetes/minikube/issues/7218
         // To workaround the bug, it is required to patch storage provisioner as well as its permissions.
         title: 'Patch minikube storage',
-        enabled: ctx => ctx.minikubeVersionMajor && ctx.minikubeVersionMinor &&
-          ctx.minikubeVersionMajor === 1 && ctx.minikubeVersionMinor >= 9,
+        enabled: ctx => ctx.minikubeVersionMajor && ctx.minikubeVersionMinor && ctx.minikubeVersionMajor === 1 &&
+          ((ctx.minikubeVersionMinor >= 9 && ctx.minikubeVersionMinor <= 11) || (ctx.minikubeVersionMinor === 12 && ctx.minikubeVersionPatch <= 1)),
         task: async (_ctx: any, task: any) => {
           // Patch storage provisioner pod to the latest version
           const storageProvisionerImage = 'gcr.io/k8s-minikube/storage-provisioner@sha256:bb22ad560924f0f111eb30ffc2dc1315736ab09979c5e77ff9d7d3737f671ca0'
@@ -118,7 +118,7 @@ export class MinikubeTasks {
 
           // Set required permissions for cluster role of persistent volume provisioner
           if (! await kube.addClusterRoleRule('system:persistent-volume-provisioner',
-                                              [''], ['endpoints'], ['get', 'list', 'watch', 'create', 'patch', 'update'])) {
+            [''], ['endpoints'], ['get', 'list', 'watch', 'create', 'patch', 'update'])) {
             throw new Error('Failed to patch permissions for persistent-volume-provisioner')
           }
 


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Patch minikube storage only for 1.9.1...1.12.1 versions

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18228

### How to test this PR?
1. Deploy Eclipse Che on minikube 1.12.1 and latest versions
2. Check that patch is applied only for minikube 1.12.1


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
