### PR TITLE
fix: Detect Che operator group name instead of using hardcoded constant

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1963,6 +1963,21 @@ export class KubeHelper {
     }
   }
 
+  async getOperatorGroup(name: string, namespace: string): Promise<OperatorGroup | undefined> {
+    const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi)
+    try {
+      const response = await customObjectsApi.getNamespacedCustomObject('operators.coreos.com', 'v1', namespace, 'operatorgroups', name)
+      if (response && response.body) {
+        return response.body as OperatorGroup
+      }
+    } catch (error) {
+      if (error.response && error.response.statusCode === 404) {
+        return
+      }
+      throw this.wrapK8sClientError(error)
+    }
+  }
+
   async createOperatorGroup(operatorGroupName: string, namespace: string) {
     const operatorGroup: OperatorGroup = {
       apiVersion: 'operators.coreos.com/v1',

--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -363,7 +363,7 @@ export default class Update extends Command {
    */
   private async setDefaultInstaller(flags: any): Promise<void> {
     const cheHelper = new CheHelper(flags)
-    if (await cheHelper.findCheSubscription(flags.chenamespace)) {
+    if (await cheHelper.findCheOperatorSubscription(flags.chenamespace)) {
       flags.installer = 'olm'
     } else {
       flags.installer = 'operator'


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Implements mechanism of finding operator group of Che operator instead of using hardcoded name.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20424

### How to test this PR?
1. Manually create a subscription for Che, for example:
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: eclipse-che
  namespace: eclipse-che
spec:
  channel: stable
  installPlanApproval: Automatic
  name: eclipse-che-preview-openshift
  source: comunity-operators
  sourceNamespace: openshift-marketplace
  startingCSV: eclipse-che.v7.36.2
```
2. Check that an operator group is created by OLM (with a generated name)
3. Run `server:delete` command
4. Check that the operator group is gone

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
