### PR TITLE
feat: Add pre-install task to check if an OIDC provider is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ EXAMPLES
   $ chectl autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.3.0/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.1.0/src/commands/autocomplete/index.ts)_
 
 ## `chectl cacert:export`
 
@@ -180,7 +180,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.14/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.18/src/commands/help.ts)_
 
 ## `chectl server:backup`
 
@@ -652,7 +652,7 @@ OPTIONS
   --from-local  interactively choose an already installed version
 ```
 
-_See code: [@oclif/plugin-update](https://github.com/oclif/plugin-update/blob/v1.5.0/src/commands/update.ts)_
+_See code: [@oclif/plugin-update](https://github.com/oclif/plugin-update/blob/v2.1.3/src/commands/update.ts)_
 <!-- commandsstop -->
 
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ OPTIONS
       Skip Kubernetes health check
 
   --skip-oidc-provider-check
-      Skip check for configured OIDC Provider.
+      Skip OIDC Provider check
 
   --skip-version-check
       Skip minimal versions check.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,9 @@ OPTIONS
   --skip-kubernetes-health-check
       Skip Kubernetes health check
 
+  --skip-oidc-provider-check
+      Skip check for configured OIDC Provider.
+
   --skip-version-check
       Skip minimal versions check.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "command-exists": "^1.2.9",
     "countries-and-timezones": "^3.3.0",
     "debug": "^4.3.3",
-    "eclipse-che-operator": "git://github.com/eclipse-che/che-operator#main",
+    "eclipse-che-operator": "https://github.com/eclipse-che/che-operator#main",
     "execa": "^5.1.1",
     "fancy-test": "^2.0.0",
     "fs-extra": "^10.0.0",

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -136,7 +136,7 @@ export default class Deploy extends Command {
       default: false,
     }),
     'skip-oidc-provider-check': flags.boolean({
-      description: 'Skip check for configured OIDC Provider.',
+      description: 'Skip OIDC Provider check',
       default: false,
     }),
     'auto-update': flags.boolean({
@@ -432,7 +432,7 @@ export default class Deploy extends Command {
 function ensureOIDCProviderInstalled(flags: any): Listr.ListrTask {
   return {
     title: 'Check if OIDC Provider installed',
-    enabled: ctx => !flags['skip-oidc-provider-check'] && !isOpenshiftPlatformFamily(flags.platform) && !ctx.isCheDeployed,
+    enabled: () => !flags['skip-oidc-provider-check'] && isKubernetesPlatformFamily(flags.platform),
     skip: () => {
       if (flags.platform === 'minikube') {
         return 'Dex will be automatically installed'

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -22,7 +22,7 @@ import { DEFAULT_ANALYTIC_HOOK_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OLM_SUGGESTE
 import { CheTasks } from '../../tasks/che'
 import { DevWorkspaceTasks } from '../../tasks/component-installers/devfile-workspace-operator-installer'
 import { DexTasks } from '../../tasks/component-installers/dex'
-import { checkChectlAndCheVersionCompatibility, createNamespaceTask, downloadTemplates, getPrintHighlightedMessagesTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
+import { checkChectlAndCheVersionCompatibility, createNamespaceTask, downloadTemplates, ensureOIDCProviderInstalled, getPrintHighlightedMessagesTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
 import { InstallerTasks } from '../../tasks/installers/installer'
 import { ApiTasks } from '../../tasks/platforms/api'
 import { PlatformTasks } from '../../tasks/platforms/platform'
@@ -357,6 +357,7 @@ export default class Deploy extends Command {
       title: '👀  Looking for an already existing Eclipse Che instance',
       task: () => new Listr(cheTasks.checkIfCheIsInstalledTasks(flags)),
     })
+    preInstallTasks.add(ensureOIDCProviderInstalled(flags))
     preInstallTasks.add(checkChectlAndCheVersionCompatibility(flags))
     preInstallTasks.add(downloadTemplates(flags))
     preInstallTasks.add({

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -15,7 +15,7 @@ import { boolean, string } from '@oclif/parser/lib/flags'
 import { cli } from 'cli-ux'
 import * as Listr from 'listr'
 import * as semver from 'semver'
-import { ChectlContext, OLM } from '../../api/context'
+import { ChectlContext, OIDCContextKeys, OLM } from '../../api/context'
 import { KubeHelper } from '../../api/kube'
 import { batch, cheDeployment, cheDeployVersion, cheNamespace, cheOperatorCRPatchYaml, cheOperatorCRYaml, CHE_OPERATOR_CR_PATCH_YAML_KEY, CHE_OPERATOR_CR_YAML_KEY, CHE_TELEMETRY, DEPLOY_VERSION_KEY, k8sPodDownloadImageTimeout, K8SPODDOWNLOADIMAGETIMEOUT_KEY, k8sPodErrorRecheckTimeout, K8SPODERRORRECHECKTIMEOUT_KEY, k8sPodReadyTimeout, K8SPODREADYTIMEOUT_KEY, k8sPodWaitTimeout, K8SPODWAITTIMEOUT_KEY, listrRenderer, logsDirectory, LOG_DIRECTORY_KEY, skipKubeHealthzCheck as skipK8sHealthCheck } from '../../common-flags'
 import { DEFAULT_ANALYTIC_HOOK_NAME, DEFAULT_CHE_NAMESPACE, DEFAULT_OLM_SUGGESTED_NAMESPACE, DOCS_LINK_INSTALL_RUNNING_CHE_LOCALLY, MIN_CHE_OPERATOR_INSTALLER_VERSION, MIN_OLM_INSTALLER_VERSION } from '../../constants'
@@ -447,7 +447,7 @@ function ensureOIDCProviderInstalled(flags: any): Listr.ListrTask {
         }
         for (const container of pod.spec.containers) {
           if (container.command) {
-            if (container.command.some(value => value.includes('oidc-username'))) {
+            if (container.command.some(value => value.includes(OIDCContextKeys.ISSUER_URL) && value.includes(OIDCContextKeys.CLIENT_ID))) {
               task.title = `${task.title}...OK`
               return
             }

--- a/src/commands/server/deploy.ts
+++ b/src/commands/server/deploy.ts
@@ -432,7 +432,7 @@ export default class Deploy extends Command {
 function ensureOIDCProviderInstalled(flags: any): Listr.ListrTask {
   return {
     title: 'Check if OIDC Provider installed',
-    enabled: () => !flags['skip-oidc-provider-check'] && isKubernetesPlatformFamily(flags.platform),
+    enabled: ctx => !flags['skip-oidc-provider-check'] && isKubernetesPlatformFamily(flags.platform) && !ctx.isCheDeployed,
     skip: () => {
       if (flags.platform === 'minikube') {
         return 'Dex will be automatically installed'
@@ -455,7 +455,7 @@ function ensureOIDCProviderInstalled(flags: any): Listr.ListrTask {
         }
       }
       task.title = `${task.title}...NOT INSTALLED`
-      throw new Error('OIDC Provider is not installed, but required in order to run Che')
+      throw new Error('OIDC Provider is not installed in order to deploy Eclipse Che. To bypass OIDC Provider check use \'--skip-oidc-provider-check\' flag')
     },
   }
 }

--- a/src/tasks/installers/common-tasks.ts
+++ b/src/tasks/installers/common-tasks.ts
@@ -25,7 +25,7 @@ import { CheGithubClient } from '../../api/github-client'
 import { KubeHelper } from '../../api/kube'
 import { VersionHelper } from '../../api/version'
 import { CHE_CLUSTER_CRD, DEFAULT_CA_CERT_FILE_NAME, DOCS_LINK_IMPORT_CA_CERT_INTO_BROWSER, OPERATOR_TEMPLATE_DIR } from '../../constants'
-import { getProjectVersion } from '../../util'
+import { getProjectVersion, isOpenshiftPlatformFamily } from '../../util'
 
 export const TASK_TITLE_CREATE_CHE_CLUSTER_CRD = `Create the Custom Resource of type ${CHE_CLUSTER_CRD}`
 export const TASK_TITLE_PATCH_CHECLUSTER_CR = `Patching the Custom Resource of type ${CHE_CLUSTER_CRD}`
@@ -111,6 +111,37 @@ export function downloadTemplates(flags: any): Listr.ListrTask {
       const cheHelper = new CheHelper(flags)
       await cheHelper.downloadAndUnpackTemplates(flags.installer, ctx.versionInfo.zipball_url, versionTemplatesDirPath)
       task.title = `${task.title} ... OK`
+    },
+  }
+}
+
+export function ensureOIDCProviderInstalled(flags: any): Listr.ListrTask {
+  return {
+    title: 'Check if OIDC Provider installed',
+    enabled: ctx => !isOpenshiftPlatformFamily(flags.platform) && !ctx.isCheDeployed,
+    skip: () => {
+      if (flags.platform === 'minikube') {
+        return 'Dex will be automatically installed'
+      }
+    },
+    task: async (_ctx: any, task: any) => {
+      const kube = new KubeHelper(flags)
+      const apiServerPods = await kube.getPodListByLabel('kube-system', 'component=kube-apiserver')
+      for (const pod of apiServerPods) {
+        if (!pod.spec) {
+          continue
+        }
+        for (const container of pod.spec.containers) {
+          if (container.command) {
+            if (container.command.some(value => value.includes('oidc-username'))) {
+              task.title = `${task.title}...OK`
+              return
+            }
+          }
+        }
+      }
+      task.title = `${task.title}...NOT INSTALLED`
+      throw new Error('OIDC Provider is not installed, but required in order to run Che')
     },
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2611,9 +2611,9 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-"eclipse-che-operator@git://github.com/eclipse-che/che-operator#main":
+"eclipse-che-operator@https://github.com/eclipse-che/che-operator#main":
   version "0.0.0"
-  resolved "git://github.com/eclipse-che/che-operator#4ccd0bdde3c349b125d0ae2d3eb2835e18390c76"
+  resolved "https://github.com/eclipse-che/che-operator#bb3c53cc6cba197ebab9d2889aa4fc0788c076e8"
 
 editorconfig@^0.15.0:
   version "0.15.3"


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>
### What does this PR do?
Adds a new check that ensures k8s cluster has OIDC provider installed and configured.
The only exception is `minikube` as Dex is automatically installed.

### Screenshot/screencast of this PR
In case of missing OIDC provider on a k8s cluster:
![Screenshot from 2021-12-21 17-14-04](https://user-images.githubusercontent.com/15607393/146954544-27a8a75b-6458-45d6-b5fa-95b122f1f308.png)

In case of `minikube`:
![Screenshot from 2021-12-21 17-16-42](https://user-images.githubusercontent.com/15607393/146954633-e84bc9ef-d4a8-4984-b901-7584b67d8633.png)

In case if Che is already installed, the check is disabled (and not displayed).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20909

### How to test this PR?
Try to deploy Che using `chectl server:deploy --platform=k8s --domain=****`.
Deployment should fail if he cluster misses an OIDC provider installed and k8s API server configured to use it.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
