### PR TITLE
fix: Wait until operator remove cluster scope objects itself

### DIFF
--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -361,16 +361,34 @@ export class OperatorTasks {
     {
       title: `Delete the Custom Resource of type ${CHE_CLUSTER_CRD}`,
       task: async (_ctx: any, task: any) => {
-        const checluster = await kh.getCheCluster(flags.chenamespace)
-        if (checluster) {
-          await kh.patchCheClusterCustomResource(checluster.metadata.name, flags.chenamespace, { metadata: { finalizers: null } })
-        }
-
         await kh.deleteCheCluster(flags.chenamespace)
         do {
-          await cli.wait(2000) //wait a couple of secs for the finalizers to be executed
+          await cli.wait(20 * 60 * 1000) // default timeout in che operator to clean up cluster scope objects
         } while (await kh.getCheCluster(flags.chenamespace))
-        task.title = `${task.title}...OK`
+
+        const checluster = await kh.getCheCluster(flags.chenamespace)
+        if (checluster) {
+          // if checluster still exists then remove finalizers and delete again
+          try {
+            await kh.patchCheClusterCustomResource(checluster.metadata.name, flags.chenamespace, { metadata: { finalizers: null } })
+          } catch (error) {
+            if (!await kh.getCheCluster(flags.chenamespace)) { // check again if exists
+              return // successfully removed
+            }
+            throw error
+          }
+
+          await kh.deleteCheCluster(flags.chenamespace)
+          do {
+            await cli.wait(2 * 60 * 1000)
+          } while (await kh.getCheCluster(flags.chenamespace))
+        }
+
+        if (!await kh.getCheCluster(flags.chenamespace)) {
+          task.title = `${task.title}...OK`
+        } else {
+          task.title = `${task.title}...Failed`
+        }
       }
     },
     {


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Wait until operator remove cluster scope objects itself

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18501


### How to test this PR?
1. deploy eclipse-che  on OpenShift
2. run `server:delete` make sure when checluster is removed then all cluster scope objects are removed as well

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
