### PR TITLE
fix: fix dex configuration, set identity provider in checluster

### DIFF
--- a/resources/dex/configmap.yaml
+++ b/resources/dex/configmap.yaml
@@ -21,7 +21,7 @@ data:
     staticClients:
     - id: {{CLIENT_ID}}
       redirectURIs:
-      - 'https://che-{{NAMESPACE}}.{{DOMAIN}}/oauth/callback'
+      - 'https://{{DOMAIN}}/oauth/callback'
       name: 'Eclipse Che'
       secret: {{CLIENT_SECRET}}
     enablePasswordDB: true

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -339,7 +339,7 @@ export default class Deploy extends Command {
     await this.setPlaformDefaults(flags, ctx)
     await this.config.runHook(DEFAULT_ANALYTIC_HOOK_NAME, { command: Deploy.id, flags })
 
-    if (!flags.batch && isKubernetesPlatformFamily(flags.platform) && (isDevWorkspaceEnabled(ctx) || flags['workspace-engine'] === 'dev-workspace')) {
+    if (!flags.batch && isKubernetesPlatformFamily(flags.platform) && (isDevWorkspaceEnabled(ctx) || flags['workspace-engine'] === 'dev-workspace') && !isNativeUserModeEnabled(ctx)) {
       if (!await cli.confirm('DevWorkspace is experimental feature. It requires direct access to the underlying infrastructure REST API.\nThis results in huge privilege escalation. Do you want to proceed? [y/n]')) {
         cli.exit(0)
       }

--- a/src/tasks/component-installers/dex.ts
+++ b/src/tasks/component-installers/dex.ts
@@ -207,6 +207,10 @@ export class DexTasks {
                   await this.kube.createServiceFromFile(yamlFilePath, DexTasks.NAMESPACE_NAME)
                   task.title = `${task.title}...[OK]`
                 }
+
+                // set service in a CR
+                ctx[ChectlContext.CR_PATCH] = ctx[ChectlContext.CR_PATCH] || {}
+                merge(ctx[ChectlContext.CR_PATCH], { spec: { auth: { identityProviderURL: 'http://dex.dex:5556' } } })
               },
             },
             {
@@ -271,7 +275,6 @@ export class DexTasks {
                   const yamlFilePath = this.getDexResourceFilePath('configmap.yaml')
                   let yamlContent = fs.readFileSync(yamlFilePath).toString()
                   yamlContent = yamlContent.replace(new RegExp(TemplatePlaceholders.DOMAIN, 'g'), this.flags.domain)
-                  yamlContent = yamlContent.replace(new RegExp(TemplatePlaceholders.CHE_NAMESPACE, 'g'), this.flags.chenamespace)
                   yamlContent = yamlContent.replace(new RegExp(TemplatePlaceholders.CLIENT_ID, 'g'), DexTasks.CLIENT_ID)
                   // generate client secret
                   const clientSecret = crypto.randomBytes(32).toString('base64')


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
 - fixes dex configuration to set oauth callback without subdomain, where che is really deployed
 - sets identity provider url to dex service in checluster CR
 - don't show warning message when native user mode is enabled


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20635


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
```
cat EOF << > /tmp/patch.yaml
spec:
  auth:
    nativeUserMode: true
EOF

chectl server:deploy \
     --installer operator \
     --platform minikube \
     --che-operator-image quay.io/mvala/che-operator:gh20635-nativeAuthKube \
     --che-operator-cr-patch-yaml /tmp/patch.yaml
```
after deploy, install dex certificate into the browser and open che url.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
