### PR TITLE
fix: create /etc/ca-certificates directory on minikube before copying…

### DIFF
--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -134,6 +134,19 @@ export class MinikubeTasks {
   configureApiServerForDex(flags: any): ReadonlyArray<Listr.ListrTask> {
     return [
       {
+        title: 'Create /etc/ca-certificates directory',
+        enabled: (ctx: any) => Boolean(ctx[OIDCContextKeys.CA_FILE]),
+        task: async (_ctx: any, task: any) => {
+          const args: string[] = []
+          args.push('ssh')
+          args.push('sudo mkdir -p /etc/ca-certificates')
+
+          await execa('minikube', args, { timeout: 60000 })
+
+          task.title = `${task.title}...[OK]`
+        },
+      },
+      {
         title: 'Copy Dex certificate into Minikube',
         enabled: (ctx: any) => Boolean(ctx[OIDCContextKeys.CA_FILE]),
         task: async (ctx: any, task: any) => {


### PR DESCRIPTION
… certificates

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Create /etc/ca-certificates directory on minikube before copying certificates

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
   ✔ Configure API server
      ✔ Create /etc/ca-certificates directory...[OK]
      ✔ Copy Dex certificate into Minikube...[OK]
      ✔ Configure Minikube API server...[OK]
      ✔ Wait for Minikube API server...[OK]
  ✔ 🏃‍  Running the Eclipse Che operator
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20797

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
