### PR TITLE
fix: allow wait for multiple DWO webhook pods

### DIFF
--- a/src/api/kube-client.ts
+++ b/src/api/kube-client.ts
@@ -745,7 +745,7 @@ export class KubeClient {
     return conditions
   }
 
-  async getPodReadyConditionStatus(selector: string, namespace: string): Promise<string | undefined> {
+  async getPodReadyConditionStatus(selector: string, namespace: string, allowMultiple: boolean): Promise<string | undefined> {
     const k8sCoreApi = this.kubeConfig.makeApiClient(CoreV1Api)
     let res
     try {
@@ -763,7 +763,7 @@ export class KubeClient {
       return 'False'
     }
 
-    if (res.body.items.length > 1) {
+    if (!allowMultiple && res.body.items.length > 1) {
       // Several pods found, rolling update?
       return
     }
@@ -780,10 +780,10 @@ export class KubeClient {
     }
   }
 
-  async waitForPodReady(selector: string, namespace: string, intervalMs = 500, timeoutMs = this.podReadyTimeout) {
+  async waitForPodReady(selector: string, namespace: string, allowMultiple = false, intervalMs = 500, timeoutMs = this.podReadyTimeout) {
     const iterations = timeoutMs / intervalMs
     for (let index = 0; index < iterations; index++) {
-      const readyStatus = await this.getPodReadyConditionStatus(selector, namespace)
+      const readyStatus = await this.getPodReadyConditionStatus(selector, namespace, allowMultiple)
       if (readyStatus === 'True') {
         return
       }

--- a/src/tasks/installers/dev-workspace/dev-workspace-tasks.ts
+++ b/src/tasks/installers/dev-workspace/dev-workspace-tasks.ts
@@ -133,7 +133,7 @@ export namespace DevWorkspacesTasks {
       task: async (ctx: any, task: any) => {
         const kubeHelper = KubeClient.getInstance()
         await kubeHelper.waitForPodReady('app.kubernetes.io/name=devworkspace-controller', ctx[DevWorkspaceContext.NAMESPACE])
-        await kubeHelper.waitForPodReady('app.kubernetes.io/name=devworkspace-webhook-server', ctx[DevWorkspaceContext.NAMESPACE])
+        await kubeHelper.waitForPodReady('app.kubernetes.io/name=devworkspace-webhook-server', ctx[DevWorkspaceContext.NAMESPACE], true)
         task.title = `${task.title}...[OK]`
       },
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Fixes the DWO pod timeout issue when running `chectl server:deploy -p openshift`:
```
      ✖ Wait for Dev Workspace operator ready
        → ERR_TIMEOUT: Timeout set to pod ready timeout 60000
      Create Subscription eclipse-che
      Eclipse Che Operator pod bootstrap
      Fetch CheCluster sample from a CSV
      Create CheCluster Custom Resource
Error: Command server:deploy failed with the error: ERR_TIMEOUT: Timeout set to pod ready timeout 60000 See details: /home/vsvydenko/.cache/chectl/error.log. Eclipse Che logs: /tmp/chectl-logs/1720444057431.
    at newError (/home/vsvydenko/.local/share/chectl/client/0.0.20240702-next.8e77812/lib/utils/utls.js:39:19)
    at wrapCommandError (/home/vsvydenko/.local/share/chectl/client/0.0.20240702-next.8e77812/lib/utils/command-utils.js:54:32)
    at Deploy.<anonymous> (/home/vsvydenko/.local/share/chectl/client/0.0.20240702-next.8e77812/lib/commands/server/deploy.js:82:65)
    at Generator.throw (<anonymous>)
    at rejected (/home/vsvydenko/.local/share/chectl/client/0.0.20240702-next.8e77812/node_modules/tslib/tslib.js:167:69)
Cause: Error: ERR_TIMEOUT: Timeout set to pod ready timeout 60000
    at KubeClient.<anonymous> (/home/vsvydenko/.local/share/chectl/client/0.0.20240702-next.8e77812/lib/api/kube-client.js:826:19)
    at Generator.next (<anonymous>)
    at fulfilled (/home/vsvydenko/.local/share/chectl/client/0.0.20240702-next.8e77812/node_modules/tslib/tslib.js:166:62)
```



### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23029

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
To test this PR on OpenShift, run:
```
yarn && ./bin/run server:deploy -p openshift
```
The command should complete without any problems.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
