### PR TITLE
fix: backup/restore credentials change case

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -85,6 +85,10 @@ export function base64Decode(arg: string): string {
   return Buffer.from(arg, 'base64').toString('ascii')
 }
 
+export function base64Encode(arg: string): string {
+  return Buffer.from(arg).toString('base64')
+}
+
 /**
  * Separates docker image repository and tag.
  * @param image string with image and tag separated by a colon

--- a/test/api/kube.test.ts
+++ b/test/api/kube.test.ts
@@ -75,4 +75,25 @@ describe('Kube API helper', () => {
       const res = await kube.getDeploymentsBySelector(selector, namespace)
       expect(res.items.length).to.equal(1)
     })
+  fancy
+    .it('should compare secrets data', () => {
+      const equalSecretsData: Array<Array<{ [key: string]: string }>> = [
+        [{a: 'a', b: 'b', c: '5'}, {a: 'a', b: 'b', c: '5'}],
+        [{a: 'a', b: 'b', c: '5'}, {a: 'a', c: '5', b: 'b'}],
+      ]
+
+      const differentSecretsData: Array<Array<{ [key: string]: string }>> = [
+        [{a: 'a', b: 'b', c: '5'}, {a: 'a', b: 'b'}],
+        [{a: 'a', b: 'b', c: '5'}, {a: 'a', b: 'b', c: 'c'}],
+        [{a: 'a', b: 'b'}, {a: 'a', c: 'b'}],
+      ]
+
+      for (const pair of equalSecretsData) {
+        expect(kube.isSecretsDataEqual(pair[0], pair[1])).to.be.true
+      }
+
+      for (const pair of differentSecretsData) {
+        expect(kube.isSecretsDataEqual(pair[0], pair[1])).to.be.false
+      }
+    })
 })


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Fixes comparison of secrets data and recreation in case if secrets should be replaced

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2314

### How to test this PR?
1. Create a backup into an external backup server
2. Create a backup into another backup server by providing server credentials in command line

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
