### PR TITLE
feat: Include Che Gateway logs in server:logs command

### DIFF
--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -41,6 +41,8 @@ export class CheTasks {
   devfileRegistrySelector = 'app=che,component=devfile-registry'
   pluginRegistryDeploymentName = 'plugin-registry'
   pluginRegistrySelector = 'app=che,component=plugin-registry'
+  cheGatewayDeploymentName = 'che-gateway'
+  cheGatewaySelector = 'app=che,component=che-gateway'
   cheConsoleLinkName = 'che'
 
   constructor(flags: any) {
@@ -507,6 +509,7 @@ export class CheTasks {
           await this.che.readPodLog(flags.chenamespace, this.pluginRegistrySelector, ctx.directory, follow)
           await this.che.readPodLog(flags.chenamespace, this.devfileRegistrySelector, ctx.directory, follow)
           await this.che.readPodLog(flags.chenamespace, this.dashboardSelector, ctx.directory, follow)
+          await this.che.readPodLog(flags.chenamespace, this.cheGatewaySelector, ctx.directory, follow)
           await this.che.readNamespaceEvents(flags.chenamespace, ctx.directory, follow)
           task.title = `${task.title}...[OK]`
         },


### PR DESCRIPTION
### What does this PR do?
Includes logs from the `che-gateway` deployment in the `server:logs` command

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/21312 

### How to test this PR?
1. Execute `chectl server:logs`
2. Verify that /tmp/ directory includes logs from che-gateway containers

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [N/A] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [N/A] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [N/A] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
