### PR TITLE
feat: Implement version rollback for server restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,8 +669,8 @@ OPTIONS
   -r, --repository-url=repository-url                    Full address of backup repository. Format is identical to
                                                          restic.
 
-  -s, --snapshot-id=snapshot-id                          (required) snapshot identificator to restore from. Value
-                                                         "latest" means restoring from the most recent snapshot.
+  -s, --snapshot-id=snapshot-id                          snapshot identificator to restore from. Value "latest" means
+                                                         restoring from the most recent snapshot.
 
   -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1). If the flag
                                                          is not set, restore to the current version.

--- a/README.md
+++ b/README.md
@@ -683,6 +683,8 @@ OPTIONS
 
   --backup-server-config-name=backup-server-config-name  Name of custom resource with backup server config
 
+  --batch                                                Batch mode. Running a command without end user interaction.
+
   --password=password                                    Authentication password for backup REST server
 
   --rollback                                             Rolling back to previous version of Eclipse Che if a backup of
@@ -699,14 +701,14 @@ EXAMPLES
   # Reuse existing backup configuration:
   chectl server:restore
   # Restore from specific backup snapshot using previos backup configuration:
-  chectl server:restore -s 585421f3
+  chectl server:restore --snapshot-id=585421f3
   # Restore from latest snapshot located in provided REST backup server:
   chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword
   # Restore from latest snapshot located in provided AWS S3 (or API compatible) backup server (bucket should be 
   precreated):
   chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword
   # Restore from latest snapshot located in provided SFTP backup server:
-  chectl server:restore -r=sftp:user@my-server.net:/srv/sftp/che-data -p repopassword
+  chectl server:restore -r sftp:user@my-server.net:/srv/sftp/che-data -p repopassword
   # Rollback to previous version (if it was installed):
   chectl server:restore --rollback
   # Restore from specific backup object:
@@ -714,6 +716,8 @@ EXAMPLES
   # Restore from specific backup of different version:
   chectl server:restore --version=7.35.2 --snapshot-id=9ea02f58 -r rest:http://my-sert-server.net:4000/che-backup -p 
   repopassword
+  # Restore from the latest backup of different version:
+  chectl server:restore --version=7.36.1 --snapshot-id=latest
 ```
 
 _See code: [src/commands/server/restore.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/restore.ts)_

--- a/README.md
+++ b/README.md
@@ -700,11 +700,12 @@ EXAMPLES
   chectl server:restore
   # Restore from specific backup snapshot using previos backup configuration:
   chectl server:restore -s 585421f3
-  # Create and use configuration for REST backup server:
+  # Restore from latest snapshot located in provided REST backup server:
   chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword
-  # Create and use configuration for AWS S3 (and API compatible) backup server (bucket should be precreated):
+  # Restore from latest snapshot located in provided AWS S3 (or API compatible) backup server (bucket should be 
+  precreated):
   chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword
-  # Create and use configuration for SFTP backup server:
+  # Restore from latest snapshot located in provided SFTP backup server:
   chectl server:restore -r=sftp:user@my-server.net:/srv/sftp/che-data -p repopassword
   # Rollback to previous version (if it was installed):
   chectl server:restore --rollback

--- a/README.md
+++ b/README.md
@@ -669,8 +669,8 @@ OPTIONS
   -r, --repository-url=repository-url                    Full address of backup repository. Format is identical to
                                                          restic.
 
-  -s, --snapshot-id=snapshot-id                          (required) ID of a snapshot to restore from. Value "latest"
-                                                         means restoring from the most recent snapshot.
+  -s, --snapshot-id=snapshot-id                          (required) snapshot identificator to restore from. Value
+                                                         "latest" means restoring from the most recent snapshot.
 
   -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1). If the flag
                                                          is not set, restore to the current version.
@@ -698,8 +698,6 @@ OPTIONS
   --username=username                                    Username for authentication in backup REST server
 
 EXAMPLES
-  # Restore from specific backup snapshot using previos backup configuration:
-  chectl server:restore --snapshot-id=585421f3
   # Restore from latest snapshot located in provided REST backup server:
   chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword --snapshot-id=latest
   # Restore from latest snapshot located in provided AWS S3 (or API compatible) backup server (bucket should be 

--- a/README.md
+++ b/README.md
@@ -671,13 +671,23 @@ OPTIONS
 
   -s, --snapshot-id=snapshot-id                          ID of a snapshot to restore from
 
+  -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1).
+                                                         Must comply with the version in backup snapshot.
+                                                         Defaults to the existing operator version or to chectl
+                                                         version if none deployed.
+
   --aws-access-key-id=aws-access-key-id                  AWS access key ID
 
   --aws-secret-access-key=aws-secret-access-key          AWS secret access key
 
+  --backup-cr=backup-cr                                  Name of a backup custom resource to restore from
+
   --backup-server-config-name=backup-server-config-name  Name of custom resource with backup server config
 
   --password=password                                    Authentication password for backup REST server
+
+  --rollback                                             Rolling back to previous version of Eclipse Che if a backup of
+                                                         that version is available
 
   --ssh-key=ssh-key                                      Private SSH key for authentication on SFTP server
 
@@ -694,9 +704,16 @@ EXAMPLES
   # Create and use configuration for REST backup server:
   chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword
   # Create and use configuration for AWS S3 (and API compatible) backup server (bucket should be precreated):
-  chectl server:backup -r s3:s3.amazonaws.com/bucketche -p repopassword
+  chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword
   # Create and use configuration for SFTP backup server:
-  chectl server:backup -r=sftp:user@my-server.net:/srv/sftp/che-data -p repopassword
+  chectl server:restore -r=sftp:user@my-server.net:/srv/sftp/che-data -p repopassword
+  # Rollback to previous version (if it was installed):
+  chectl server:restore --rollback
+  # Restore from specific backup object:
+  chectl server:restore --backup-cr=backup-object-name
+  # Restore from specific backup of different version:
+  chectl server:restore --version=7.35.2 --snapshot-id=9ea02f58 -r rest:http://my-sert-server.net:4000/che-backup -p 
+  repopassword
 ```
 
 _See code: [src/commands/server/restore.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/restore.ts)_

--- a/README.md
+++ b/README.md
@@ -671,16 +671,15 @@ OPTIONS
 
   -s, --snapshot-id=snapshot-id                          ID of a snapshot to restore from
 
-  -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1).
-                                                         Must comply with the version in used backup snapshot.
-                                                         Defaults to the existing operator version or to chectl version
-                                                         if none deployed.
+  -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1). Defaults to
+                                                         the existing operator version or to chectl version if none
+                                                         deployed.
 
   --aws-access-key-id=aws-access-key-id                  AWS access key ID
 
   --aws-secret-access-key=aws-secret-access-key          AWS secret access key
 
-  --backup-cr=backup-cr                                  Name of a backup custom resource to restore from
+  --backup-cr-name=backup-cr-name                        Name of a backup custom resource to restore from
 
   --backup-server-config-name=backup-server-config-name  Name of custom resource with backup server config
 
@@ -710,7 +709,7 @@ EXAMPLES
   # Rollback to previous version (if it was installed):
   chectl server:restore --rollback
   # Restore from specific backup object:
-  chectl server:restore --backup-cr=backup-object-name
+  chectl server:restore --backup-cr-name=backup-object-name
   # Restore from specific backup of different version:
   chectl server:restore --version=7.35.2 --snapshot-id=9ea02f58 -r rest:http://my-sert-server.net:4000/che-backup -p 
   repopassword

--- a/README.md
+++ b/README.md
@@ -669,11 +669,11 @@ OPTIONS
   -r, --repository-url=repository-url                    Full address of backup repository. Format is identical to
                                                          restic.
 
-  -s, --snapshot-id=snapshot-id                          ID of a snapshot to restore from
+  -s, --snapshot-id=snapshot-id                          (required) ID of a snapshot to restore from. Value "latest"
+                                                         means restoring from the most recent snapshot.
 
-  -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1). Defaults to
-                                                         the existing operator version or to chectl version if none
-                                                         deployed.
+  -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1). If the flag
+                                                         is not set, restore to the current version.
 
   --aws-access-key-id=aws-access-key-id                  AWS access key ID
 
@@ -698,26 +698,24 @@ OPTIONS
   --username=username                                    Username for authentication in backup REST server
 
 EXAMPLES
-  # Reuse existing backup configuration:
-  chectl server:restore
   # Restore from specific backup snapshot using previos backup configuration:
   chectl server:restore --snapshot-id=585421f3
   # Restore from latest snapshot located in provided REST backup server:
-  chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword
+  chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword --snapshot-id=latest
   # Restore from latest snapshot located in provided AWS S3 (or API compatible) backup server (bucket should be 
   precreated):
-  chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword
+  chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword --snapshot-id=latest
   # Restore from latest snapshot located in provided SFTP backup server:
-  chectl server:restore -r sftp:user@my-server.net:/srv/sftp/che-data -p repopassword
-  # Rollback to previous version (if it was installed):
+  chectl server:restore -r sftp:user@my-server.net:/srv/sftp/che-data -p repopassword --snapshot-id=latest
+  # Restore from the latest backup of different version:
+  chectl server:restore --version=7.36.1 --snapshot-id=latest
+  # Restore from specific backup located on another backup server and of different version:
+  chectl server:restore --version=7.35.2 --snapshot-id=9ea02f58 -r rest:http://my-sert-server.net:4000/che-backup -p 
+  repopassword
+  # Rollback to the previous version (if it was installed):
   chectl server:restore --rollback
   # Restore from specific backup object:
   chectl server:restore --backup-cr-name=backup-object-name
-  # Restore from specific backup of different version:
-  chectl server:restore --version=7.35.2 --snapshot-id=9ea02f58 -r rest:http://my-sert-server.net:4000/che-backup -p 
-  repopassword
-  # Restore from the latest backup of different version:
-  chectl server:restore --version=7.36.1 --snapshot-id=latest
 ```
 
 _See code: [src/commands/server/restore.ts](https://github.com/che-incubator/chectl/blob/v0.0.2/src/commands/server/restore.ts)_

--- a/README.md
+++ b/README.md
@@ -687,8 +687,8 @@ OPTIONS
 
   --password=password                                    Authentication password for backup REST server
 
-  --rollback                                             Rolling back to previous version of Eclipse Che if a backup of
-                                                         that version is available
+  --rollback                                             Rolling back to previous version of Eclipse Che only if backup
+                                                         exists
 
   --ssh-key=ssh-key                                      Private SSH key for authentication on SFTP server
 
@@ -698,21 +698,19 @@ OPTIONS
   --username=username                                    Username for authentication in backup REST server
 
 EXAMPLES
-  # Restore from latest snapshot located in provided REST backup server:
-  chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword --snapshot-id=latest
-  # Restore from latest snapshot located in provided AWS S3 (or API compatible) backup server (bucket should be 
+  # Restore from the latest snapshot from a provided REST backup server:
+  chectl server:restore -r rest:http://my-sert-server.net:4000/che-backup -p repopassword --snapshot-id=latest
+  # Restore from the latest snapshot from a provided AWS S3 (or API compatible) backup server (bucket must be 
   precreated):
   chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword --snapshot-id=latest
-  # Restore from latest snapshot located in provided SFTP backup server:
+  # Restore from the latest snapshot from a provided SFTP backup server:
   chectl server:restore -r sftp:user@my-server.net:/srv/sftp/che-data -p repopassword --snapshot-id=latest
-  # Restore from the latest backup of different version:
-  chectl server:restore --version=7.36.1 --snapshot-id=latest
-  # Restore from specific backup located on another backup server and of different version:
-  chectl server:restore --version=7.35.2 --snapshot-id=9ea02f58 -r rest:http://my-sert-server.net:4000/che-backup -p 
-  repopassword
-  # Rollback to the previous version (if it was installed):
+  # Restore from a specific snapshot to a given Eclipse Che version from a provided REST backup server:
+  chectl server:restore -r rest:http://my-sert-server.net:4000/che-backup -p repopassword --version=7.35.2 
+  --snapshot-id=9ea02f58
+  # Rollback to a previous version only if backup exists:
   chectl server:restore --rollback
-  # Restore from specific backup object:
+  # Restore from a specific backup object:
   chectl server:restore --backup-cr-name=backup-object-name
 ```
 

--- a/README.md
+++ b/README.md
@@ -672,9 +672,9 @@ OPTIONS
   -s, --snapshot-id=snapshot-id                          ID of a snapshot to restore from
 
   -v, --version=version                                  Che Operator version to restore to (e.g. 7.35.1).
-                                                         Must comply with the version in backup snapshot.
-                                                         Defaults to the existing operator version or to chectl
-                                                         version if none deployed.
+                                                         Must comply with the version in used backup snapshot.
+                                                         Defaults to the existing operator version or to chectl version
+                                                         if none deployed.
 
   --aws-access-key-id=aws-access-key-id                  AWS access key ID
 

--- a/src/api/backup-restore.ts
+++ b/src/api/backup-restore.ts
@@ -52,9 +52,6 @@ export interface SftpBackupServerCredentials {
   sshKey: string
 }
 
-export const BACKUP_CR_NAME = 'eclipse-che-backup'
-export const RESTORE_CR_NAME = 'eclipse-che-restore'
-
 export const BACKUP_SERVER_CONFIG_NAME = 'eclipse-che-backup-server-config'
 
 export const BACKUP_REPOSITORY_PASSWORD_SECRET_NAME = 'chectl-backup-repository-password'
@@ -80,26 +77,28 @@ export function getBackupServerType(url: string): BackupServerType {
 /**
  * Submits backup of Che installation task.
  * @param namespace namespace in which Che is installed
+ * @param name name of the backup CR to create
  * @param backupServerConfig backup server configuration data or name of the config CR
  */
-export async function requestBackup(namespace: string, backupServerConfig?: BackupServerConfig | string): Promise<V1CheClusterBackup> {
+export async function requestBackup(namespace: string, name: string, backupServerConfig?: BackupServerConfig | string): Promise<V1CheClusterBackup> {
   const kube = new KubeHelper()
   const backupServerConfigName = await getBackupServerConfigurationName(namespace, backupServerConfig)
-  return kube.recreateBackupCr(namespace, BACKUP_CR_NAME, backupServerConfigName)
+  return kube.recreateBackupCr(namespace, name, backupServerConfigName)
 }
 
 /**
  * Submits Che restore task.
  * @param namespace namespace in which Che should be restored
+ * @param name name of the restore CR to create
  * @param backupServerConfig backup server configuration data or name of the config CR
  */
-export async function requestRestore(namespace: string, backupServerConfig?: BackupServerConfig | string, snapshotId?: string): Promise<V1CheClusterBackup> {
+export async function requestRestore(namespace: string, name: string, backupServerConfig?: BackupServerConfig | string, snapshotId?: string): Promise<V1CheClusterBackup> {
   const kube = new KubeHelper()
   const backupServerConfigName = await getBackupServerConfigurationName(namespace, backupServerConfig)
   if (!backupServerConfigName) {
     throw new Error(`No backup server configuration found in ${namespace} namespace`)
   }
-  return kube.recreateRestoreCr(namespace, RESTORE_CR_NAME, backupServerConfigName, snapshotId)
+  return kube.recreateRestoreCr(namespace, name, backupServerConfigName, snapshotId)
 }
 
 /**
@@ -118,7 +117,7 @@ async function getBackupServerConfigurationName(namespace: string, backupServerC
     if (typeof backupServerConfig === 'string') {
       // Name of CR with backup server configuration provided
       // Check if it exists
-      const backupServerConfigCr = await kube.getCustomResource(namespace, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_BACKUP_SERVER_CONFIG_KIND_PLURAL)
+      const backupServerConfigCr = await kube.getCustomResource(namespace, backupServerConfig, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_BACKUP_SERVER_CONFIG_KIND_PLURAL)
       if (!backupServerConfigCr) {
         throw new Error(`Backup server configuration with '${backupServerConfig}' name not found in '${namespace}' namespace.`)
       }

--- a/src/api/backup-restore.ts
+++ b/src/api/backup-restore.ts
@@ -110,7 +110,7 @@ export async function requestRestore(namespace: string, name: string, backupServ
  * @param backupServerConfig backup server configuration data or name of the backup server config CR
  * @returns name of existing backup server configuration in the given namespace or empty string if none suitable
  */
-async function getBackupServerConfigurationName(namespace: string, backupServerConfig?: BackupServerConfig | string): Promise<string> {
+export async function getBackupServerConfigurationName(namespace: string, backupServerConfig?: BackupServerConfig | string): Promise<string> {
   const kube = new KubeHelper()
 
   if (backupServerConfig) {

--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -16,7 +16,7 @@ import * as os from 'os'
 import * as path from 'path'
 
 import { CHE_OPERATOR_CR_PATCH_YAML_KEY, CHE_OPERATOR_CR_YAML_KEY, LOG_DIRECTORY_KEY } from '../common-flags'
-import { CHECTL_PROJECT_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OPENSHIFT_OPERATORS_NS_NAME, STABLE_ALL_NAMESPACES_CHANNEL_NAME } from '../constants'
+import { CHECTL_PROJECT_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OPENSHIFT_OPERATORS_NS_NAME, OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME } from '../constants'
 import { getProjectName, getProjectVersion, readCRFile } from '../util'
 
 import { CHECTL_DEVELOPMENT_VERSION } from './version'
@@ -45,12 +45,12 @@ export namespace ChectlContext {
   export async function init(flags: any, command: Command): Promise<void> {
     ctx.isChectl = getProjectName() === CHECTL_PROJECT_NAME
     ctx.isDevVersion = getProjectVersion().includes('next') || getProjectVersion() === CHECTL_DEVELOPMENT_VERSION
-    ctx.operatorNamespace = flags.chenamespace || DEFAULT_CHE_NAMESPACE
     if (flags['listr-renderer'] as any) {
       ctx.listrOptions = { renderer: (flags['listr-renderer'] as any), collapse: false } as Listr.ListrOptions
     }
 
-    if (flags['olm-channel'] === STABLE_ALL_NAMESPACES_CHANNEL_NAME) {
+    ctx.operatorNamespace = flags.chenamespace || DEFAULT_CHE_NAMESPACE
+    if (flags['olm-channel'] === OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME) {
       ctx.operatorNamespace = DEFAULT_OPENSHIFT_OPERATORS_NS_NAME
     }
 

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1656,7 +1656,8 @@ export class KubeHelper {
   async getCustomResource(namespace: string, name: string, resourceAPIGroup: string, resourceAPIVersion: string, resourcePlural: string): Promise<any | undefined> {
     const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi)
     try {
-      return await customObjectsApi.getNamespacedCustomObject(resourceAPIGroup, resourceAPIVersion, namespace, resourcePlural, name)
+      const res = await customObjectsApi.getNamespacedCustomObject(resourceAPIGroup, resourceAPIVersion, namespace, resourcePlural, name)
+      return res.body
     } catch (e) {
       if (e.response && e.response.statusCode !== 404) {
         throw this.wrapK8sClientError(e)

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1199,17 +1199,16 @@ export class KubeHelper {
     }
   }
 
-  async deleteDeployment(namespace: string, name: string): Promise<boolean> {
+  async deleteDeployment(namespace: string, name: string): Promise<void> {
     const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api)
     try {
       k8sAppsApi.deleteNamespacedDeployment(name, namespace)
     } catch (error) {
       if (error.response && error.response.statusCode === 404) {
-        return false
+        return
       }
       throw this.wrapK8sClientError(error)
     }
-    return true
   }
 
   async deleteAllDeployments(namespace: string): Promise<void> {

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1199,6 +1199,19 @@ export class KubeHelper {
     }
   }
 
+  async deleteDeployment(namespace: string, name: string): Promise<boolean> {
+    const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api)
+    try {
+      k8sAppsApi.deleteNamespacedDeployment(name, namespace)
+    } catch (error) {
+      if (error.response && error.response.statusCode === 404) {
+        return false
+      }
+      throw this.wrapK8sClientError(error)
+    }
+    return true
+  }
+
   async deleteAllDeployments(namespace: string): Promise<void> {
     const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api)
     try {

--- a/src/api/typings/backup-restore-crds.d.ts
+++ b/src/api/typings/backup-restore-crds.d.ts
@@ -29,6 +29,7 @@ export interface V1CheClusterBackupStatus {
   message?: string
   state?: string
   stage?: string
+  cheVersion?: string
   snapshotId?: string
 }
 

--- a/src/commands/server/backup.ts
+++ b/src/commands/server/backup.ts
@@ -172,7 +172,7 @@ export default class Backup extends Command {
             if (backupStatus.stage) {
               task.title = `Waiting until backup process finishes: ${backupStatus.stage}`
             }
-          } while (backupStatus.state === 'InProgress')
+          } while (!backupStatus.state || backupStatus.state === 'InProgress')
 
           if (backupStatus.state === 'Failed') {
             throw new Error(`Failed to create backup: ${backupStatus.message}`)

--- a/src/commands/server/backup.ts
+++ b/src/commands/server/backup.ts
@@ -92,6 +92,8 @@ export const backupServerConfigName = string({
   exclusive: [BACKUP_REPOSITORY_URL_KEY, BACKUP_REPOSITORY_PASSWORD_KEY],
 })
 
+const BACKUP_CR_NAME = 'eclipse-che-backup'
+
 export default class Backup extends Command {
   static description = 'Backup Eclipse Che installation'
 
@@ -150,7 +152,7 @@ export default class Backup extends Command {
         title: 'Scheduling backup...',
         task: async (_ctx: any, task: any) => {
           const backupServerConfig = getBackupServerConfiguration(flags)
-          await requestBackup(flags.chenamespace, backupServerConfig)
+          await requestBackup(flags.chenamespace, BACKUP_CR_NAME, backupServerConfig)
           task.title = `${task.title}OK`
         },
       },
@@ -161,7 +163,7 @@ export default class Backup extends Command {
           let backupStatus: V1CheClusterBackupStatus = {}
           do {
             await cli.wait(1000)
-            const backupCr: V1CheClusterBackup = await kube.getCustomResource(flags.chenamespace, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL)
+            const backupCr: V1CheClusterBackup = await kube.getCustomResource(flags.chenamespace, BACKUP_CR_NAME, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL)
             if (!backupCr.status) {
               continue
             }

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -18,7 +18,7 @@ import * as semver from 'semver'
 import { ChectlContext } from '../../api/context'
 import { KubeHelper } from '../../api/kube'
 import { batch, cheDeployment, cheDeployVersion, cheNamespace, cheOperatorCRPatchYaml, cheOperatorCRYaml, CHE_OPERATOR_CR_PATCH_YAML_KEY, CHE_OPERATOR_CR_YAML_KEY, CHE_TELEMETRY, DEPLOY_VERSION_KEY, devWorkspaceControllerNamespace, k8sPodDownloadImageTimeout, K8SPODDOWNLOADIMAGETIMEOUT_KEY, k8sPodErrorRecheckTimeout, K8SPODERRORRECHECKTIMEOUT_KEY, k8sPodReadyTimeout, K8SPODREADYTIMEOUT_KEY, k8sPodWaitTimeout, K8SPODWAITTIMEOUT_KEY, listrRenderer, logsDirectory, LOG_DIRECTORY_KEY, skipKubeHealthzCheck as skipK8sHealthCheck } from '../../common-flags'
-import { DEFAULT_ANALYTIC_HOOK_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OLM_SUGGESTED_NAMESPACE, DOCS_LINK_INSTALL_RUNNING_CHE_LOCALLY, MIN_CHE_OPERATOR_INSTALLER_VERSION, MIN_HELM_INSTALLER_VERSION, MIN_OLM_INSTALLER_VERSION, STABLE_ALL_NAMESPACES_CHANNEL_NAME } from '../../constants'
+import { DEFAULT_ANALYTIC_HOOK_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OLM_SUGGESTED_NAMESPACE, DOCS_LINK_INSTALL_RUNNING_CHE_LOCALLY, MIN_CHE_OPERATOR_INSTALLER_VERSION, MIN_HELM_INSTALLER_VERSION, MIN_OLM_INSTALLER_VERSION, OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { DevWorkspaceTasks } from '../../tasks/component-installers/devfile-workspace-operator-installer'
 import { checkChectlAndCheVersionCompatibility, downloadTemplates, getPrintHighlightedMessagesTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
@@ -295,7 +295,7 @@ export default class Deploy extends Command {
         this.error(`🛑 The specified installer ${flags.installer} does not support Minishift`)
       }
 
-      if (flags['olm-channel'] === STABLE_ALL_NAMESPACES_CHANNEL_NAME && isKubernetesPlatformFamily(flags.platform)) {
+      if (flags['olm-channel'] === OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME && isKubernetesPlatformFamily(flags.platform)) {
         this.error('"stable-all-namespaces" channel is supported only in "openshift" platform')
       }
 
@@ -418,7 +418,7 @@ export default class Deploy extends Command {
       enabled: () => (this.isDevWorkspaceEnabled(ctx) || flags['workspace-engine'] === 'dev-workspace') && !ctx.isOpenShift,
       task: () => new Listr(devWorkspaceTasks.getInstallTasks(flags)),
     })
-    const installTasks = new Listr(installerTasks.installTasks(flags, this), ctx.listrOptions)
+    const installTasks = new Listr(await installerTasks.installTasks(flags, this), ctx.listrOptions)
 
     // Post Install Checks
     const postInstallTasks = new Listr([

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -306,9 +306,6 @@ export default class Deploy extends Command {
         if (flags['starting-csv']) {
           this.error('"starting-csv" and "version" flags are mutually exclusive. Please specify only one of them.')
         }
-        if (flags['olm-channel']) {
-          this.error('"starting-csv" and "version" flags are mutually exclusive. Use "starting-csv" with "olm-channel" flag.')
-        }
         if (flags['auto-update']) {
           this.error('enabled "auto-update" flag cannot be used with version flag. Deploy latest version instead.')
         }

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -210,7 +210,7 @@ export default class Deploy extends Command {
     }
 
     if (!flags.installer) {
-      await this.setDefaultInstaller(flags, ctx)
+      await setDefaultInstaller(flags)
       cli.info(`› Installer type is set to: '${flags.installer}'`)
     }
 
@@ -457,24 +457,24 @@ export default class Deploy extends Command {
     notifyCommandCompletedSuccessfully()
     this.exit(0)
   }
+}
 
-  /**
-   * Sets default installer which is `olm` for OpenShift 4 with stable version of chectl
-   * and `operator` for other cases.
-   */
-  async setDefaultInstaller(flags: any, _ctx: any): Promise<void> {
-    const kubeHelper = new KubeHelper(flags)
+/**
+ * Sets default installer which is `olm` for OpenShift 4 with stable version of chectl
+ * and `operator` for other cases.
+ */
+export async function setDefaultInstaller(flags: any): Promise<void> {
+  const kubeHelper = new KubeHelper(flags)
 
-    const isOlmPreinstalled = await kubeHelper.isPreInstalledOLM()
-    if ((flags['catalog-source-name'] || flags['catalog-source-yaml']) && isOlmPreinstalled) {
-      flags.installer = 'olm'
-      return
-    }
+  const isOlmPreinstalled = await kubeHelper.isPreInstalledOLM()
+  if ((flags['catalog-source-name'] || flags['catalog-source-yaml']) && isOlmPreinstalled) {
+    flags.installer = 'olm'
+    return
+  }
 
-    if (flags.platform === 'openshift' && await kubeHelper.isOpenShift4() && isOlmPreinstalled) {
-      flags.installer = 'olm'
-    } else {
-      flags.installer = 'operator'
-    }
+  if (flags.platform === 'openshift' && await kubeHelper.isOpenShift4() && isOlmPreinstalled) {
+    flags.installer = 'olm'
+  } else {
+    flags.installer = 'operator'
   }
 }

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -11,10 +11,10 @@
  */
 
 import { Command, flags } from '@oclif/command'
-import { string } from '@oclif/parser/lib/flags'
+import { boolean, string } from '@oclif/parser/lib/flags'
 import * as Listr from 'listr'
 
-import { CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_RESTORE_KIND_PLURAL, DEFAULT_ANALYTIC_HOOK_NAME } from '../../constants'
+import { CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL, CHE_CLUSTER_RESTORE_KIND_PLURAL, DEFAULT_ANALYTIC_HOOK_NAME, OPERATOR_DEPLOYMENT_NAME } from '../../constants'
 import { ChectlContext } from '../../api/context'
 import { KubeHelper } from '../../api/kube'
 import { cheNamespace } from '../../common-flags'
@@ -22,9 +22,11 @@ import { requestRestore } from '../../api/backup-restore'
 import { cli } from 'cli-ux'
 import { ApiTasks } from '../../tasks/platforms/api'
 import { findWorkingNamespace, getCommandSuccessMessage, notifyCommandCompletedSuccessfully, wrapCommandError } from '../../util'
-import { V1CheClusterRestore, V1CheClusterRestoreStatus } from '../../api/typings/backup-restore-crds'
+import { V1CheClusterBackup, V1CheClusterRestore, V1CheClusterRestoreStatus } from '../../api/typings/backup-restore-crds'
 
 import { awsAccessKeyId, awsSecretAccessKey, AWS_ACCESS_KEY_ID_KEY, AWS_SECRET_ACCESS_KEY_KEY, backupRepositoryPassword, backupRepositoryUrl, backupRestServerPassword, backupRestServerUsername, backupServerConfigName, BACKUP_REPOSITORY_PASSWORD_KEY, BACKUP_REPOSITORY_URL_KEY, BACKUP_REST_SERVER_PASSWORD_KEY, BACKUP_REST_SERVER_USERNAME_KEY, BACKUP_SERVER_CONFIG_CR_NAME_KEY, getBackupServerConfiguration, sshKey, sshKeyFile, SSH_KEY_FILE_KEY, SSH_KEY_KEY } from './backup'
+
+const RESTORE_CR_NAME = 'eclipse-che-restore'
 
 export default class Restore extends Command {
   static description = 'Restore Eclipse Che installation'
@@ -59,6 +61,25 @@ export default class Restore extends Command {
       description: 'ID of a snapshot to restore from',
       required: false,
     }),
+    version: string({
+      char: 'v',
+      description: `
+        Che Operator version to restore to (e.g. 7.35.1).
+        Must comply with the version in backup snapshot.
+        Defaults to the existing operator version or to chectl version if none deployed.
+      `,
+      required: false,
+    }),
+    'backup-cr': string({
+      description: 'Name of a backup custom resource to restore from',
+      required: false,
+      exclusive: ['version', 'snapshot-id', BACKUP_REPOSITORY_URL_KEY, BACKUP_SERVER_CONFIG_CR_NAME_KEY],
+    }),
+    'rollback': boolean({
+      description: 'Rolling back to previous version of Eclipse Che if a backup of that version is available',
+      required: false,
+      exclusive: ['version', 'snapshot-id', 'backup-cr', BACKUP_REPOSITORY_URL_KEY, BACKUP_SERVER_CONFIG_CR_NAME_KEY],
+    }),
   }
 
   async run() {
@@ -85,10 +106,92 @@ export default class Restore extends Command {
   private getRestoreTasks(flags: any): Listr.ListrTask[] {
     return [
       {
+        title: 'Detecting existing operator version...',
+        enabled: flags.version || flags.rollback || flags['backup-cr'],
+        task: async (ctx: any, task: any) => {
+          const kube = new KubeHelper(flags)
+          const operatorDeploymentYaml = await kube.getDeployment(OPERATOR_DEPLOYMENT_NAME, flags.chenamespace)
+          if (!operatorDeploymentYaml) {
+            // There is no operator deployment
+            ctx.currentOperatorVersion = ''
+            task.title = `${task.title} operator is not deployed`
+            return
+          }
+          const operatorEnv = operatorDeploymentYaml.spec!.template.spec!.containers[0].env!
+          const currentVersionEnvVar = operatorEnv.find(envVar => envVar.name === 'CHE_VERSION')
+          if (!currentVersionEnvVar) {
+            throw new Error(`Failed to find Che operator version in '${OPERATOR_DEPLOYMENT_NAME}' deployment in '${flags.chenamespace}' namespace`)
+          }
+          ctx.currentOperatorVersion = currentVersionEnvVar.value
+          task.title = `${task.title} ${ctx.currentOperatorVersion} found`
+        },
+      },
+      {
+        title: 'Looking for corresponding backup object...',
+        enabled: flags.rollback,
+        task: async (ctx: any, task: any) => {
+          const currentOperatorVersion: string | undefined = ctx.currentOperatorVersion
+          if (!currentOperatorVersion) {
+            throw new Error('Che operator not found. Cannot detect version to use.')
+          }
+          const backupCrName = "backup-before-update-to-" + currentOperatorVersion.replace(/./g, '-')
+
+          const kube = new KubeHelper(flags)
+          const backupCr = await kube.getCustomResource(flags.chenamespace, backupCrName, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL)
+          if (!backupCr) {
+            throw new Error(`Cannot find backup: ${backupCrName}`)
+          }
+          flags['backup-cr'] = backupCrName
+          task.title = `${task.title} ${backupCrName} found`
+        }
+      },
+      {
+        title: 'Gathering information about backup...',
+        enabled: flags['backup-cr'],
+        task: async (ctx: any, task: any) => {
+          const backupCrName = flags['backup-cr']
+          const kube = new KubeHelper(flags)
+          const backupCr: V1CheClusterBackup | undefined = await kube.getCustomResource(flags.chenamespace, backupCrName, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL)
+          if (!backupCr) {
+            throw new Error(`Backup CR with name '${backupCrName}' not found`)
+          }
+
+          if (!backupCr.spec.backupServerConfigRef) {
+            throw new Error(`Backup CR '${backupCrName}' missing backup server configuration reference`)
+          }
+          if (!backupCr.status || !backupCr.status.cheVersion) {
+            throw new Error(`Backup CR '${backupCrName}' missing Che version`)
+          }
+          if (!backupCr.status || !backupCr.status.snapshotId) {
+            throw new Error(`Backup CR '${backupCrName}' missing snapshot ID`)
+          }
+
+          flags.version = backupCr.status.cheVersion
+          flags['snapshot-id'] = backupCr.status.snapshotId
+          task.title = `${task.title}OK`
+        }
+      },
+      {
+        title: 'Getting backup server info...',
+        task: async (ctx: any, task: any) => {
+          // Get all information about backup server and validate it where possible
+          // before redeploying operator to requested version.
+          ctx.backupServerConfig = getBackupServerConfiguration(flags)
+          task.title = `${task.title}OK`
+        },
+      },
+      {
+        title: 'Deploy Che operator of requested version',
+        enabled: (ctx: any) => flags.version && ctx.currentOperatorVersion !== flags.version,
+        task: async (_ctx: any, _task: any) => {
+          // All preparations and validations must be done before this task
+          return this.getRedeployOperatorTasks(flags)
+        },
+      },
+      {
         title: 'Scheduling restore...',
-        task: async (_ctx: any, task: any) => {
-          const backupServerConfig = getBackupServerConfiguration(flags)
-          await requestRestore(flags.chenamespace, backupServerConfig, flags['snapshot-id'])
+        task: async (ctx: any, task: any) => {
+          await requestRestore(flags.chenamespace, RESTORE_CR_NAME, ctx.backupServerConfig, flags['snapshot-id'])
           task.title = `${task.title}OK`
         },
       },
@@ -99,7 +202,7 @@ export default class Restore extends Command {
           let restoreStatus: V1CheClusterRestoreStatus = {}
           do {
             await cli.wait(1000)
-            const restoreCr: V1CheClusterRestore = await kube.getCustomResource(flags.chenamespace, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_RESTORE_KIND_PLURAL)
+            const restoreCr: V1CheClusterRestore = await kube.getCustomResource(flags.chenamespace, RESTORE_CR_NAME, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_RESTORE_KIND_PLURAL)
             if (!restoreCr.status) {
               continue
             }
@@ -119,4 +222,19 @@ export default class Restore extends Command {
       },
     ]
   }
+
+  /**
+   * Returns list of tasks that (re)deploys the flags.version version of Che operator.
+   */
+  private getRedeployOperatorTasks(flags: any): ReadonlyArray<Listr.ListrTask> {
+    return [
+      {
+        title: '',
+        task: async (ctx: any, task: any) => {
+
+        }
+      },
+    ]
+  }
+
 }

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -262,7 +262,7 @@ export default class Restore extends Command {
           } else if (!ctx.isOperatorDeployed && flags.version) {
             outputLines.push(`Deploy Che version ${flags.version}`)
           } else if (ctx.isOperatorDeployed && !flags.version) {
-            outputLines.push(`Che version is ${flags.version}`)
+            outputLines.push(`Che version is ${ctx.currentOperatorVersion}`)
           }
 
           // Backup server configuration

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -70,7 +70,7 @@ export default class Restore extends Command {
       description:
         'snapshot identificator to restore from. ' +
         'Value "latest" means restoring from the most recent snapshot.',
-      required: true,
+      required: false,
     }),
     version: string({
       char: 'v',
@@ -109,6 +109,10 @@ export default class Restore extends Command {
     flags.chenamespace = await findWorkingNamespace(flags)
 
     await this.config.runHook(DEFAULT_ANALYTIC_HOOK_NAME, { command: Restore.id, flags })
+
+    if (!flags['snapshot-id'] && !(flags.rollback || flags['backup-cr-name'])) {
+      this.error('"--snapshot-id" flag is required')
+    }
 
     const tasks = new Listr([], ctx.listrOptions)
     const apiTasks = new ApiTasks()

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -75,7 +75,6 @@ export default class Restore extends Command {
       char: 'v',
       description:
         'Che Operator version to restore to (e.g. 7.35.1). ' +
-        'Must comply with the version in used backup snapshot. ' +
         'Defaults to the existing operator version or to chectl version if none deployed.',
       required: false,
     }),
@@ -278,13 +277,12 @@ export default class Restore extends Command {
             flags['cluster-monitoring'] = true
           } else {
             flags.platform = 'kubernetes'
-            // TODO domain ?
           }
 
-          // Use plain operator on Kubernetes or if it is requested instead of OLM
-          if (!isOpenshift || flags.installer === 'operator') {
+          if (flags.installer === 'operator') {
             const operatorTasks = new OperatorTasks()
-            // Update tasks can deploy operator as well
+            // Update tasks can also deploy operator. If a resource already exist, it will be replaced.
+            // When operator of requested version is deployed, then restore will rollout data from the backup.
             const operatorUpdateTasks = operatorTasks.updateTasks(flags, this)
             // Remove last tasks that deploys CR (it will be done on restore)
             operatorUpdateTasks.splice(-1)

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -182,9 +182,12 @@ export default class Restore extends Command {
           const backupCrName = 'backup-before-update-to-' + currentOperatorVersion.replace(/\./g, '-')
 
           const kube = new KubeHelper(flags)
-          const backupCr = await kube.getCustomResource(flags.chenamespace, backupCrName, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL)
+          const backupCr: V1CheClusterBackup = await kube.getCustomResource(flags.chenamespace, backupCrName, CHE_CLUSTER_API_GROUP, CHE_CLUSTER_API_VERSION, CHE_CLUSTER_BACKUP_KIND_PLURAL)
           if (!backupCr) {
             throw new Error(`Cannot find backup: ${backupCrName}`)
+          }
+          if (!backupCr.status || backupCr.status.state !== 'Succeeded') {
+            throw new Error(`Backup with name '${backupCrName}' is not successful`)
           }
           flags['backup-cr'] = backupCrName
           task.title = `${task.title} ${backupCrName} found`

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -23,7 +23,7 @@ import { cheNamespace } from '../../common-flags'
 import { getBackupServerConfigurationName, parseBackupServerConfig, requestRestore } from '../../api/backup-restore'
 import { cli } from 'cli-ux'
 import { ApiTasks } from '../../tasks/platforms/api'
-import { TASK_TITLE_CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE, TASK_TITLE_DELETE_CUSTOM_CATALOG_SOURCE, TASK_TITLE_DELETE_NIGHTLY_CATALOG_SOURCE, TASK_TITLE_DELETE_OPERATOR_GROUP, OLMTasks, TASK_TITLE_SET_CUSTOM_OPERATOR_IMAGE, TASK_TITLE_PREPARE_CHE_CLUSTER_CR } from '../../tasks/installers/olm'
+import { TASK_TITLE_CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE, TASK_TITLE_DELETE_CUSTOM_CATALOG_SOURCE, TASK_TITLE_DELETE_NIGHTLY_CATALOG_SOURCE, OLMTasks, TASK_TITLE_SET_CUSTOM_OPERATOR_IMAGE, TASK_TITLE_PREPARE_CHE_CLUSTER_CR } from '../../tasks/installers/olm'
 import { OperatorTasks } from '../../tasks/installers/operator'
 import { checkChectlAndCheVersionCompatibility, downloadTemplates, TASK_TITLE_CREATE_CHE_CLUSTER_CRD, TASK_TITLE_PATCH_CHECLUSTER_CR } from '../../tasks/installers/common-tasks'
 import { confirmYN, findWorkingNamespace, getCommandSuccessMessage, getEmbeddedTemplatesDirectory, notifyCommandCompletedSuccessfully, wrapCommandError } from '../../util'
@@ -365,7 +365,6 @@ export default class Restore extends Command {
           const olmTasks = new OLMTasks()
           let olmDeleteTasks = olmTasks.deleteTasks(flags)
           const tasksToDelete = [
-            TASK_TITLE_DELETE_OPERATOR_GROUP,
             TASK_TITLE_DELETE_CUSTOM_CATALOG_SOURCE,
             TASK_TITLE_DELETE_NIGHTLY_CATALOG_SOURCE,
           ]

--- a/src/commands/server/restore.ts
+++ b/src/commands/server/restore.ts
@@ -41,11 +41,11 @@ export default class Restore extends Command {
     'chectl server:restore',
     '# Restore from specific backup snapshot using previos backup configuration:\n' +
     'chectl server:restore -s 585421f3',
-    '# Create and use configuration for REST backup server:\n' +
+    '# Restore from latest snapshot located in provided REST backup server:\n' +
     'chectl server:resotre -r rest:http://my-sert-server.net:4000/che-backup -p repopassword',
-    '# Create and use configuration for AWS S3 (and API compatible) backup server (bucket should be precreated):\n' +
+    '# Restore from latest snapshot located in provided AWS S3 (or API compatible) backup server (bucket should be precreated):\n' +
     'chectl server:restore -r s3:s3.amazonaws.com/bucketche -p repopassword',
-    '# Create and use configuration for SFTP backup server:\n' +
+    '# Restore from latest snapshot located in provided SFTP backup server:\n' +
     'chectl server:restore -r=sftp:user@my-server.net:/srv/sftp/che-data -p repopassword',
     '# Rollback to previous version (if it was installed):\n' +
     'chectl server:restore --rollback',
@@ -78,6 +78,7 @@ export default class Restore extends Command {
         'Che Operator version to restore to (e.g. 7.35.1). ' +
         'Defaults to the existing operator version or to chectl version if none deployed.',
       required: false,
+      dependsOn: ['snapshot-id'],
     }),
     'backup-cr-name': string({
       description: 'Name of a backup custom resource to restore from',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,6 +44,7 @@ export const LEGACY_CHE_NAMESPACE = 'che'
 // OLM
 export const DEFAULT_CHE_OLM_PACKAGE_NAME = 'eclipse-che'
 export const OLM_STABLE_CHANNEL_NAME = 'stable'
+export const OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME = 'stable-all-namespaces'
 export const OLM_NEXT_CHANNEL_NAME = 'next'
 export const DEFAULT_OPENSHIFT_MARKET_PLACE_NAMESPACE = 'openshift-marketplace'
 export const DEFAULT_OLM_KUBERNETES_NAMESPACE = 'olm'
@@ -55,6 +56,7 @@ export const OPENSHIFT_OLM_CATALOG = 'community-operators'
 export const CVS_PREFIX = 'eclipse-che'
 export const NEXT_CATALOG_SOURCE_NAME = 'eclipse-che-preview'
 export const DEFAULT_OLM_SUGGESTED_NAMESPACE = 'eclipse-che'
+export const DEFAULT_OPENSHIFT_OPERATORS_NS_NAME = 'openshift-operators'
 
 // Documentation links
 export const DOC_LINK = 'https://www.eclipse.org/che/docs/'
@@ -90,6 +92,3 @@ export const CHE_CLUSTER_BACKUP_CRD = 'checlusterbackups.org.eclipse.che'
 export const CHE_CLUSTER_BACKUP_KIND_PLURAL = 'checlusterbackups'
 export const CHE_CLUSTER_RESTORE_CRD = 'checlusterrestores.org.eclipse.che'
 export const CHE_CLUSTER_RESTORE_KIND_PLURAL = 'checlusterrestores'
-
-export const DEFAULT_OPENSHIFT_OPERATORS_NS_NAME = 'openshift-operators'
-export const STABLE_ALL_NAMESPACES_CHANNEL_NAME = 'tech-preview-stable-all-namespaces'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,7 +44,7 @@ export const LEGACY_CHE_NAMESPACE = 'che'
 // OLM
 export const DEFAULT_CHE_OLM_PACKAGE_NAME = 'eclipse-che'
 export const OLM_STABLE_CHANNEL_NAME = 'stable'
-export const OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME = 'stable-all-namespaces'
+export const OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME = 'tech-preview-stable-all-namespaces'
 export const OLM_NEXT_CHANNEL_NAME = 'next'
 export const DEFAULT_OPENSHIFT_MARKET_PLACE_NAMESPACE = 'openshift-marketplace'
 export const DEFAULT_OLM_KUBERNETES_NAMESPACE = 'olm'

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -26,6 +26,9 @@ import { VersionHelper } from '../../api/version'
 import { CHE_CLUSTER_CRD, DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER, OPERATOR_TEMPLATE_DIR } from '../../constants'
 import { getProjectVersion } from '../../util'
 
+export const TASK_TITLE_CREATE_CHE_CLUSTER_CRD = `Create the Custom Resource of type ${CHE_CLUSTER_CRD}`
+export const TASK_TITLE_PATCH_CHECLUSTER_CR = `Patching the Custom Resource of type ${CHE_CLUSTER_CRD}`
+
 export function createNamespaceTask(namespaceName: string, labels: {}): Listr.ListrTask {
   return {
     title: `Create Namespace (${namespaceName})`,
@@ -117,9 +120,11 @@ export function downloadTemplates(flags: any): Listr.ListrTask {
 
 export function createEclipseCheCluster(flags: any, kube: KubeHelper): Listr.ListrTask {
   return {
-    title: `Create the Custom Resource of type ${CHE_CLUSTER_CRD} in the namespace ${flags.chenamespace}`,
+    title: TASK_TITLE_CREATE_CHE_CLUSTER_CRD,
     enabled: ctx => Boolean(ctx.customCR) || Boolean(ctx.defaultCR),
     task: async (ctx: any, task: any) => {
+      task.title = `${task.title} in the namespace ${flags.chenamespace}`
+
       ctx.isCheDeployed = true
       ctx.isPostgresDeployed = true
       ctx.isKeycloakDeployed = true
@@ -160,9 +165,10 @@ export function createEclipseCheCluster(flags: any, kube: KubeHelper): Listr.Lis
  */
 export function patchingEclipseCheCluster(flags: any, kube: KubeHelper, command: Command): Listr.ListrTask {
   return {
-    title: `Patching the Custom Resource of type '${CHE_CLUSTER_CRD}' in the namespace '${flags.chenamespace}'`,
+    title: TASK_TITLE_PATCH_CHECLUSTER_CR,
     skip: (ctx: any) => isEmpty(ctx[ChectlContext.CR_PATCH]),
     task: async (ctx: any, task: any) => {
+      task.title = `${task.title} in the namespace ${flags.chenamespace}`
       const cheCluster = await kube.getCheCluster(flags.chenamespace)
       if (!cheCluster) {
         command.error(`Eclipse Che cluster CR is not found in the namespace '${flags.chenamespace}'`)

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -81,7 +81,7 @@ export class InstallerTasks {
     }]
   }
 
-  installTasks(flags: any, command: Command): ReadonlyArray<Listr.ListrTask> {
+  async installTasks(flags: any, command: Command): Promise<ReadonlyArray<Listr.ListrTask>> {
     const helmTasks = new HelmTasks(flags)
     const operatorTasks = new OperatorTasks()
     const olmTasks = new OLMTasks()

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -13,6 +13,8 @@
 import Command from '@oclif/command'
 import * as Listr from 'listr'
 
+import { ChectlContext } from '../../api/context'
+
 import { HelmTasks } from './helm'
 import { OLMTasks } from './olm'
 import { OperatorTasks } from './operator'
@@ -82,6 +84,8 @@ export class InstallerTasks {
   }
 
   async installTasks(flags: any, command: Command): Promise<ReadonlyArray<Listr.ListrTask>> {
+    const ctx = ChectlContext.get()
+
     const helmTasks = new HelmTasks(flags)
     const operatorTasks = new OperatorTasks()
     const olmTasks = new OLMTasks()
@@ -91,10 +95,12 @@ export class InstallerTasks {
 
     if (flags.installer === 'operator') {
       title = '🏃‍  Running the Eclipse Che operator'
-      task = () => operatorTasks.deployTasks(flags, command)
+      task = async () => {
+        return new Listr(await operatorTasks.deployTasks(flags, command), ctx.listrOptions)
+      }
     } else if (flags.installer === 'olm') {
       title = '🏃‍  Running Olm installaion Eclipse Che'
-      task = () => olmTasks.startTasks(flags, command)
+      task = () => new Listr(olmTasks.startTasks(flags, command), ctx.listrOptions)
     // installer.ts BEGIN CHE ONLY
     } else if (flags.installer === 'helm') {
       title = '🏃‍  Running Helm to install Eclipse Che'

--- a/src/tasks/installers/installer.ts
+++ b/src/tasks/installers/installer.ts
@@ -32,8 +32,8 @@ export class InstallerTasks {
 
     if (flags.installer === 'operator') {
       title = '🏃‍  Running the Eclipse Che operator Update'
-      task = () => {
-        return operatorTasks.updateTasks(flags, command)
+      task = (ctx: any) => {
+        return new Listr(operatorTasks.updateTasks(flags, command), ctx.listrOptions)
       }
     } else if (flags.installer === 'olm') {
       title = '🏃‍  Running the Eclipse Che operator Update using OLM'

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -385,6 +385,7 @@ export class OLMTasks {
       },
       {
         title: 'Delete(OLM) operator group',
+        // Do not delete global operator group if operator is in all namespaces mode
         enabled: ctx => ctx.isPreInstalledOLM && ctx.operatorNamespace !== DEFAULT_OPENSHIFT_OPERATORS_NS_NAME,
         task: async (ctx: any, task: any) => {
           const opgr = ctx.operatorGroup

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -360,7 +360,7 @@ export class OLMTasks {
         },
       },
       {
-        title: `Delete(OLM) Eclipse Che cluster service versions for all namespaces mode`,
+        title: 'Delete(OLM) Eclipse Che cluster service versions for all namespaces mode',
         enabled: ctx => ctx.isPreInstalledOLM && flags.chenamespace !== ctx.operatorNamespace,
         task: async (ctx: any, task: any) => {
           const csvs = await kube.getClusterServiceVersions(ctx.operatorNamespace)

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -360,25 +360,13 @@ export class OLMTasks {
         },
       },
       {
-        title: 'Delete(OLM) Eclipse Che cluster service versions for all namespaces mode',
-        enabled: ctx => ctx.isPreInstalledOLM && flags.chenamespace !== ctx.operatorNamespace,
+        title: 'Delete(OLM) Eclipse Che cluster service versions',
+        enabled: ctx => ctx.isPreInstalledOLM,
         task: async (ctx: any, task: any) => {
           const csvs = await kube.getClusterServiceVersions(ctx.operatorNamespace)
           const csvsToDelete = csvs.items.filter(csv => csv.metadata.name!.startsWith(CVS_PREFIX))
           for (const csv of csvsToDelete) {
             await kube.deleteClusterServiceVersion(ctx.operatorNamespace, csv.metadata.name!)
-          }
-          task.title = `${task.title}...OK`
-        },
-      },
-      {
-        title: 'Delete(OLM) Eclipse Che cluster service versions',
-        enabled: ctx => ctx.isPreInstalledOLM,
-        task: async (_ctx: any, task: any) => {
-          const csvs = await kube.getClusterServiceVersions(flags.chenamespace)
-          const csvsToDelete = csvs.items.filter(csv => csv.metadata.name!.startsWith(CVS_PREFIX))
-          for (const csv of csvsToDelete) {
-            await kube.deleteClusterServiceVersion(flags.chenamespace, csv.metadata.name!)
           }
           task.title = `${task.title}...OK`
         },

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -20,7 +20,7 @@ import { CheHelper } from '../../api/che'
 import { KubeHelper } from '../../api/kube'
 import { CatalogSource, Subscription } from '../../api/typings/olm'
 import { VersionHelper } from '../../api/version'
-import { CUSTOM_CATALOG_SOURCE_NAME, CVS_PREFIX, DEFAULT_CHE_NAMESPACE, DEFAULT_CHE_OLM_PACKAGE_NAME, DEFAULT_OLM_KUBERNETES_NAMESPACE, DEFAULT_OPENSHIFT_MARKET_PLACE_NAMESPACE, DEFAULT_OPENSHIFT_OPERATORS_NS_NAME, KUBERNETES_OLM_CATALOG, NEXT_CATALOG_SOURCE_NAME, OLM_NEXT_CHANNEL_NAME, OLM_STABLE_CHANNEL_NAME, OPENSHIFT_OLM_CATALOG, OPERATOR_GROUP_NAME, STABLE_ALL_NAMESPACES_CHANNEL_NAME, DEFAULT_CHE_OPERATOR_SUBSCRIPTION_NAME } from '../../constants'
+import { CUSTOM_CATALOG_SOURCE_NAME, CVS_PREFIX, DEFAULT_CHE_NAMESPACE, DEFAULT_CHE_OLM_PACKAGE_NAME, DEFAULT_OLM_KUBERNETES_NAMESPACE, DEFAULT_OPENSHIFT_MARKET_PLACE_NAMESPACE, DEFAULT_OPENSHIFT_OPERATORS_NS_NAME, KUBERNETES_OLM_CATALOG, NEXT_CATALOG_SOURCE_NAME, OLM_NEXT_CHANNEL_NAME, OLM_STABLE_CHANNEL_NAME, OPENSHIFT_OLM_CATALOG, OPERATOR_GROUP_NAME, OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME, DEFAULT_CHE_OPERATOR_SUBSCRIPTION_NAME } from '../../constants'
 import { isKubernetesPlatformFamily } from '../../util'
 
 import { createEclipseCheCluster, createNamespaceTask, patchingEclipseCheCluster } from './common-tasks'
@@ -33,10 +33,10 @@ export class OLMTasks {
   /**
    * Returns list of tasks which perform preflight platform checks.
    */
-  startTasks(flags: any, command: Command): Listr {
+  startTasks(flags: any, command: Command): Listr.ListrTask<any>[] {
     const kube = new KubeHelper(flags)
     const che = new CheHelper(flags)
-    return new Listr([
+    return [
       this.isOlmPreInstalledTask(command, kube),
       createNamespaceTask(flags.chenamespace, this.getOlmNamespaceLabels(flags)),
       {
@@ -162,9 +162,9 @@ export class OLMTasks {
           } else if (VersionHelper.isDeployingStableVersion(flags) || flags['olm-channel'] === OLM_STABLE_CHANNEL_NAME) {
             // stable Che CatalogSource
             subscription = this.constructSubscription(ctx.subscriptionName, DEFAULT_CHE_OLM_PACKAGE_NAME, ctx.operatorNamespace, ctx.defaultCatalogSourceNamespace, OLM_STABLE_CHANNEL_NAME, ctx.catalogSourceNameStable, ctx.approvalStarategy, ctx.startingCSV)
-          } else if (flags['olm-channel'] === STABLE_ALL_NAMESPACES_CHANNEL_NAME) {
+          } else if (flags['olm-channel'] === OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME) {
             // stable Che CatalogSource
-            subscription = this.constructSubscription(ctx.subscriptionName, DEFAULT_CHE_OLM_PACKAGE_NAME, ctx.operatorNamespace, ctx.defaultCatalogSourceNamespace, STABLE_ALL_NAMESPACES_CHANNEL_NAME, ctx.catalogSourceNameStable, ctx.approvalStarategy, ctx.startingCSV)
+            subscription = this.constructSubscription(ctx.subscriptionName, DEFAULT_CHE_OLM_PACKAGE_NAME, ctx.operatorNamespace, ctx.defaultCatalogSourceNamespace, OLM_STABLE_ALL_NAMESPACES_CHANNEL_NAME, ctx.catalogSourceNameStable, ctx.approvalStarategy, ctx.startingCSV)
           } else {
             // next Che CatalogSource
             subscription = this.constructSubscription(ctx.subscriptionName, `eclipse-che-preview-${ctx.generalPlatformName}`, ctx.operatorNamespace, ctx.operatorNamespace, OLM_NEXT_CHANNEL_NAME, NEXT_CATALOG_SOURCE_NAME, ctx.approvalStarategy, ctx.startingCSV)
@@ -227,7 +227,7 @@ export class OLMTasks {
         },
       },
       createEclipseCheCluster(flags, kube),
-    ], { renderer: flags['listr-renderer'] as any })
+    ]
   }
 
   preUpdateTasks(flags: any, command: Command): Listr {

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -29,7 +29,6 @@ export const TASK_TITLE_SET_CUSTOM_OPERATOR_IMAGE = 'Set custom operator image'
 export const TASK_TITLE_CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE = 'Create custom catalog source from file'
 export const TASK_TITLE_PREPARE_CHE_CLUSTER_CR = 'Prepare Eclipse Che cluster CR'
 
-export const TASK_TITLE_DELETE_OPERATOR_GROUP = 'Delete(OLM) operator group'
 export const TASK_TITLE_DELETE_CUSTOM_CATALOG_SOURCE = `Delete(OLM) custom catalog source ${CUSTOM_CATALOG_SOURCE_NAME}`
 export const TASK_TITLE_DELETE_NIGHTLY_CATALOG_SOURCE = `Delete(OLM) nigthly catalog source ${NEXT_CATALOG_SOURCE_NAME}`
 
@@ -380,7 +379,7 @@ export class OLMTasks {
         },
       },
       {
-        title: TASK_TITLE_DELETE_OPERATOR_GROUP,
+        title: 'Delete(OLM) operator group',
         // Do not delete global operator group if operator is in all namespaces mode
         enabled: ctx => ctx.isPreInstalledOLM && ctx.operatorNamespace !== DEFAULT_OPENSHIFT_OPERATORS_NS_NAME,
         task: async (ctx: any, task: any) => {

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -25,12 +25,13 @@ import { isKubernetesPlatformFamily } from '../../util'
 
 import { createEclipseCheCluster, createNamespaceTask, patchingEclipseCheCluster } from './common-tasks'
 
-export const SET_CUSTOM_OPERATOR_IMAGE_TASK_TITLE = 'Set custom operator image'
-export const CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE_TASK_TITLE = 'Create custom catalog source from file'
+export const TASK_TITLE_SET_CUSTOM_OPERATOR_IMAGE = 'Set custom operator image'
+export const TASK_TITLE_CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE = 'Create custom catalog source from file'
+export const TASK_TITLE_PREPARE_CHE_CLUSTER_CR = 'Prepare Eclipse Che cluster CR'
 
-export const DELETE_OPERATOR_GROUP_TASK_TITLE = 'Delete(OLM) operator group'
-export const DELETE_CUSTOM_CATALOG_SOURCE_TASK_TITLE = `Delete(OLM) custom catalog source ${CUSTOM_CATALOG_SOURCE_NAME}`
-export const DELETE_NIGHTLY_CATALOG_SOURCE_TASK_TITLE = `Delete(OLM) nigthly catalog source ${NEXT_CATALOG_SOURCE_NAME}`
+export const TASK_TITLE_DELETE_OPERATOR_GROUP = 'Delete(OLM) operator group'
+export const TASK_TITLE_DELETE_CUSTOM_CATALOG_SOURCE = `Delete(OLM) custom catalog source ${CUSTOM_CATALOG_SOURCE_NAME}`
+export const TASK_TITLE_DELETE_NIGHTLY_CATALOG_SOURCE = `Delete(OLM) nigthly catalog source ${NEXT_CATALOG_SOURCE_NAME}`
 
 export class OLMTasks {
   prometheusRoleName = 'prometheus-k8s'
@@ -142,7 +143,7 @@ export class OLMTasks {
         },
       },
       {
-        title: CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE_TASK_TITLE,
+        title: TASK_TITLE_CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE,
         enabled: () => flags['catalog-source-yaml'],
         task: async (ctx: any, task: any) => {
           const customCatalogSource: CatalogSource = kube.readCatalogSourceFromFile(flags['catalog-source-yaml'])
@@ -210,7 +211,7 @@ export class OLMTasks {
         },
       },
       {
-        title: SET_CUSTOM_OPERATOR_IMAGE_TASK_TITLE,
+        title: TASK_TITLE_SET_CUSTOM_OPERATOR_IMAGE,
         enabled: () => flags['che-operator-image'],
         task: async (_ctx: any, task: any) => {
           const csvList = await kube.getClusterServiceVersions(flags.chenamespace)
@@ -224,7 +225,7 @@ export class OLMTasks {
         },
       },
       {
-        title: 'Prepare Eclipse Che cluster CR',
+        title: TASK_TITLE_PREPARE_CHE_CLUSTER_CR,
         task: async (ctx: any, task: any) => {
           const cheCluster = await kube.getCheCluster(flags.chenamespace)
           if (cheCluster) {
@@ -379,7 +380,7 @@ export class OLMTasks {
         },
       },
       {
-        title: DELETE_OPERATOR_GROUP_TASK_TITLE,
+        title: TASK_TITLE_DELETE_OPERATOR_GROUP,
         // Do not delete global operator group if operator is in all namespaces mode
         enabled: ctx => ctx.isPreInstalledOLM && ctx.operatorNamespace !== DEFAULT_OPENSHIFT_OPERATORS_NS_NAME,
         task: async (ctx: any, task: any) => {
@@ -391,14 +392,14 @@ export class OLMTasks {
         },
       },
       {
-        title: DELETE_CUSTOM_CATALOG_SOURCE_TASK_TITLE,
+        title: TASK_TITLE_DELETE_CUSTOM_CATALOG_SOURCE,
         task: async (ctx: any, task: any) => {
           await kube.deleteCatalogSource(ctx.operatorNamespace, CUSTOM_CATALOG_SOURCE_NAME)
           task.title = `${task.title}...OK`
         },
       },
       {
-        title: DELETE_NIGHTLY_CATALOG_SOURCE_TASK_TITLE,
+        title: TASK_TITLE_DELETE_NIGHTLY_CATALOG_SOURCE,
         task: async (ctx: any, task: any) => {
           await kube.deleteCatalogSource(ctx.operatorNamespace, NEXT_CATALOG_SOURCE_NAME)
           task.title = `${task.title}...OK`

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -412,7 +412,7 @@ export class OLMTasks {
         if (!await kube.isPreInstalledOLM()) {
           cli.warn('Looks like your platform hasn\'t got embedded OLM, so you should install it manually. For quick start you can use:')
           cli.url('install.sh', 'https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/install.sh')
-          command.error('OLM is required for installation Eclipse Che with installer flag \'olm\'')
+          command.error('OLM is required for installation of Eclipse Che with installer flag \'olm\'')
         }
         task.title = `${task.title}...done.`
       },

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -25,6 +25,13 @@ import { isKubernetesPlatformFamily } from '../../util'
 
 import { createEclipseCheCluster, createNamespaceTask, patchingEclipseCheCluster } from './common-tasks'
 
+export const SET_CUSTOM_OPERATOR_IMAGE_TASK_TITLE = 'Set custom operator image'
+export const CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE_TASK_TITLE = 'Create custom catalog source from file'
+
+export const DELETE_OPERATOR_GROUP_TASK_TITLE = 'Delete(OLM) operator group'
+export const DELETE_CUSTOM_CATALOG_SOURCE_TASK_TITLE = `Delete(OLM) custom catalog source ${CUSTOM_CATALOG_SOURCE_NAME}`
+export const DELETE_NIGHTLY_CATALOG_SOURCE_TASK_TITLE = `Delete(OLM) nigthly catalog source ${NEXT_CATALOG_SOURCE_NAME}`
+
 export class OLMTasks {
   prometheusRoleName = 'prometheus-k8s'
 
@@ -135,8 +142,8 @@ export class OLMTasks {
         },
       },
       {
+        title: CREATE_CUSTOM_CATALOG_SOURCE_FROM_FILE_TASK_TITLE,
         enabled: () => flags['catalog-source-yaml'],
-        title: 'Create custom catalog source from file',
         task: async (ctx: any, task: any) => {
           const customCatalogSource: CatalogSource = kube.readCatalogSourceFromFile(flags['catalog-source-yaml'])
           if (!await kube.catalogSourceExists(customCatalogSource.metadata!.name!, flags.chenamespace)) {
@@ -203,7 +210,7 @@ export class OLMTasks {
         },
       },
       {
-        title: 'Set custom operator image',
+        title: SET_CUSTOM_OPERATOR_IMAGE_TASK_TITLE,
         enabled: () => flags['che-operator-image'],
         task: async (_ctx: any, task: any) => {
           const csvList = await kube.getClusterServiceVersions(flags.chenamespace)
@@ -372,7 +379,7 @@ export class OLMTasks {
         },
       },
       {
-        title: 'Delete(OLM) operator group',
+        title: DELETE_OPERATOR_GROUP_TASK_TITLE,
         // Do not delete global operator group if operator is in all namespaces mode
         enabled: ctx => ctx.isPreInstalledOLM && ctx.operatorNamespace !== DEFAULT_OPENSHIFT_OPERATORS_NS_NAME,
         task: async (ctx: any, task: any) => {
@@ -384,14 +391,14 @@ export class OLMTasks {
         },
       },
       {
-        title: `Delete(OLM) custom catalog source ${CUSTOM_CATALOG_SOURCE_NAME}`,
+        title: DELETE_CUSTOM_CATALOG_SOURCE_TASK_TITLE,
         task: async (ctx: any, task: any) => {
           await kube.deleteCatalogSource(ctx.operatorNamespace, CUSTOM_CATALOG_SOURCE_NAME)
           task.title = `${task.title}...OK`
         },
       },
       {
-        title: `Delete(OLM) nigthly catalog source ${NEXT_CATALOG_SOURCE_NAME}`,
+        title: DELETE_NIGHTLY_CATALOG_SOURCE_TASK_TITLE,
         task: async (ctx: any, task: any) => {
           await kube.deleteCatalogSource(ctx.operatorNamespace, NEXT_CATALOG_SOURCE_NAME)
           task.title = `${task.title}...OK`

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -148,7 +148,7 @@ export class OperatorTasks {
   /**
    * Returns tasks list which perform preflight platform checks.
    */
-  async deployTasks(flags: any, command: Command): Promise<Listr> {
+  async deployTasks(flags: any, command: Command): Promise<Listr.ListrTask[]> {
     const kube = new KubeHelper(flags)
     const kubeTasks = new KubeTasks(flags)
     const ctx = ChectlContext.get()
@@ -156,7 +156,7 @@ export class OperatorTasks {
     if (VersionHelper.isDeployingStableVersion(flags) && !await kube.isOpenShift3()) {
       command.warn('Consider using the more reliable \'OLM\' installer when deploying a stable release of Eclipse Che (--installer=olm).')
     }
-    return new Listr([
+    return [
       createNamespaceTask(flags.chenamespace, {}),
       {
         title: `Create ServiceAccount ${this.operatorServiceAccount} in namespace ${flags.chenamespace}`,
@@ -268,7 +268,7 @@ export class OperatorTasks {
         },
       },
       createEclipseCheCluster(flags, kube),
-    ], { renderer: flags['listr-renderer'] as any })
+    ]
   }
 
   preUpdateTasks(flags: any, command: Command): Listr {

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -310,11 +310,11 @@ export class OperatorTasks {
     ])
   }
 
-  updateTasks(flags: any, command: Command): Listr {
+  updateTasks(flags: any, command: Command): Array<Listr.ListrTask> {
     const kube = new KubeHelper(flags)
     const ctx = ChectlContext.get()
     ctx.resourcesPath = path.join(flags.templates, OPERATOR_TEMPLATE_DIR)
-    return new Listr([
+    return [
       {
         title: `Updating ServiceAccount ${this.operatorServiceAccount} in namespace ${flags.chenamespace}`,
         task: async (ctx: any, task: any) => {
@@ -429,7 +429,7 @@ export class OperatorTasks {
         },
       },
       patchingEclipseCheCluster(flags, kube, command),
-    ], { renderer: flags['listr-renderer'] as any })
+    ]
   }
 
   /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,6 +21,7 @@ import * as yaml from 'js-yaml'
 import * as notifier from 'node-notifier'
 import * as os from 'os'
 import * as path from 'path'
+import * as readline from 'readline'
 import { promisify } from 'util'
 
 import { ChectlContext } from './api/context'
@@ -344,4 +345,36 @@ export function addTrailingSlash(url: string): string {
     return url
   }
   return url + '/'
+}
+
+/**
+ * Waits until y or n is pressed (no return press needed) and returns confirmation result.
+ * ctrl+c causes exception.
+ * This function doesn't print anything, this is the task of the code that invokes it.
+ */
+export function confirmYN(): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    readline.emitKeypressEvents(process.stdin)
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true)
+    }
+
+    const keyPressHandler = (_string: any, key: any) => {
+      // Handle brake
+      if (key.ctrl && key.name === 'c') {
+        process.stdin.removeListener('keypress', keyPressHandler)
+        reject('Interrupted')
+      }
+
+      // Check if y or n pressed
+      if (key.name === 'y' || key.name === 'Y') {
+        process.stdin.removeListener('keypress', keyPressHandler)
+        resolve(true)
+      } else if (key.name === 'n' || key.name === 'N') {
+        process.stdin.removeListener('keypress', keyPressHandler)
+        resolve(false)
+      }
+    }
+    process.stdin.on('keypress', keyPressHandler)
+  })
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -359,19 +359,23 @@ export function confirmYN(): Promise<boolean> {
       process.stdin.setRawMode(true)
     }
 
+    const removeKeyPressHandler = () => {
+      process.stdin.removeListener('keypress', keyPressHandler)
+      process.stdin.setRawMode(false)
+    }
     const keyPressHandler = (_string: any, key: any) => {
       // Handle brake
       if (key.ctrl && key.name === 'c') {
-        process.stdin.removeListener('keypress', keyPressHandler)
+        removeKeyPressHandler()
         reject('Interrupted')
       }
 
       // Check if y or n pressed
       if (key.name === 'y' || key.name === 'Y') {
-        process.stdin.removeListener('keypress', keyPressHandler)
+        removeKeyPressHandler()
         resolve(true)
       } else if (key.name === 'n' || key.name === 'N') {
-        process.stdin.removeListener('keypress', keyPressHandler)
+        removeKeyPressHandler()
         resolve(false)
       }
     }


### PR DESCRIPTION
### What does this PR do?
Implements ability to restore to a different version of Che than deployed operator.
It added several new falgs to `server:restore` command:
`--rollback` - finds backup made automatically and restores Che operator to the previous version and restore installation from the backup
`--backup-cr` - restores Che from given backup described by a backup object (it includes Che version as well)
`--version` - before restoring Che installation, deploys given version of Che Operator (usually used together with `--snapshot-id`)

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1497

### How to test this PR?
1. Edit latest CSV for OLM stable channel: increment version everywhere, change replace version to the one being replaced. Optionally change operator image.
2. Build test catalog source with the following command:
```sh
olm/buildAndPushBundleImages.sh -p openshift -c "stable"  -i quay.io/eclipse/eclipse-che-openshift-opm-catalog:preview -f true
```
The script should push images to your images registry account. Remember catalog source image name, for example: `docker.io/user/eclipse-che-openshift-opm-catalog:preview`
3. Open Openshift console, navigate to `Administration` -> `Cluster Settings` -> `Configuration` tab. Scroll to and click on `OperatorHub`. Switch to `Sources` tab. Click `Create CatalogSource`. Fill in the fields with `test` and put your catalog source image. Click `Create` button.
4. Create subscription for the real latest version in stable channel (but there is your fake one on top, so it is possible to update to). Example subscription yaml (change `startingCSV` to real latest stable one):
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: eclipse-che
  namespace: eclipse-che
spec:
  channel: stable
  installPlanApproval: Manual
  name: eclipse-che-preview-openshift
  source: test
  sourceNamespace: openshift-marketplace
  startingCSV: eclipse-che-preview-openshift.v7.36.1
```
5. Create a checluster object (from terminal or Openshift console).
6. Wait until Che is ready
7. Approve new installation plan: `oc get ip`, select pending to your fake version install plan and edit it: `oc edit ip <install-planname>`. Set `spec.approved` to `true`.
8. Wait unitl new Operator is deployed and Che is updated. New operator should create a new backup with name like: `backup-before-update-to-7-37-0` (the version should be your fake one).
9. Run `./debug server:restore --rollback`. Note, you have to stop in `olm.ts` `constructSubscription` function and replace `sourceName ` to your catalog source name (`test`). It might be omitted if your replace exiting catalog source image instead of adding a new one.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
