### PR TITLE
feat: Inspect checluster status and fail if status.reason is not empty

### DIFF
--- a/src/tasks/kube.ts
+++ b/src/tasks/kube.ts
@@ -29,34 +29,31 @@ export class KubeTasks {
       {
         title: 'Scheduling',
         task: async (_ctx: any, task: any) => {
-          const taskTitle = task.title
           const iterations = this.kubeHelper.podWaitTimeout / this.interval
           for (let i = 1; i <= iterations; i++) {
             // check cheCluster status
             const cheClusterFailState = await this.getCheClusterFailState(namespace)
             if (cheClusterFailState) {
-              task.title = `${taskTitle}...failed`
+              task.title = `${task.title}...failed`
               throw new Error(`Eclipse Che operator failed, reason: ${cheClusterFailState.reason}, message: ${cheClusterFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
             }
 
             // check 'PodScheduled' condition
             const podFailState = await this.getPodFailState(namespace, selector, 'PodScheduled')
             if (podFailState) {
-              task.title = `${taskTitle}`
-
               // for instance we need some time for pvc provisioning...
               await cli.wait(this.kubeHelper.podErrorRecheckTimeout)
 
               const podFailState = await this.getPodFailState(namespace, selector, 'PodScheduled')
               if (podFailState) {
-                task.title = `${taskTitle}...failed`
+                task.title = `${task.title}...failed`
                 throw new Error(`Failed to schedule a pod, reason: ${podFailState.reason}, message: ${podFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
               }
             }
 
             const allScheduled = await this.isPodConditionStatusPassed(namespace, selector, 'PodScheduled')
             if (allScheduled) {
-              task.title = `${taskTitle}...done`
+              task.title = `${task.title}...done`
               return
             }
 
@@ -69,17 +66,15 @@ export class KubeTasks {
       {
         title: 'Downloading images',
         task: async (_ctx: any, task: any) => {
-          const taskTitle = task.title
           const iterations = this.kubeHelper.podDownloadImageTimeout / this.interval
           for (let i = 1; i <= iterations; i++) {
             const failedState = await this.getContainerFailState(namespace, selector, 'Pending')
             if (failedState) {
-              task.title = `${taskTitle}...failed, rechecking...`
               await cli.wait(this.kubeHelper.podErrorRecheckTimeout)
 
               const failedState = await this.getContainerFailState(namespace, selector, 'Pending')
               if (failedState) {
-                task.title = `${taskTitle}...failed`
+                task.title = `${task.title}...failed`
                 throw new Error(`Failed to download image, reason: ${failedState.reason}, message: ${failedState.message}.`)
               }
             }
@@ -87,7 +82,7 @@ export class KubeTasks {
             const pods = await this.kubeHelper.getPodListByLabel(namespace, selector)
             const allRunning = !pods.some(value => !value.status || value.status.phase !== 'Running')
             if (pods.length && allRunning) {
-              task.title = `${taskTitle}...done`
+              task.title = `${task.title}...done`
               return
             }
 
@@ -100,31 +95,29 @@ export class KubeTasks {
       {
         title: 'Starting',
         task: async (_ctx: any, task: any) => {
-          const taskTitle = task.title
           const iterations = this.kubeHelper.podReadyTimeout / this.interval
           for (let i = 1; i <= iterations; i++) {
             // check cheCluster status
             const cheClusterFailState = await this.getCheClusterFailState(namespace)
             if (cheClusterFailState) {
-              task.title = `${taskTitle}...failed`
+              task.title = `${task.title}...failed`
               throw new Error(`Eclipse Che operator failed, reason: ${cheClusterFailState.reason}, message: ${cheClusterFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
             }
 
             const failedState = await this.getContainerFailState(namespace, selector, 'Running')
             if (failedState) {
-              task.title = `${taskTitle}...failed, rechecking...`
               await cli.wait(this.kubeHelper.podErrorRecheckTimeout)
 
               const failedState = await this.getContainerFailState(namespace, selector, 'Running')
               if (failedState) {
-                task.title = `${taskTitle}...failed`
+                task.title = `${task.title}...failed`
                 throw new Error(`Failed to start a pod, reason: ${failedState.reason}, message: ${failedState.message}`)
               }
             }
 
             const terminatedState = await this.kubeHelper.getPodLastTerminatedState(namespace, selector)
             if (terminatedState) {
-              task.title = `${taskTitle}...failed`
+              task.title = `${task.title}...failed`
               let errorMsg = `Failed to start a pod, reason: ${terminatedState.reason}`
               terminatedState.message && (errorMsg += `, message: ${terminatedState.message}`)
               terminatedState.exitCode && (errorMsg += `, exitCode: ${terminatedState.exitCode}`)
@@ -134,7 +127,7 @@ export class KubeTasks {
 
             const allStarted = await this.isPodConditionStatusPassed(namespace, selector, 'Ready')
             if (allStarted) {
-              task.title = `${taskTitle}...done`
+              task.title = `${task.title}...done`
               return
             }
 

--- a/src/tasks/kube.ts
+++ b/src/tasks/kube.ts
@@ -34,21 +34,18 @@ export class KubeTasks {
           for (let i = 1; i <= iterations; i++) {
             // check cheCluster status
             const cheClusterFailState = await this.getCheClusterFailState(namespace)
+            if (cheClusterFailState) {
+              task.title = `${taskTitle}...failed`
+              throw new Error(`Eclipse Che operator failed, reason: ${cheClusterFailState.reason}, message: ${cheClusterFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
+            }
 
             // check 'PodScheduled' condition
             const podFailState = await this.getPodFailState(namespace, selector, 'PodScheduled')
-
-            if (cheClusterFailState || podFailState) {
-              task.title = `${taskTitle}...failed, rechecking...`
+            if (podFailState) {
+              task.title = `${taskTitle}`
 
               // for instance we need some time for pvc provisioning...
               await cli.wait(this.kubeHelper.podErrorRecheckTimeout)
-
-              const cheClusterFailState = await this.getCheClusterFailState(namespace)
-              if (cheClusterFailState) {
-                task.title = `${taskTitle}...failed`
-                throw new Error(`Eclipse Che operator failed, reason: ${cheClusterFailState.reason}, message: ${cheClusterFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
-              }
 
               const podFailState = await this.getPodFailState(namespace, selector, 'PodScheduled')
               if (podFailState) {
@@ -108,17 +105,15 @@ export class KubeTasks {
           for (let i = 1; i <= iterations; i++) {
             // check cheCluster status
             const cheClusterFailState = await this.getCheClusterFailState(namespace)
+            if (cheClusterFailState) {
+              task.title = `${taskTitle}...failed`
+              throw new Error(`Eclipse Che operator failed, reason: ${cheClusterFailState.reason}, message: ${cheClusterFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
+            }
 
             const failedState = await this.getContainerFailState(namespace, selector, 'Running')
-            if (cheClusterFailState || failedState) {
+            if (failedState) {
               task.title = `${taskTitle}...failed, rechecking...`
               await cli.wait(this.kubeHelper.podErrorRecheckTimeout)
-
-              const cheClusterFailState = await this.getCheClusterFailState(namespace)
-              if (cheClusterFailState) {
-                task.title = `${taskTitle}...failed`
-                throw new Error(`Eclipse Che operator failed, reason: ${cheClusterFailState.reason}, message: ${cheClusterFailState.message}. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.`)
-              }
 
               const failedState = await this.getContainerFailState(namespace, selector, 'Running')
               if (failedState) {


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
- Inspect checluster status and fail if status.reason is not empty (when there is an error on operator side)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
    ❯ Operator pod bootstrap
      ✖ Scheduling...failed
        → Eclipse Che operator failed, reason: Fail, message: Fail for some reason. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.
        Downloading images
        Starting
      Prepare Eclipse Che cluster CR
 ›   Error: Error: Eclipse Che operator failed, reason: Fail, message: Fail for some reason. Consider increasing error recheck timeout with --k8spoderrorrechecktimeout flag.
 ›   Command server:deploy failed. Error log: /home/tolusha/.cache/chectl/error.log
 ```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19284

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. Deploy Eclipse Che using custom operator image with setting not empty status details
```
deploy.SetStatusDetails(deployContext, "Fail", "Fail for some reason", "")
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
