### PR TITLE
fix: Backport fix catalog yaml argument and first installation timeout issue

### DIFF
--- a/src/api/typings/olm.d.ts
+++ b/src/api/typings/olm.d.ts
@@ -66,12 +66,15 @@ export interface InstallPlanSpec {
 }
 
 export interface InstallPlanStatus {
+  phase?: string
   conditions: InstallPlanCondition[]
 }
 
 export interface InstallPlanCondition {
   type: string
   status: string
+  reason: string
+  message: string
 }
 
 export interface ClusterServiceVersion {

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -60,7 +60,7 @@ export class OLMTasks {
         }
       },
       {
-        enabled: () => !isStableVersion(flags),
+        enabled: () => !isStableVersion(flags) && !flags['catalog-source-name'] && !flags['catalog-source-yaml'],
         title: `Create nightly index CatalogSource in the namespace ${flags.chenamespace}`,
         task: async (ctx: any, task: any) => {
           if (!await kube.catalogSourceExists(NIGHTLY_CATALOG_SOURCE_NAME, flags.chenamespace)) {
@@ -77,8 +77,8 @@ export class OLMTasks {
         enabled: () => flags['catalog-source-yaml'],
         title: 'Create custom catalog source from file',
         task: async (ctx: any, task: any) => {
-          if (!await kube.catalogSourceExists(CUSTOM_CATALOG_SOURCE_NAME, flags.chenamespace)) {
-            const customCatalogSource: CatalogSource = kube.readCatalogSourceFromFile(flags['catalog-source-yaml'])
+          const customCatalogSource: CatalogSource = kube.readCatalogSourceFromFile(flags['catalog-source-yaml'])
+          if (!await kube.catalogSourceExists(customCatalogSource.metadata!.name!, flags.chenamespace)) {
             customCatalogSource.metadata.name = ctx.sourceName
             customCatalogSource.metadata.namespace = flags.chenamespace
             await kube.createCatalogSource(customCatalogSource)


### PR DESCRIPTION
### What does this PR do?
Backport to branch 7.20.x
1. Fix catalog source yaml argument for olm installer. 
2. Fix timeout installation error, when install plan installs longer than 30 sec. It's reproducible with cluster bot on first installation. Second installation is much faster and bug is not reproducible. Fix important for CRW.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18105

### How to test this PR?
**Test fix timeout error:**
1. Request cluster using bot.
2. Install Che first time:

```bash
$ ./bin/run server:start -n che -p openshift -m
```
This first installation could fail. With this fix it should not.


**Test catalogsource yaml argument:**
1. Create file with custom catalog source yaml:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: eclipse-che-preview-openshift
  namespace: che
spec:
  sourceType: grpc
  image: quay.io/aandriienko/eclipse-che-openshift-opm-catalog:preview
  updateStrategy:
    registryPoll:
      interval: 5m
```
2. Install Che on the Openshift cluster:

```bash
$ ./bin/run server:start -n che \
-p openshift \
-m \
--catalog-source-yaml "/home/user/projects/chectl/catalogSource.yaml" \
--package-manifest-name "eclipse-che-preview-openshift" \
--olm-channel "nightly" \
--installer olm
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
