### PR TITLE
fix: release versions comparator

### DIFF
--- a/src/api/version.ts
+++ b/src/api/version.ts
@@ -19,7 +19,7 @@ import Listr = require('listr')
 import * as path from 'path'
 import * as semver from 'semver'
 
-import { CHECTL_REPO, CheGithubClient } from '../api/github-client'
+import { CHECTL_REPO, CheGithubClient, ECLIPSE_CHE_INCUBATOR_ORG } from '../api/github-client'
 import { CHECTL_PROJECT_NAME } from '../constants'
 import { CheTasks } from '../tasks/che'
 import { getClusterClientCommand, getProjectName, getProjectVersion } from '../util'
@@ -315,8 +315,8 @@ export namespace VersionHelper {
     const verBCommitId = verB.split('-')[1].split('.')[1]
 
     const githubClient = new CheGithubClient()
-    const verACommitDateString = await githubClient.getCommitDate(CHECTL_REPO, verACommitId)
-    const verBCommitDateString = await githubClient.getCommitDate(CHECTL_REPO, verBCommitId)
+    const verACommitDateString = await githubClient.getCommitDate(ECLIPSE_CHE_INCUBATOR_ORG, CHECTL_REPO, verACommitId)
+    const verBCommitDateString = await githubClient.getCommitDate(ECLIPSE_CHE_INCUBATOR_ORG, CHECTL_REPO, verBCommitId)
     const verATimestamp = Date.parse(verACommitDateString)
     const verBTimestamp = Date.parse(verBCommitDateString)
     return verATimestamp > verBTimestamp ? 1 : -1

--- a/src/api/version.ts
+++ b/src/api/version.ts
@@ -19,6 +19,7 @@ import Listr = require('listr')
 import * as path from 'path'
 import * as semver from 'semver'
 
+import { CHECTL_REPO, CheGithubClient } from '../api/github-client'
 import { CHECTL_PROJECT_NAME } from '../constants'
 import { CheTasks } from '../tasks/che'
 import { getClusterClientCommand, getProjectName, getProjectVersion } from '../util'
@@ -238,7 +239,7 @@ export namespace VersionHelper {
     // Check cache, if it is already known that newer version available
     let isCachedNewerVersionAvailable = false
     try {
-      isCachedNewerVersionAvailable = semver.gt(newVersionInfo.latestVersion, currentVersion)
+      isCachedNewerVersionAvailable = await gtChectlVersion(newVersionInfo.latestVersion, currentVersion)
     } catch (error) {
       // not a version (corrupted data)
       cli.debug(`Failed to compare versions '${newVersionInfo.latestVersion}' and '${currentVersion}': ${error}`)
@@ -258,7 +259,7 @@ export namespace VersionHelper {
       newVersionInfo = { latestVersion, lastCheck: now }
       await fs.writeJson(newVersionInfoFilePath, newVersionInfo, { encoding: 'utf8' })
       try {
-        return semver.gt(newVersionInfo.latestVersion, currentVersion)
+        return gtChectlVersion(newVersionInfo.latestVersion, currentVersion)
       } catch (error) {
         // not to fail unexpectedly
         cli.debug(`Failed to compare versions '${newVersionInfo.latestVersion}' and '${currentVersion}': ${error}`)
@@ -268,6 +269,57 @@ export namespace VersionHelper {
 
     // Information whether a newer version available is already in cache
     return isCachedNewerVersionAvailable
+  }
+
+  /**
+   * Returns true if verA > verB
+   */
+  export async function gtChectlVersion(verA: string, verB: string): Promise<boolean> {
+    return (await compareChectlVersions(verA, verB)) > 0
+  }
+
+  /**
+   * Retruns:
+   *  1 if verA > verB
+   *  0 if verA = verB
+   * -1 if verA < verB
+   */
+  async function compareChectlVersions(verA: string, verB: string): Promise<number> {
+    if (verA === verB) {
+      return 0
+    }
+
+    const verAChannel = verA.includes('next') ? 'next' : 'stable'
+    const verBChannel = verB.includes('next') ? 'next' : 'stable'
+    if (verAChannel !== verBChannel) {
+      // Consider next is always newer
+      return (verAChannel === 'next') ? 1 : -1
+    }
+
+    if (verAChannel === 'stable') {
+      return semver.gt(verA, verB) ? 1 : -1
+    }
+
+    // Compare next versions, like: 0.0.20210715-next.597729a
+    const verABase = verA.split('-')[0]
+    const verBBase = verB.split('-')[0]
+    if (verABase !== verBBase) {
+      // Releases are made in different days
+      // It is possible to compare just versions
+      return semver.gt(verA, verB) ? 1 : -1
+    }
+
+    // Releases are made in the same day
+    // It is not possible to compare by versions as the difference only in commits hashes
+    const verACommitId = verA.split('-')[1].split('.')[1]
+    const verBCommitId = verB.split('-')[1].split('.')[1]
+
+    const githubClient = new CheGithubClient()
+    const verACommitDateString = await githubClient.getCommitDate(CHECTL_REPO, verACommitId)
+    const verBCommitDateString = await githubClient.getCommitDate(CHECTL_REPO, verBCommitId)
+    const verATimestamp = Date.parse(verACommitDateString)
+    const verBTimestamp = Date.parse(verBCommitDateString)
+    return verATimestamp > verBTimestamp ? 1 : -1
   }
 
   /**

--- a/test/api/version.test.ts
+++ b/test/api/version.test.ts
@@ -39,4 +39,81 @@ describe('Version Helper', () => {
         expect(check).to.false
       })
   })
+
+  describe('chectl version comparator', () => {
+    function getCommitDateFakeResponse(commitDate: string) {
+      return {
+        commit : {
+          committer: {
+            date: commitDate
+          }
+        }
+      }
+    }
+
+    fancy
+      .it('should update stable version', async () => {
+        const currentVersion = '7.30.2'
+        const newVersion = '7.31.1'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.true
+      })
+    fancy
+      .it('should not update stable version', async () => {
+        const currentVersion = '7.30.2'
+        const newVersion = '7.30.2'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.false
+      })
+    fancy
+      .it('should not downgrade stable version', async () => {
+        const currentVersion = '7.31.1'
+        const newVersion = '7.30.2'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.false
+      })
+    fancy
+      .it('should update nightly version (release day differs)', async () => {
+        const currentVersion = '0.0.20210727-next.81f31b0'
+        const newVersion = '0.0.20210729-next.6041615'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.true
+      })
+    fancy
+      .it('should not update nightly version (release day differs)', async () => {
+        const currentVersion = '0.0.20210729-next.6041615'
+        const newVersion = '0.0.20210729-next.6041615'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.false
+      })
+    fancy
+      .it('should not downgrade nightly version (release day differs)', async () => {
+        const currentVersion = '0.0.20210729-next.6041615'
+        const newVersion = '0.0.20210727-next.81f31b0'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.false
+      })
+    fancy
+      .nock('https://api.github.com/repos/che-incubator/chectl/commits', api => api
+        .get('/597729a').reply(200, getCommitDateFakeResponse('2021-07-15T08:20:00Z'))
+        .get('/4771039').reply(200, getCommitDateFakeResponse('2021-07-15T09:45:37Z'))
+      )
+      .it('should update nightly version (release day the same)', async () => {
+        const currentVersion = '0.0.20210715-next.597729a'
+        const newVersion = '0.0.20210715-next.4771039'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.true
+      })
+    fancy
+      .nock('https://api.github.com/repos/che-incubator/chectl/commits', api => api
+        .get('/597729a').reply(200, getCommitDateFakeResponse('2021-07-15T08:20:00Z'))
+        .get('/4771039').reply(200, getCommitDateFakeResponse('2021-07-15T09:45:37Z'))
+      )
+      .it('should not downgrade nightly version (release day the same)', async () => {
+        const currentVersion = '0.0.20210715-next.4771039'
+        const newVersion = '0.0.20210715-next.597729a'
+        const shouldUpdate = await VersionHelper.gtChectlVersion(newVersion, currentVersion)
+        expect(shouldUpdate).to.be.false
+      })
+  })
 })


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds a separate comparator for chectl versions instead of just using `semver.gt`.
The new comparator can compare releases made on the same day by commit hashes (in such case there is a need to query commit info from Github to compare datetime of the commits)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20135

### How to test this PR?
This is not trivial. Better take a look at tests.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
