### PR TITLE
fix: Increase timeout to wait installplan

### DIFF
--- a/src/api/kube-client.ts
+++ b/src/api/kube-client.ts
@@ -1437,8 +1437,8 @@ export class KubeClient {
           }
         }
       },
-      `Timeout reached while waiting for "${name}" has go status 'Installed'.`,
-      60,
+      `Timeout reached while waiting for "${name}" has status 'Installed'.`,
+      180,
     )
   }
 
@@ -1835,7 +1835,7 @@ export class KubeClient {
 
       timeoutHandler = setTimeout(() => {
         request.abort()
-        reject(errMsg)
+        reject(new Error(errMsg))
       }, timeout * 1000)
     })
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
fix: Increase timeout to wait installplan

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
```
04:38:25  [22:38:13] Create Subscription eclipse-che [failed]
04:38:25  [22:38:13] → undefined
04:38:25  [22:38:13] Deploy Eclipse Che [failed]
04:38:25  [22:38:13] → Cannot create property 'context' on string 'Timeout reached while waiting for "install-lr522" has go status 'Installed'.'
04:38:25  Error: Command server:deploy failed with the error: Cannot create property 'context' on string 'Timeout reached while waiting for "install-lr522" has go status 'Installed'.' See details: /home/hudson/.cache/chectl/error.log. Eclipse Che logs: /tmp/chectl-logs/1748486221076.
04:38:25      at newError (/usr/local/lib/chectl/lib/utils/utls.js:39:19)
04:38:25      at wrapCommandError (/usr/local/lib/chectl/lib/utils/command-utils.js:54:32)
04:38:25      at Deploy.<anonymous> (/usr/local/lib/chectl/lib/commands/server/deploy.js:82:65)
04:38:25      at Generator.throw (<anonymous>)
04:38:25      at rejected (/usr/local/lib/chectl/node_modules/tslib/tslib.js:167:69)
04:38:25      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
04:38:25  Cause: TypeError: Cannot create property 'context' on string 'Timeout reached while waiting for "install-lr522" has go status 'Installed'.'
04:38:25      at /usr/local/lib/chectl/node_modules/listr/index.js:112:19
04:38:25      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
