### PR TITLE
fix: Improve olm update  command

### DIFF
--- a/src/commands/server/update.ts
+++ b/src/commands/server/update.ts
@@ -154,7 +154,7 @@ export default class Update extends Command {
           return
         }
       }
-      await this.checkComponentImages(flags)
+      await this.checkComponentImages(flags, ctx)
 
       await updateTasks.run(ctx)
       await postUpdateTasks.run(ctx)
@@ -173,9 +173,10 @@ export default class Update extends Command {
    * Tests if existing Che installation uses custom docker images.
    * If so, asks user whether keep custom images or revert to default images and update them.
    */
-  private async checkComponentImages(flags: any): Promise<void> {
+  private async checkComponentImages(flags: any, ctx: any): Promise<void> {
     const kubeHelper = new KubeHelper(flags)
-    const cheCluster = await kubeHelper.getCheCluster(flags.chenamespace)
+    const namespace = flags.installer === 'olm' ? ctx.checlusterNamespace : flags.chenamespace
+    const cheCluster = await kubeHelper.getCheCluster(namespace)
     if (cheCluster.spec.server.cheImage ||
       cheCluster.spec.server.cheImageTag ||
       cheCluster.spec.server.devfileRegistryImage ||

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -260,6 +260,27 @@ export class OLMTasks {
           task.title = `${task.title}...[OK]`
         },
       },
+      {
+        title: 'Check if CheCluster CR exists',
+        task: async (ctx: any, _task: any) => {
+          if (ctx.operatorNamespace === DEFAULT_OPENSHIFT_OPERATORS_NS_NAME) {
+            const cheClusters = await kube.getAllCheClusters()
+            if (cheClusters.length === 0) {
+              command.error(`Eclipse Che cluster CR was not found in the namespace '${flags.chenamespace}'`)
+            }
+            if (cheClusters.length > 0) {
+              command.error('Eclipse Che does not support more than one installation in all namespaces mode.')
+            }
+            ctx.checlusterNamespace = cheClusters[0].metadata.namespace
+          } else {
+            const cheCluster = await kube.getCheCluster(ctx.operatorNamespace)
+            if (!cheCluster) {
+              command.error(`Eclipse Che cluster CR was not found in the namespace '${flags.chenamespace}'`)
+            }
+            ctx.checlusterNamespace = cheCluster.metadata.namespace
+          }
+        },
+      },
     ], { renderer: flags['listr-renderer'] as any })
   }
 


### PR DESCRIPTION

### What does this PR do?
Update Che installation even if CR is not located in the default eclipse-che namespace.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
enhancements


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
