### PR TITLE
feat: (Un)install DevWorkspaceRouting CRD during during (un)installation using operator.

### DIFF
--- a/src/tasks/component-installers/devfile-workspace-operator-installer.ts
+++ b/src/tasks/component-installers/devfile-workspace-operator-installer.ts
@@ -76,8 +76,6 @@ export class DevWorkspaceTasks {
 
   protected devWorkspaceTemplatesCrdName = 'devworkspacetemplates.workspace.devfile.io'
 
-  protected workspaceRoutingsCrdName = 'devworkspaceroutings.controller.devfile.io'
-
   protected webhooksName = 'controller.devfile.io'
 
   // Web Terminal Operator constants
@@ -260,7 +258,6 @@ export class DevWorkspaceTasks {
         task: async (_ctx: any, task: any) => {
           await this.kubeHelper.deleteCrd(this.devWorkspacesCrdName)
           await this.kubeHelper.deleteCrd(this.devWorkspaceTemplatesCrdName)
-          await this.kubeHelper.deleteCrd(this.workspaceRoutingsCrdName)
 
           task.title = await `${task.title}...OK`
         },


### PR DESCRIPTION
### What does this PR do?
This creates the `DevWorkspaceRouting` CRD during the installation with `che-operator` and uninstalls
it when deleting the cluster.

`DevWorkspaceRouting` will become a prerequisite of `che-operator` once the `devworkspace-che-operator` is merged into the `che-operator` codebase.

Note that this PR depends on eclipse-che/che-operator#894.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
eclipse/che#20088

### How to test this PR?
1. `chectl server:deploy -a operator`
1. `kubectl get crds | grep devworkspaceroutings`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
