### PR TITLE
fix: Don't print keycloak credentials if `nativeUserMode: true`

### DIFF
--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -22,7 +22,7 @@ import { batch, cheDeployment, cheDeployVersion, cheNamespace, cheOperatorCRPatc
 import { DEFAULT_ANALYTIC_HOOK_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OLM_SUGGESTED_NAMESPACE, DOCS_LINK_INSTALL_RUNNING_CHE_LOCALLY, MIN_CHE_OPERATOR_INSTALLER_VERSION, MIN_HELM_INSTALLER_VERSION, MIN_OLM_INSTALLER_VERSION } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { DevWorkspaceTasks } from '../../tasks/component-installers/devfile-workspace-operator-installer'
-import { checkChectlAndCheVersionCompatibility, downloadTemplates, getPrintHighlightedMessagesTask, getRetrieveKeycloakCredentialsTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
+import { checkChectlAndCheVersionCompatibility, downloadTemplates, getPrintHighlightedMessagesTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
@@ -417,7 +417,6 @@ export default class Deploy extends Command {
         title: '✅  Post installation checklist',
         task: () => new Listr(cheTasks.waitDeployedChe()),
       },
-      getRetrieveKeycloakCredentialsTask(flags),
       retrieveCheCaCertificateTask(flags),
       ...cheTasks.preparePostInstallationOutput(flags),
       getPrintHighlightedMessagesTask(),

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -723,11 +723,18 @@ export class CheTasks {
 
             if (cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL) {
               messages.push(`Identity Provider URL     : ${addTrailingSlash(cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL)}`)
+
+              if (ctx.identityProviderUsername && ctx.identityProviderPassword) {
+                messages.push(`Identity Provider login   : "${ctx.identityProviderUsername}:${ctx.identityProviderPassword}".`)
+              } else {
+                const [login, password] = await this.che.retrieveKeycloakAdminCredentials(flags.chenamespace)
+                if (login && password) {
+                  messages.push(`Identity Provider login   : "${login}:${password}".`)
+                }
+              }
+
+              messages.push(OUTPUT_SEPARATOR)
             }
-            if (ctx.identityProviderUsername && ctx.identityProviderPassword) {
-              messages.push(`Identity Provider login   : "${ctx.identityProviderUsername}:${ctx.identityProviderPassword}".`)
-            }
-            messages.push(OUTPUT_SEPARATOR)
           }
           ctx.highlightedMessages = messages.concat(ctx.highlightedMessages)
           task.title = `${task.title}...done`

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -207,24 +207,6 @@ export function getMessageImportCaCertIntoBrowser(caCertFileLocation: string): s
   return message
 }
 
-export function getRetrieveKeycloakCredentialsTask(flags: any): Listr.ListrTask {
-  return {
-    title: 'Retrieving Keycloak admin credentials',
-    enabled: () => (flags.installer !== 'helm'),
-    task: async (ctx: any, task: any) => {
-      const che = new CheHelper(flags)
-      const [login, password] = await che.retrieveKeycloakAdminCredentials(flags.chenamespace)
-      if (login && password) {
-        ctx.identityProviderUsername = login
-        ctx.identityProviderPassword = password
-        task.title = `${task.title}...done`
-      } else {
-        task.title = `${task.title}...failed.`
-      }
-    },
-  }
-}
-
 /**
  * Prints important to user messages which are stored in ctx.highlightedMessages
  * Typically this task is the last task of a command.


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
 Don't print keycloak credentials if `nativeUserMode: true`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
 ✔ Eclipse Che status check...done
  ✔ Retrieving Che self-signed CA certificate...OK
  ✔ Prepare post installation output...done
  ✔ Show important messages
    ✔ Eclipse Che 7.35.0-SNAPSHOT has been successfully deployed.
    ✔ Documentation             : https://www.eclipse.org/che/docs/
    ✔ -------------------------------------------------------------------------------
    ✔ Users Dashboard           : https://che-eclipse-che.apps.ci-ln-lzv1012-f76d1.origin-ci-int-gce.dev.openshift.com
    ✔ HTPasswd user credentials : "che:3SoBty".
    ✔ -------------------------------------------------------------------------------
    ✔ Plug-in Registry          : https://che-eclipse-che.apps.ci-ln-lzv1012-f76d1.origin-ci-int-gce.dev.openshift.com/plugin-registry/v3/
    ✔ Devfile Registry          : https://che-eclipse-che.apps.ci-ln-lzv1012-f76d1.origin-ci-int-gce.dev.openshift.com/devfile-registry/
    ✔ -------------------------------------------------------------------------------
Command server:deploy has completed successfully in 04:35.
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
N/A

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
