### PR TITLE
feat: Add support minikube none driver.

### DIFF
--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -84,7 +84,12 @@ export namespace MinikubeTasks {
           const args: string[] = []
           args.push('ssh', 'sudo mkdir -p /etc/ca-certificates')
 
-          await execa('minikube', args, { timeout: 60_000 })
+          const { stderr, exitCode } = await execa('minikube', args, { timeout: 60_000, reject: false })
+
+          // Check the driver, and if it is `none`, ignore the exception
+          if (exitCode !== 14 && stderr.includes('\'none\' driver')) {
+            throw new Error(`Failed to create /etc/ca-certificates directory: ${stderr}`)
+          }
 
           task.title = `${task.title}...[Created]`
         },

--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -90,7 +90,7 @@ export namespace MinikubeTasks {
           // if not MK_USAGE(errorCode: 14) when throw Error.
           // if MK_USAGE and not include `'none' driver` when throw Error.
           const EXIT_CODE_MK_USAGE: number = 14
-          if (exitCode !== EXIT_CODE_MK_USAGE || !stderr.includes('\'none\' driver')) {
+          if (exitCode && (exitCode !== EXIT_CODE_MK_USAGE || !stderr.includes('\'none\' driver'))) {
             throw new Error(`Failed to create /etc/ca-certificates directory: ${stderr}`)
           }
 

--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -89,7 +89,7 @@ export namespace MinikubeTasks {
           // Check the error code and driver and if it is 14(MK_USAGE) and `none`, ignore the exception
           // if not MK_USAGE(errorCode: 14) when throw Error.
           // if MK_USAGE and not include `'none' driver` when throw Error.
-          const EXIT_CODE_MK_USAGE: number = 14;
+          const EXIT_CODE_MK_USAGE: number = 14
           if (exitCode !== EXIT_CODE_MK_USAGE || !stderr.includes('\'none\' driver')) {
             throw new Error(`Failed to create /etc/ca-certificates directory: ${stderr}`)
           }

--- a/src/tasks/platforms/minikube.ts
+++ b/src/tasks/platforms/minikube.ts
@@ -86,8 +86,11 @@ export namespace MinikubeTasks {
 
           const { stderr, exitCode } = await execa('minikube', args, { timeout: 60_000, reject: false })
 
-          // Check the driver, and if it is `none`, ignore the exception
-          if (exitCode !== 14 && stderr.includes('\'none\' driver')) {
+          // Check the error code and driver and if it is 14(MK_USAGE) and `none`, ignore the exception
+          // if not MK_USAGE(errorCode: 14) when throw Error.
+          // if MK_USAGE and not include `'none' driver` when throw Error.
+          const EXIT_CODE_MK_USAGE: number = 14;
+          if (exitCode !== EXIT_CODE_MK_USAGE || !stderr.includes('\'none\' driver')) {
             throw new Error(`Failed to create /etc/ca-certificates directory: ${stderr}`)
           }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Add support minikube none driver.

### Screenshot/screencast of this PR
```sh
root@kubernetes:/home/mikoto/chectl# minikube ssh

❌  Exiting due to MK_USAGE: 'none' driver does not support 'minikube ssh' command

root@kubernetes:/home/mikoto/chectl# ./bin/chectl server:deploy --platform minikube
Enable CLI usage data to be sent to Red Hat online services. More info: https://developers.redhat.com/article/tool-data-collection [y/n]: y
› Current Kubernetes context: 'minikube'
  ✔ Verify Kubernetes API...[1.33]
  ✔ Minikube preflight checklist
    ✔ Verify if kubectl is installed...[OK]
    ✔ Verify if minikube is installed...[OK]
    ✔ Verify if minikube is running...[OK]
    ✔ Enable minikube ingress addon...[Enabled]
    ✔ Retrieving minikube IP and domain for ingress URLs...[192.168.1.38.nip.io]
    ✔ Checking minikube version...[1.36.0]
  ✔ Create Namespace eclipse-che...[Exists]
  ✔ Install Cert Manager v1.8.2
    ✔ Apply resources...[Exists]
    ✔ Wait for Cert Manager pods ready...[OK]
  ✔ Install Dex
    ✔ Create Namespace dex...[Exists]
    ✔ Create Certificates...[Exists: /tmp/dex-ca.crt]
    ✔ Create ConfigMap dex-ca...[Updated]
    ✔ Create ServiceAccount dex...[Exists]
    ✔ Create ClusterRole dex...[Exists]
    ✔ Create ClusterRoleBinding dex...[Exists]
    ✔ Create Service dex...[Exists]
    ✔ Create Ingress dex...[Exists]
    ✔ Generate Dex username and password...[Exists]
    ✔ Create ConfigMap dex...[Exists]
    ✔ Create Deployment dex...[Exists]
    ✔ Configure API server
      ✔ Create /etc/ca-certificates directory...[Created]
      ✔ Copy Dex certificate into Minikube...[OK]
      ✔ Configure Minikube API server...[OK]
      ✔ Wait for Minikube API server...[OK]
  ✔ Start following Eclipse Che installation logs...[OK]
  ✔ Deploy Eclipse Che operator
    ✔ Install Dev Workspace operator
      ✔ Create Namespace devworkspace-controller...[Exists]
      ✔ Create Dev Workspace operator resources...[Created]
      ✔ Wait for Dev Workspace operator ready...[OK]
    ✔ Create ServiceAccount che-operator...[Created]
    ✔ Create RBAC
      ✔ Create Role che-operator...[Created]
      ✔ Create RoleBinding che-operator...[Created]
      ✔ Create RoleBinding eclipse-che-che-operator...[Created]
      ✔ Create RoleBinding eclipse-che-che-operator...[Created]
    ✔ Wait for Cert Manager pods ready...[OK]
    ✔ Waiting...[OK]
    ✔ Create Certificate che-operator-serving-cert...[Created]
    ✔ Create Issuer che-operator-selfsigned-issuer...[Created]
    ✔ Create Service che-operator-service...[Created]
    ✔ Create CRD checlusters.org.eclipse.che...[Created]
    ✔ Waiting...[OK]
    ✔ Create Deployment che-operator...[Created]
    ✔ Eclipse Che Operator pod bootstrap
      ✔ Scheduling...[OK]
      ✔ Downloading images...[OK]
      ✔ Starting...[OK]
    ✔ Create ValidatingWebhookConfiguration org.eclipse.che...[Created]
    ✔ Create MutatingWebhookConfiguration org.eclipse.che...[Created]
    ✔ Create CheCluster Custom Resource...[Created]
  ✔ Wait for Eclipse Che ready
    ✔ Dashboard pod bootstrap
      ✔ Scheduling...[OK]
      ✔ Downloading images...[OK]
      ✔ Starting...[OK]
    ✔ Gateway pod bootstrap
      ✔ Scheduling...[OK]
      ✔ Downloading images...[OK]
      ✔ Starting...[OK]
    ✔ Eclipse Che Server pod bootstrap
      ✔ Scheduling...[OK]
      ✔ Downloading images...[OK]
      ✔ Starting...[OK]
    ✔ Wait Eclipse Che active...[OK]
  ✔ Retrieving Eclipse Che self-signed CA certificate...[OK: /tmp/cheCA.crt]
  ✔ Prepare post installation output...[OK]
  ✔ Show important messages
    ✔ Eclipse Che next has been successfully deployed.
    ✔ Documentation             : https://www.eclipse.org/che/docs/
    ✔ -------------------------------------------------------------------------------
    ✔ Users Dashboard           : https://192.168.1.38.nip.io/dashboard/
    ✔ -------------------------------------------------------------------------------
    ✔ Dex user credentials      : che@eclipse.org:admin
    ✔ Dex user credentials      : user1@che:password
    ✔ Dex user credentials      : user2@che:password
    ✔ Dex user credentials      : user3@che:password
    ✔ Dex user credentials      : user4@che:password
    ✔ Dex user credentials      : user5@che:password
    ✔ -------------------------------------------------------------------------------
Command server:deploy has completed successfully in 02:53.
```


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23523


### How to test this PR?
N/A


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
