### PR TITLE
feat: mm notifications for releases only

### DIFF
--- a/.github/workflows/release-build-and-push-to-GH-releases.yml
+++ b/.github/workflows/release-build-and-push-to-GH-releases.yml
@@ -78,12 +78,3 @@ jobs:
           files: "./dist/channels/**/chectl-*.gz"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create MM message
-        run: |
-          echo "{\"text\":\":building_construction: chectl ${{ github.event.inputs.version }} has been released: https://github.com/che-incubator/chectl/releases/tag/${{ github.event.inputs.version }}\"}" > mattermost.json
-      - name: Send MM message
-        uses: mattermost/action-mattermost-notify@master
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot

--- a/.github/workflows/release-notify-mattermost.yml
+++ b/.github/workflows/release-notify-mattermost.yml
@@ -1,0 +1,28 @@
+#
+#  Copyright (c) 2012-2020 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+name: Release - generate release and push artifacts to github pages (after PR approved)
+on:
+  # Trigger the workflow on push only for the master and 7.y.x branches
+  push:
+    tags:
+      - '7.*.x'
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-20.04
+      - name: Create MM message
+        run: |
+          echo "{\"text\":\":building_construction: chectl ${{ github.ref }} has been released: https://github.com/che-incubator/chectl/releases/tag/${{ github.ref }}\"}" > mattermost.json
+      - name: Send MM message
+        uses: mattermost/action-mattermost-notify@master
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          MATTERMOST_CHANNEL: eclipse-che-releases
+          MATTERMOST_USERNAME: che-bot


### PR DESCRIPTION
### What does this PR do?

only notify for releases (tags = 7.yy.*); use tag = github.ref instead of github.event.inputs.version

Change-Id: I7ea6a3e32e79b2c0e1e27438dc25c55a1218e403
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/18906#issuecomment-796472177

Followup to https://github.com/che-incubator/chectl/pull/1129

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.