### PR TITLE
feat: track OpenVSX pods readiness during deployment and cleanup on deletion

### DIFF
--- a/src/api/types/che-cluster.ts
+++ b/src/api/types/che-cluster.ts
@@ -55,6 +55,11 @@ interface CheClusterPluginRegistryComponent {
   openVSXURL?: string
 }
 
+interface CheClusterOpenVSXRegistryComponent {
+  enable?: boolean
+}
+
 export interface CheClusterComponents {
   pluginRegistry?: CheClusterPluginRegistryComponent
+  openVSXRegistry?: CheClusterOpenVSXRegistryComponent
 }

--- a/src/tasks/che-tasks.ts
+++ b/src/tasks/che-tasks.ts
@@ -39,6 +39,11 @@ export namespace CheTasks {
             tasks.add(PodTasks.getPodStartTasks(EclipseChe.PLUGIN_REGISTRY, EclipseChe.PLUGIN_REGISTRY_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
           }
 
+          if (cheCluster.spec?.components?.openVSXRegistry?.enable) {
+            tasks.add(PodTasks.getPodStartTasks(EclipseChe.OPENVSX_DATABASE, EclipseChe.OPENVSX_DATABASE_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
+            tasks.add(PodTasks.getPodStartTasks(EclipseChe.OPENVSX_SERVER, EclipseChe.OPENVSX_SERVER_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
+          }
+
           tasks.add(PodTasks.getPodStartTasks(EclipseChe.DASHBOARD, EclipseChe.DASHBOARD_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
           tasks.add(PodTasks.getPodStartTasks(EclipseChe.GATEWAY, EclipseChe.GATEWAY_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
           tasks.add(PodTasks.getPodStartTasks(EclipseChe.CHE_SERVER, EclipseChe.CHE_SERVER_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
@@ -67,6 +72,16 @@ export namespace CheTasks {
           tasks.add(PodTasks.getPodDeletedTask(EclipseChe.PLUGIN_REGISTRY, EclipseChe.PLUGIN_REGISTRY_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
         }
 
+        const openvsxDatabasePods = await kubeHelper.getPodListByLabel(flags[CHE_NAMESPACE_FLAG], EclipseChe.OPENVSX_DATABASE_SELECTOR)
+        if (openvsxDatabasePods.length > 0) {
+          tasks.add(PodTasks.getPodDeletedTask(EclipseChe.OPENVSX_DATABASE, EclipseChe.OPENVSX_DATABASE_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
+        }
+
+        const openvsxServerPods = await kubeHelper.getPodListByLabel(flags[CHE_NAMESPACE_FLAG], EclipseChe.OPENVSX_SERVER_SELECTOR)
+        if (openvsxServerPods.length > 0) {
+          tasks.add(PodTasks.getPodDeletedTask(EclipseChe.OPENVSX_SERVER, EclipseChe.OPENVSX_SERVER_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
+        }
+
         return tasks
       },
     }
@@ -88,6 +103,11 @@ export namespace CheTasks {
           tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.PLUGIN_REGISTRY, EclipseChe.PLUGIN_REGISTRY_DEPLOYMENT_NAME, 0, flags[CHE_NAMESPACE_FLAG]))
         }
 
+        if (cheCluster?.spec?.components?.openVSXRegistry?.enable) {
+          tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.OPENVSX_DATABASE, EclipseChe.OPENVSX_DATABASE_DEPLOYMENT_NAME, 0, flags[CHE_NAMESPACE_FLAG]))
+          tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.OPENVSX_SERVER, EclipseChe.OPENVSX_SERVER_DEPLOYMENT_NAME, 0, flags[CHE_NAMESPACE_FLAG]))
+        }
+
         return tasks
       },
     }
@@ -106,6 +126,14 @@ export namespace CheTasks {
           if (!cheCluster.spec?.components?.pluginRegistry?.disableInternalRegistry) {
             tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.PLUGIN_REGISTRY, EclipseChe.PLUGIN_REGISTRY_DEPLOYMENT_NAME, 1, flags[CHE_NAMESPACE_FLAG]))
             tasks.add(PodTasks.getPodStartTasks(EclipseChe.PLUGIN_REGISTRY, EclipseChe.PLUGIN_REGISTRY_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
+          }
+
+          if (cheCluster.spec?.components?.openVSXRegistry?.enable) {
+            tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.OPENVSX_DATABASE, EclipseChe.OPENVSX_DATABASE_DEPLOYMENT_NAME, 1, flags[CHE_NAMESPACE_FLAG]))
+            tasks.add(PodTasks.getPodStartTasks(EclipseChe.OPENVSX_DATABASE, EclipseChe.OPENVSX_DATABASE_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
+
+            tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.OPENVSX_SERVER, EclipseChe.OPENVSX_SERVER_DEPLOYMENT_NAME, 1, flags[CHE_NAMESPACE_FLAG]))
+            tasks.add(PodTasks.getPodStartTasks(EclipseChe.OPENVSX_SERVER, EclipseChe.OPENVSX_SERVER_SELECTOR, flags[CHE_NAMESPACE_FLAG]))
           }
 
           tasks.add(PodTasks.getScaleDeploymentTask(EclipseChe.DASHBOARD, EclipseChe.DASHBOARD_DEPLOYMENT_NAME, 1, flags[CHE_NAMESPACE_FLAG]))
@@ -157,6 +185,8 @@ export namespace CheTasks {
         await Che.readPodLog(flags[CHE_NAMESPACE_FLAG], EclipseChe.PLUGIN_REGISTRY_SELECTOR, ctx[CliContext.CLI_COMMAND_LOGS_DIR], follow)
         await Che.readPodLog(flags[CHE_NAMESPACE_FLAG], EclipseChe.DASHBOARD_SELECTOR, ctx[CliContext.CLI_COMMAND_LOGS_DIR], follow)
         await Che.readPodLog(flags[CHE_NAMESPACE_FLAG], EclipseChe.GATEWAY_SELECTOR, ctx[CliContext.CLI_COMMAND_LOGS_DIR], follow)
+        await Che.readPodLog(flags[CHE_NAMESPACE_FLAG], EclipseChe.OPENVSX_DATABASE_SELECTOR, ctx[CliContext.CLI_COMMAND_LOGS_DIR], follow)
+        await Che.readPodLog(flags[CHE_NAMESPACE_FLAG], EclipseChe.OPENVSX_SERVER_SELECTOR, ctx[CliContext.CLI_COMMAND_LOGS_DIR], follow)
         await Che.readNamespaceEvents(flags[CHE_NAMESPACE_FLAG], ctx[CliContext.CLI_COMMAND_LOGS_DIR], follow)
         task.title = `${task.title}...[OK]`
       },

--- a/src/tasks/common-tasks.ts
+++ b/src/tasks/common-tasks.ts
@@ -220,20 +220,29 @@ export namespace CommonTasks {
 
         messages.push(OUTPUT_SEPARATOR)
 
-        const dashboardURL = Che.buildDashboardURL(await Che.getCheURL(flags[CHE_NAMESPACE_FLAG]))
-        messages.push(`Users Dashboard           : ${dashboardURL}`, OUTPUT_SEPARATOR)
+        const cheURL = await Che.getCheURL(flags[CHE_NAMESPACE_FLAG])
+        const dashboardURL = Che.buildDashboardURL(cheURL)
+        messages.push(`Users Dashboard           : ${dashboardURL}`)
+
+        const cheCluster = await kubeHelper.getCheCluster(flags[CHE_NAMESPACE_FLAG])
+        if (cheCluster?.spec?.components?.openVSXRegistry?.enable) {
+          const openVSXURL = cheURL.endsWith('/') ? `${cheURL}openvsx/` : `${cheURL}/openvsx/`
+          messages.push(`Open VSX Registry         : ${openVSXURL}`)
+        }
 
         const cheConfigMap = await kubeHelper.getConfigMap(EclipseChe.CONFIG_MAP, flags[CHE_NAMESPACE_FLAG])
         if (cheConfigMap && cheConfigMap.data) {
           if (cheConfigMap.data.CHE_WORKSPACE_PLUGIN__REGISTRY__URL) {
-            messages.push(`Plug-in Registry          : ${addTrailingSlash(cheConfigMap.data.CHE_WORKSPACE_PLUGIN__REGISTRY__URL)}`, OUTPUT_SEPARATOR)
+            messages.push(`Plug-in Registry          : ${addTrailingSlash(cheConfigMap.data.CHE_WORKSPACE_PLUGIN__REGISTRY__URL)}`)
           }
 
           if (flags[PLATFORM_FLAG] === 'minikube') {
-            messages.push('Dex user credentials      : che@eclipse.org:admin', 'Dex user credentials      : user1@che:password', 'Dex user credentials      : user2@che:password', 'Dex user credentials      : user3@che:password', 'Dex user credentials      : user4@che:password', 'Dex user credentials      : user5@che:password', OUTPUT_SEPARATOR)
+            messages.push(OUTPUT_SEPARATOR)
+            messages.push('Dex user credentials      : che@eclipse.org:admin', 'Dex user credentials      : user1@che:password', 'Dex user credentials      : user2@che:password', 'Dex user credentials      : user3@che:password', 'Dex user credentials      : user4@che:password', 'Dex user credentials      : user5@che:password')
           }
         }
 
+        messages.push(OUTPUT_SEPARATOR)
         ctx[CliContext.CLI_COMMAND_POST_OUTPUT_MESSAGES] = messages.concat(ctx[CliContext.CLI_COMMAND_POST_OUTPUT_MESSAGES])
         task.title = `${task.title}...[OK]`
       },

--- a/src/tasks/installers/eclipse-che/eclipse-che.ts
+++ b/src/tasks/installers/eclipse-che/eclipse-che.ts
@@ -68,6 +68,8 @@ export namespace EclipseChe {
   export const GATEWAY = 'Gateway'
   export const PLUGIN_REGISTRY = 'Plugin Registry'
   export const CHE_OPERATOR = `${PRODUCT_NAME} Operator`
+  export const OPENVSX_SERVER = 'Open VSX Server'
+  export const OPENVSX_DATABASE = 'Open VSX Database'
 
   // Deployments
   export const OPERATOR_DEPLOYMENT_NAME = `${CHE_FLAVOR}-operator`
@@ -75,6 +77,8 @@ export namespace EclipseChe {
   export const DASHBOARD_DEPLOYMENT_NAME = `${CHE_FLAVOR}-dashboard`
   export const GATEWAY_DEPLOYMENT_NAME = 'che-gateway'
   export const PLUGIN_REGISTRY_DEPLOYMENT_NAME = 'plugin-registry'
+  export const OPENVSX_SERVER_DEPLOYMENT_NAME = 'openvsx-server'
+  export const OPENVSX_DATABASE_DEPLOYMENT_NAME = 'openvsx-database'
 
   // Selectors
   // It must be `app=`, see: https://issues.redhat.com/browse/CRW-4848
@@ -84,4 +88,7 @@ export namespace EclipseChe {
   export const DASHBOARD_SELECTOR = `app.kubernetes.io/name=${CHE_FLAVOR},app.kubernetes.io/component=${CHE_FLAVOR}-dashboard`
   export const PLUGIN_REGISTRY_SELECTOR = `app.kubernetes.io/name=${CHE_FLAVOR},app.kubernetes.io/component=plugin-registry`
   export const GATEWAY_SELECTOR = `app.kubernetes.io/name=${CHE_FLAVOR},app.kubernetes.io/component=che-gateway`
+  export const OPENVSX_SERVER_SELECTOR = `app.kubernetes.io/name=${CHE_FLAVOR},app.kubernetes.io/component=openvsx-server`
+  export const OPENVSX_DATABASE_SELECTOR = `app.kubernetes.io/name=${CHE_FLAVOR},app.kubernetes.io/component=openvsx-database`
+
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/main/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
  When `spec.components.openVSX.enable` is set to `true` in the CheCluster CR, chectl now additionally tracks:

  - **Open VSX Database** deployment pod readiness
  - **Open VSX Server** deployment pod readiness
 
<img width="877" height="435" alt="Screenshot 2026-07-28 at 12 31 04" src="https://github.com/user-attachments/assets/a174f749-dc24-4ac1-b928-6b5e9d1d3685" />



  On `server:delete`, chectl cleans up all OpenVSX resources:

  - Deployments: `openvsx-database`, `openvsx-server`
  - Services: `openvsx-database`, `openvsx-server`
  - ConfigMaps: `openvsx-server`, `openvsx-server-extensions`, `che-gateway-config-openvsx-server`
  - PVCs: `openvsx-database`, `openvsx-server`
  - Secret: `openvsx-credentials`

<img width="709" height="117" alt="Screenshot 2026-07-27 at 16 25 26" src="https://github.com/user-attachments/assets/dc5b7533-74de-48d0-a459-d1ab0e7945c9" />



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

https://redhat.atlassian.net/browse/CRW-11780

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
Test deploy tracking

  1. Deploy Eclipse Che with OpenVSX enabled:

```
  ./bin/run server:deploy --platform openshift -n eclipse-che --che-operator-cr-patch-yaml=patch.yaml
```
  Where patch.yaml contains:

```yaml
spec:
  components:
    openVSXRegistry:
      enable: true
```

  2. Verify that the deploy output shows:
    - Open VSX Database pod bootstrap task (with Scheduling / Downloading images / Starting sub-tasks)
    - Open VSX Server pod bootstrap task (with Scheduling / Downloading images / Starting sub-tasks)
    - Open VSX Registry URL is shown
    
Test delete cleanup

  1. Delete Eclipse Che:

```
./bin/run server:delete --delete-all
```

  2. Verify all OpenVSX resources are removed:

```
  kubectl get deploy,svc,cm,pvc,secret -n eclipse-che | grep openvsx
```
  Expected: no results.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OpenVSX Registry configuration with an enable/disable switch.
  * When enabled, OpenVSX Registry database and server are included in readiness, scaling, and cleanup workflows.
  * Post-installation output now includes OpenVSX Registry access information (including proper URL formatting).
  * Cluster logs now also capture OpenVSX Registry database and server logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->