### PR TITLE
chore: instead of just having a VERSION file, bump chectl version to match release version (0.0.2 --> 7.yy.0)

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019-2022 Red Hat, Inc.
+# Copyright (c) 2019-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -91,6 +91,8 @@ release() {
   # now replace package.json dependencies
   apply_sed "s;github.com/eclipse-che/che-operator#\(.*\)\",;github.com/eclipse-che/che-operator#${VERSION}\",;g" package.json
   apply_sed "s;https://github.com/devfile/devworkspace-operator#\(.*\)\",;https://github.com/devfile/devworkspace-operator#${DWO_VERSION}\",;g" package.json
+  # and update the app version in package.json
+  jq '.version |= "'$VERSION'"' package.json > package.json_; mv -f package.json_ package.json
 
   if ! grep -q "github.com/eclipse-che/che-operator#${VERSION}" package.json; then
     echo "[ERROR] Unable to find Che Operator version ${VERSION} in the package.json"; exit 1


### PR DESCRIPTION
### What does this PR do?

chore: instead of just having a VERSION file, bump chectl version to match release version (0.0.2 --> 7.yy.0)

Change-Id: Id9133f0e7f6bb738f8625fd3bdc79730df6a004e
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Sort of related to https://issues.redhat.com/browse/CRW-4922 -- discovered while trying to figure out what's borked there. 

### How to test this PR?
1. check out branch
2. `yarn`
3. `./bin/run --help` to see the version
4. can also build binaries with `yarn pack-binaries` and then install from one of those

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.