### PR TITLE
fix: print only Dex credentials if DevWorkspace enabled

### DIFF
--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -140,8 +140,8 @@ export class CheHelper {
     throw new Error(`ERR_ROUTE_NO_EXIST - No route ${route_names} in namespace ${namespace}`)
   }
 
-  async buildDashboardURL(ideURL: string): Promise<string> {
-    return ideURL.replace(/\/[^/|.]*\/[^/|.]*$/g, '\/dashboard\/#\/ide$&')
+  buildDashboardURL(cheUrl: string): string {
+    return cheUrl.endsWith('/') ? `${cheUrl}dashboard/` : `${cheUrl}/dashboard/`
   }
 
   /**

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -635,14 +635,14 @@ export class CheTasks {
           const messages: string[] = []
 
           const version = await VersionHelper.getCheVersion(flags)
-          messages.push(`Eclipse Che ${version.trim()} has been successfully deployed.`)
+          messages.push(`Eclipse Che '${version.trim()}' has been successfully deployed.`)
           messages.push(`Documentation             : ${DOC_LINK}`)
           if (DOC_LINK_RELEASE_NOTES) {
             messages.push(`Release Notes           : ${DOC_LINK_RELEASE_NOTES}`)
           }
           messages.push(OUTPUT_SEPARATOR)
 
-          const cheUrl = await this.che.cheURL(flags.chenamespace)
+          const cheUrl = this.che.buildDashboardURL(await this.che.cheURL(flags.chenamespace))
           messages.push(`Users Dashboard           : ${cheUrl}`)
 
           const cr = await this.kube.getCheCluster(flags.chenamespace)
@@ -669,7 +669,7 @@ export class CheTasks {
                 messages.push(`HTPasswd user credentials : "${user}:${password}".`)
               }
             }
-          } else {
+          } else if (!isDevWorkspaceEnabled(ctx)) {
             messages.push('Admin user login          : "admin:admin". NOTE: must change after first login.')
           }
           messages.push(OUTPUT_SEPARATOR)

--- a/test/api/che.test.ts
+++ b/test/api/che.test.ts
@@ -114,9 +114,9 @@ describe('Eclipse Che helper', () => {
   describe('buildDashboardURL', () => {
     fancy
       .it('builds the Dashboard URL of a workspace given the IDE link', async () => {
-        let ideURL = 'https://che-che.192.168.64.40.nip.io/che/name-with-dashes'
-        let dashboardURL = 'https://che-che.192.168.64.40.nip.io/dashboard/#/ide/che/name-with-dashes'
-        let res = await ch.buildDashboardURL(ideURL)
+        let cheURL = 'https://che-che.192.168.64.40.nip.io'
+        let dashboardURL = 'https://che-che.192.168.64.40.nip.io/dashboard/'
+        let res = await ch.buildDashboardURL(cheURL)
         expect(res).to.equal(dashboardURL)
       })
   })


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
* print only Dex credentials if DevWorkspace enabled
* fix printing dashboard ulr
* fix detecting che version

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
  ✔ Show important messages
    ✔ Eclipse Che 'next' has been successfully deployed.
    ✔ Documentation             : https://www.eclipse.org/che/docs/
    ✔ -------------------------------------------------------------------------------
    ✔ Users Dashboard           : https://192.168.59.100.nip.io/dashboard/
    ✔ -------------------------------------------------------------------------------
    ✔ Plug-in Registry          : https://192.168.59.100.nip.io/plugin-registry/v3/
    ✔ Devfile Registry          : https://192.168.59.100.nip.io/devfile-registry/
    ✔ -------------------------------------------------------------------------------
    ✔ Dex user credentials      : che@eclipse.org:admin
    ✔ Dex user credentials      : user1@che:password
    ✔ Dex user credentials      : user2@che:password
    ✔ Dex user credentials      : user3@che:password
    ✔ Dex user credentials      : user4@che:password
    ✔ Dex user credentials      : user5@che:password
    ✔ -------------------------------------------------------------------------------
Command server:deploy has completed successfully in 03:5
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21071

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
