### PR TITLE
chore: enable native user mode if devworkspace engine is enabled

### DIFF
--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -1687,6 +1687,10 @@ export class KubeHelper {
         cheClusterCR.spec.devWorkspace.enable = true
       }
 
+      if (cheClusterCR.spec.devWorkspace.enable) {
+        cheClusterCR.spec.auth.nativeUserMode = true
+      }
+
       // Use self-signed TLS certificate by default (for versions before 7.14.3).
       // In modern versions of Che this field is ignored.
       cheClusterCR.spec.server.selfSignedCert = true

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -302,15 +302,15 @@ export default class Deploy extends Command {
       // Check minimal allowed version to install
       let minAllowedVersion: string
       switch (flags.installer) {
-        case 'olm':
-          minAllowedVersion = MIN_OLM_INSTALLER_VERSION
-          break
-        case 'operator':
-          minAllowedVersion = MIN_CHE_OPERATOR_INSTALLER_VERSION
-          break
-        default:
-          // Should never happen
-          minAllowedVersion = 'latest'
+      case 'olm':
+        minAllowedVersion = MIN_OLM_INSTALLER_VERSION
+        break
+      case 'operator':
+        minAllowedVersion = MIN_CHE_OPERATOR_INSTALLER_VERSION
+        break
+      default:
+        // Should never happen
+        minAllowedVersion = 'latest'
       }
 
       let isVersionAllowed = false
@@ -338,12 +338,6 @@ export default class Deploy extends Command {
 
     await this.setPlaformDefaults(flags, ctx)
     await this.config.runHook(DEFAULT_ANALYTIC_HOOK_NAME, { command: Deploy.id, flags })
-
-    if (!flags.batch && isKubernetesPlatformFamily(flags.platform) && isDevWorkspaceEnabled(ctx, flags)) {
-      if (!await cli.confirm('DevWorkspace is experimental feature. It requires direct access to the underlying infrastructure REST API.\nThis results in huge privilege escalation. Do you want to proceed? [y/n]')) {
-        cli.exit(0)
-      }
-    }
 
     const dexTasks = new DexTasks(flags)
     const cheTasks = new CheTasks(flags)

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -15,15 +15,12 @@ import * as Listr from 'listr'
 import { CheHelper } from '../api/che'
 import { CheApiClient } from '../api/che-api-client'
 import { CheServerLoginManager } from '../api/che-login-manager'
-import { DexContextKeys } from '../api/context'
 import { KubeHelper } from '../api/kube'
 import { OpenShiftHelper } from '../api/openshift'
 import { VersionHelper } from '../api/version'
 import { CHE_OPERATOR_SELECTOR, DOC_LINK, DOC_LINK_RELEASE_NOTES, OUTPUT_SEPARATOR } from '../constants'
 import { addTrailingSlash, base64Decode, isDevWorkspaceEnabled, newError } from '../util'
 import { KubeTasks } from './kube'
-
-
 
 /**
  * Holds tasks to work with Eclipse Che component.

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -743,7 +743,17 @@ export class CheTasks {
             }
             messages.push(OUTPUT_SEPARATOR)
 
-            if (!isDevWorkspaceEnabled(ctx, flags) && cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL) {
+            if (isDevWorkspaceEnabled(ctx, flags)) {
+              if (flags.platform === 'minikube') {
+                messages.push('Dex user credentials      : che@eclipse.org:admin')
+                messages.push('Dex user credentials      : user1@che:password')
+                messages.push('Dex user credentials      : user2@che:password')
+                messages.push('Dex user credentials      : user3@che:password')
+                messages.push('Dex user credentials      : user4@che:password')
+                messages.push('Dex user credentials      : user5@che:password')
+                messages.push(OUTPUT_SEPARATOR)
+              }
+            } else if (cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL) {
               messages.push(`Identity Provider URL     : ${addTrailingSlash(cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL)}`)
 
               if (ctx.identityProviderUsername && ctx.identityProviderPassword) {
@@ -757,11 +767,6 @@ export class CheTasks {
 
               messages.push(OUTPUT_SEPARATOR)
             }
-          }
-
-          if (ctx[DexContextKeys.DEX_USERNAME] && ctx[DexContextKeys.DEX_PASSWORD]) {
-            messages.push(`Dex admin credentials     : ${ctx[DexContextKeys.DEX_USERNAME]}:${ctx[DexContextKeys.DEX_PASSWORD]}`)
-            messages.push(OUTPUT_SEPARATOR)
           }
 
           ctx.highlightedMessages = messages.concat(ctx.highlightedMessages)

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -12,18 +12,18 @@
 
 import { Command } from '@oclif/command'
 import * as Listr from 'listr'
-import { DexContextKeys } from '../api/context'
-
 import { CheHelper } from '../api/che'
 import { CheApiClient } from '../api/che-api-client'
 import { CheServerLoginManager } from '../api/che-login-manager'
+import { DexContextKeys } from '../api/context'
 import { KubeHelper } from '../api/kube'
 import { OpenShiftHelper } from '../api/openshift'
 import { VersionHelper } from '../api/version'
 import { CHE_OPERATOR_SELECTOR, DOC_LINK, DOC_LINK_RELEASE_NOTES, OUTPUT_SEPARATOR } from '../constants'
-import { addTrailingSlash, base64Decode, newError } from '../util'
-
+import { addTrailingSlash, base64Decode, isDevWorkspaceEnabled, newError } from '../util'
 import { KubeTasks } from './kube'
+
+
 
 /**
  * Holds tasks to work with Eclipse Che component.
@@ -743,7 +743,7 @@ export class CheTasks {
             }
             messages.push(OUTPUT_SEPARATOR)
 
-            if (cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL) {
+            if (!isDevWorkspaceEnabled(ctx, flags) && cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL) {
               messages.push(`Identity Provider URL     : ${addTrailingSlash(cheConfigMap.data.CHE_KEYCLOAK_AUTH__SERVER__URL)}`)
 
               if (ctx.identityProviderUsername && ctx.identityProviderPassword) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -405,7 +405,7 @@ export function getTlsSupport(ctx: any): boolean {
   return true
 }
 
-export function isDevWorkspaceEnabled(ctx: any): boolean {
+export function isDevWorkspaceEnabled(ctx: any, flags: any): boolean {
   const crPatch = ctx[ChectlContext.CR_PATCH]
   if (crPatch && crPatch.spec && crPatch.spec.devWorkspace && crPatch.spec.devWorkspace.enable) {
     return true
@@ -416,21 +416,7 @@ export function isDevWorkspaceEnabled(ctx: any): boolean {
     return true
   }
 
-  return false
-}
-
-export function isNativeUserModeEnabled(ctx: any): boolean {
-  const crPatch = ctx[ChectlContext.CR_PATCH]
-  if (crPatch && crPatch.spec && crPatch.spec.auth && crPatch.spec.auth.nativeUserMode) {
-    return true
-  }
-
-  const customCR = ctx.customCR
-  if (customCR && customCR.spec && customCR.spec.auth && customCR.spec.auth.nativeUserMode) {
-    return true
-  }
-
-  return false
+  return flags['workspace-engine'] === 'dev-workspace'
 }
 
 export function getTlsSecretName(ctx: any): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,7 +2634,7 @@ ecc-jsbn@~0.1.1:
 
 "eclipse-che-operator@git://github.com/eclipse-che/che-operator#main":
   version "0.0.0"
-  resolved "git://github.com/eclipse-che/che-operator#97a8606484653a47938b6b3d1aa4a291545b04bc"
+  resolved "git://github.com/eclipse-che/che-operator#f45a6e0ff48ef0df0a0908c66c3f2b4e33d44a77"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Enable native user mode if devworkspace engine is enabled

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
  ✔ Show important messages
    ✔ Eclipse Che 7.41.0-SNAPSHOT has been successfully deployed.
    ✔ Documentation             : https://www.eclipse.org/che/docs/
    ✔ -------------------------------------------------------------------------------
    ✔ Users Dashboard           : https://192.168.99.100.nip.io
    ✔ Admin user login          : "admin:admin". NOTE: must change after first login.
    ✔ -------------------------------------------------------------------------------
    ✔ Plug-in Registry          : https://192.168.99.100.nip.io/plugin-registry/v3/
    ✔ Devfile Registry          : https://192.168.99.100.nip.io/devfile-registry/
    ✔ -------------------------------------------------------------------------------
    ✔ Dex user credentials      : che@eclipse.org:admin
    ✔ Dex user credentials      : user1@che:password
    ✔ Dex user credentials      : user2@che:password
    ✔ Dex user credentials      : user3@che:password
    ✔ Dex user credentials      : user4@che:password
    ✔ Dex user credentials      : user5@che:password
    ✔ -------------------------------------------------------------------------------
Command server:deploy has completed successfully in 08:26.
```    

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20853
https://github.com/eclipse/che/issues/20779

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
`./run server:deploy --platform minikube --workspace-engine dev-workspace`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
