### PR TITLE
fix: Remove not actual openshift oAuth auto detection.

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1374,9 +1374,6 @@ export class KubeHelper {
       merge(cheClusterCR, ctx.crPatch)
     }
 
-    // Back off some configuration properties(chectl estimated them like not working or not desired)
-    merge(cheClusterCR, ctx.CROverrides)
-
     const customObjectsApi = KubeHelper.KUBE_CONFIG.makeApiClient(CustomObjectsApi)
     try {
       const { body } = await customObjectsApi.createNamespacedCustomObject('org.eclipse.che', 'v1', cheNamespace, 'checlusters', cheClusterCR)

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -24,7 +24,6 @@ import { DevWorkspaceTasks } from '../../tasks/component-installers/devfile-work
 import { getPrintHighlightedMessagesTask, getRetrieveKeycloakCredentialsTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
-import { CommonPlatformTasks } from '../../tasks/platforms/common-platform-tasks'
 import { PlatformTasks } from '../../tasks/platforms/platform'
 import { getCommandErrorMessage, getCommandSuccessMessage, isOpenshiftPlatformFamily, notifyCommandCompletedSuccessfully } from '../../util'
 
@@ -346,7 +345,6 @@ export default class Deploy extends Command {
 
     // Platform Checks
     let platformCheckTasks = new Listr(platformTasks.preflightCheckTasks(flags, this), ctx.listrOptions)
-    platformCheckTasks.add(CommonPlatformTasks.oAuthProvidersExists(flags))
 
     // Checks if Eclipse Che is already deployed
     let preInstallTasks = new Listr(undefined, ctx.listrOptions)

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -23,7 +23,6 @@ import { DEFAULT_CHE_OPERATOR_IMAGE, SUBSCRIPTION_NAME } from '../../constants'
 import { getPrintHighlightedMessagesTask } from '../../tasks/installers/common-tasks'
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
-import { CommonPlatformTasks } from '../../tasks/platforms/common-platform-tasks'
 import { getCommandErrorMessage, getCommandSuccessMessage, getCurrentChectlName, getCurrentChectlVersion, getImageTag, getLatestChectlVersion, notifyCommandCompletedSuccessfully } from '../../util'
 
 export default class Update extends Command {
@@ -104,7 +103,6 @@ export default class Update extends Command {
     const apiTasks = new ApiTasks()
     const preUpdateTasks = new Listr([], ctx.listrOptions)
     preUpdateTasks.add(apiTasks.testApiTasks(flags, this))
-    preUpdateTasks.add(CommonPlatformTasks.oAuthProvidersExists(flags))
     preUpdateTasks.add(installerTasks.preUpdateTasks(flags, this))
 
     // update tasks

--- a/src/tasks/platforms/common-platform-tasks.ts
+++ b/src/tasks/platforms/common-platform-tasks.ts
@@ -8,13 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import ansi = require('ansi-colors')
 import * as http from 'http'
 import * as https from 'https'
 import * as Listr from 'listr'
-
-import { KubeHelper } from '../../api/kube'
-import { DOCS_LINK_HOW_TO_ADD_IDENTITY_PROVIDER_OS4, DOCS_LINK_HOW_TO_CREATE_USER_OS3 } from '../../constants'
 
 export namespace CommonPlatformTasks {
   /**
@@ -74,46 +70,5 @@ export namespace CommonPlatformTasks {
         resolve(false)
       })
     })
-  }
-
-  export function oAuthProvidersExists(flags: any): Listr.ListrTask {
-    let kube = new KubeHelper(flags)
-    return {
-      title: 'Verify Openshift oauth.',
-      enabled: (ctx: any) => ctx.isOpenShift && isOAuthEnabled(ctx),
-      task: async (ctx: any, task: any) => {
-        if (ctx.isOpenShift4) {
-          const providers = await kube.getOpenshiftAuthProviders()
-          if (!providers || providers.length === 0) {
-            ctx.highlightedMessages.push(`❗ ${ansi.yellow('[WARNING]')} OpenShift OAuth is turned off, because there is no any identity providers configured. ${DOCS_LINK_HOW_TO_ADD_IDENTITY_PROVIDER_OS4}`)
-            ctx.CROverrides = { spec: { auth: { openShiftoAuth: false } } }
-          }
-        } else {
-          if (await kube.getUsersNumber() === 0) {
-            ctx.highlightedMessages.push(`❗ ${ansi.yellow('[WARNING]')} OpenShift OAuth is turned off, because there are no any users added. See: "${DOCS_LINK_HOW_TO_CREATE_USER_OS3}"`)
-            ctx.CROverrides = { spec: { auth: { openShiftoAuth: false } } }
-          }
-        }
-        task.title = `${task.title}...done.`
-      }
-    }
-  }
-
-  /**
-   * Checks if Openshift oAuth enabled in Che configuration.
-   * Returns true if Openshift oAuth is enabled (or omitted) and false if it is explicitly disabled.
-   */
-  function isOAuthEnabled(ctx: any): boolean {
-    const crPatch = ctx.crPatch
-    if (crPatch && crPatch.spec && crPatch.spec.auth && typeof crPatch.spec.auth.openShiftoAuth === 'boolean') {
-      return crPatch.spec.auth.openShiftoAuth
-    }
-
-    const customCR = ctx.customCR
-    if (customCR && customCR.spec && customCR.spec.auth && typeof customCR.spec.auth.openShiftoAuth === 'boolean') {
-      return customCR.spec.auth.openShiftoAuth
-    }
-
-    return true
   }
 }


### PR DESCRIPTION
### What does this PR do?
Remove not actual openshift oAuth auto detection.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1361

### How to test this PR?
You need to install Eclipse Che on the openshfit 4 with no identity providers. Message about `OpenShift OAuth is turned off` shouldn't appear.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
