### PR TITLE
feat: detect nativeUserMode will be enabled so don't wait for keycloak

### DIFF
--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -76,6 +76,14 @@ export class CheTasks {
     this.cheDeploymentName = flags['deployment-name']
   }
 
+  async skipKeycloakDeploy(): Promise<boolean> {
+    const cheCluster = await this.kube.getCheCluster(this.cheNamespace)
+    if (!cheCluster) {
+      return false
+    }
+    return cheCluster.spec.auth.nativeUserMode
+  }
+
   /**
    * Returns tasks list that waits until every Eclipse Che component will be started.
    *
@@ -93,7 +101,15 @@ export class CheTasks {
       {
         title: 'Keycloak pod bootstrap',
         enabled: ctx => ctx.isKeycloakDeployed && !ctx.isKeycloakReady,
-        task: () => this.kubeTasks.podStartTasks(this.keycloakSelector, this.cheNamespace),
+        task: async (_ctx: any, task: any) => {
+          if (await this.skipKeycloakDeploy()) {
+            task.title = `${task.title}...skipped`
+            return {
+              task: () => {},
+            }
+          }
+          return this.kubeTasks.podStartTasks(this.keycloakSelector, this.cheNamespace)
+        },
       },
       {
         title: 'Devfile Registry pod bootstrap',
@@ -252,7 +268,13 @@ export class CheTasks {
       {
         title: 'Keycloak pod bootstrap',
         enabled: ctx => ctx.isKeycloakDeployed && !ctx.isKeycloakReady,
-        task: async () => {
+        task: async (_ctx: any, task: any) => {
+          if (await this.skipKeycloakDeploy()) {
+            task.title = `${task.title}...skipped`
+            return {
+              task: () => {},
+            }
+          }
           await this.kube.scaleDeployment(this.keycloakDeploymentName, this.cheNamespace, 1)
           return this.kubeTasks.podStartTasks(this.keycloakSelector, this.cheNamespace)
         },

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -24,7 +24,7 @@ import { CheGithubClient } from '../../api/github-client'
 import { KubeHelper } from '../../api/kube'
 import { VersionHelper } from '../../api/version'
 import { CHE_CLUSTER_CRD, DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER, OPERATOR_TEMPLATE_DIR } from '../../constants'
-import { getProjectVersion, isOpenshiftPlatformFamily } from '../../util'
+import { getProjectVersion } from '../../util'
 
 export function createNamespaceTask(namespaceName: string, labels: {}): Listr.ListrTask {
   return {
@@ -141,7 +141,7 @@ export function createEclipseCheCluster(flags: any, kube: KubeHelper): Listr.Lis
       const cheClusterCR = ctx.customCR || ctx.defaultCR
       const cr = await kube.createCheCluster(cheClusterCR, flags, ctx, !ctx.customCR)
 
-      ctx.isKeycloakReady = ctx.isKeycloakReady || shouldNotDeployKeycloak(flags, cr)
+      ctx.isKeycloakReady = ctx.isKeycloakReady || cr.spec.auth.externalIdentityProvider
       ctx.isPostgresReady = ctx.isPostgresReady || cr.spec.database.externalDb
       ctx.isDevfileRegistryReady = ctx.isDevfileRegistryReady || cr.spec.server.externalDevfileRegistry
       ctx.isPluginRegistryReady = ctx.isPluginRegistryReady || cr.spec.server.externalPluginRegistry
@@ -153,11 +153,6 @@ export function createEclipseCheCluster(flags: any, kube: KubeHelper): Listr.Lis
       task.title = `${task.title}...done.`
     },
   }
-}
-
-function shouldNotDeployKeycloak(flags: any, cr: any): boolean {
-  return cr.spec.auth.externalIdentityProvider || cr.spec.auth.nativeUserMode ||
-    (isOpenshiftPlatformFamily(flags.platform) && cr.spec.devWorkspace.enable)
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
`nativeUserMode` will be enabled by default on openshift with devworkspaces by https://github.com/eclipse-che/che-operator/pull/978. We need to reflect this in chectl so it does not wait for keycloak deployment.

Because `auth.nativeUserMode` is dynamicaly changed by che-operator, we don't know the value at the moment of listing the tasks. Current implementation gets and checks the current value in Keycloak deploy task. If we're deploying in `nativeUserMode: true`, the task is skipped (see the screenshot).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Looks like this now:
![20210805_070840_590x299_scrot](https://user-images.githubusercontent.com/1160903/128294335-4de1c83d-6bf4-4651-a3cc-efd4cf762f7b.png)



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20203

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
 1. deploy with `./bin/run server:deploy --platform=openshift --installer=operator --workspace-engine=dev-workspace --che-operator-image=quay.io/mvala/che-operator:gh20203-nativeUserModeEnable` 
 2. chectl should complete process successfully



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
