### PR TITLE
only trigger when VERSION file updated in .x...

### DIFF
--- a/.github/workflows/release-notify-mattermost.yml
+++ b/.github/workflows/release-notify-mattermost.yml
@@ -8,23 +8,36 @@
 #
 #  Contributors:
 #    Red Hat, Inc. - initial API and implementation
-name: Release - send mattermost notification for 7.y.* tags
+name: Release - send mattermost notification
 on:
-  # Trigger the workflow on push only for 7.y.* tags
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version that is going to be announced. Should be in format 7.y.z'
+        required: true
   push:
-    tags:
+    # on change to VERSION file only (PR merged as part of release)
+    paths:
+      - 'VERSION'
+    # Trigger on push only for 7.y.* branch
+    branches:
       - '7.*.*'
 jobs:
-  build-and-deploy:
+  notify:
     runs-on: ubuntu-20.04
     steps:
       - name: Create MM message
         run: |
-          milestone=${{ github.event.inputs.version }}
-          milestone=${milestone%.*}; echo "milestone: ${milestone}"
-          echo "{\"text\":\":building_construction: chectl ${{ github.ref }} has been released: https://github.com/che-incubator/chectl/releases/tag/${{ github.ref }}\n\nPlease resolve or move unresolved issues assigned to this milestone: https://github.com/eclipse/che/milestones/${milestone}\"}" > mattermost.json
+          if [[ ${{ github.event.inputs.version }} != "" ]]; then
+            version=${{ github.event.inputs.version }}
+            milestone=${version%.*}; echo "version milestone: ${milestone}"
+          else
+            version=$(cat VERSION)
+            milestone=${version%.*}; echo "branch milestone: ${milestone}"
+          fi
+          echo "{\"text\":\":building_construction: chectl ${version} has been released: https://github.com/che-incubator/chectl/releases/tag/${version}\n\nPlease resolve or move unresolved issues assigned to this milestone: https://github.com/eclipse/che/milestones/${milestone}\"}" > mattermost.json
       - name: Send MM message
-        uses: mattermost/action-mattermost-notify@master
+        uses: mattermost/action-mattermost-notify@1.0.2
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
           MATTERMOST_CHANNEL: eclipse-che-releases


### PR DESCRIPTION
### What does this PR do?

only trigger when VERSION file updated in .x branch

Change-Id: If4237d7abb0a7c11010704f2da4c6ac257b6dd81
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.